### PR TITLE
Fix inverse stereo projection on an ellipsoid.

### DIFF
--- a/src/PJ_stere.c
+++ b/src/PJ_stere.c
@@ -192,8 +192,6 @@ setup(PJ *P) { /* general initialization */
 			}
 			break;
 		case EQUIT:
-			P->akm1 = 2. * P->k0;
-			break;
 		case OBLIQ:
 			t = sin(P->phi0);
 			X = 2. * atan(ssfn_(P->phi0, t, P->e)) - HALFPI;


### PR DESCRIPTION
The problem is that the setup function doesn't initialise all of the
values that it needs for the ellipsoid, inverse, equatorial case.

In the forward and spherical inverse cases, the equatorial case
(|phi0| < 1e-10) is a simplification of the oblique case, and requires
fewer parameters. However, for the ellipsoid inverse case (e_inverse),
the oblique calculation is used, but the setup function doesn't
initialise all of the parameters.

Fixes #266, with patch pulled from there / on the mailing list.
