### PR TITLE
Fix reading failure of small GTX file.

### DIFF
--- a/proj/src/pj_gridinfo.c
+++ b/proj/src/pj_gridinfo.c
@@ -860,9 +860,8 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
 /* -------------------------------------------------------------------- */
     if( pj_ctx_fread( ctx, header, sizeof(header), 1, fp ) != 1 )
     {
-        pj_ctx_fclose( ctx, fp );
-        pj_ctx_set_errno( ctx, -38 );
-        return gilist;
+        /* some files may be smaller that sizeof(header), eg 160, so */
+        ctx->last_errno = 0; /* don't treat as a persistent error */
     }
 
     pj_ctx_fseek( ctx, fp, SEEK_SET, 0 );


### PR DESCRIPTION
The minimal GTX file for vdatum shifting could contain only one tile,
thus, be smaller than the size of the header that pj_gridinfo_init
reads (160). This patch avoids failure with such minimal GTX files.