### PR TITLE
Include proj_def.dat in release tarballs too (#274).

### DIFF
--- a/nad/Makefile.am
+++ b/nad/Makefile.am
@@ -17,7 +17,7 @@ pkgdata_DATA = GL27 nad.lst proj_def.dat nad27 nad83 world epsg esri \
 		esri.extra other.extra \
 		CH IGNF
 
-EXTRA_DIST = GL27 nad.lst nad27 nad83 pj_out27.dist pj_out83.dist td_out.dist \
+EXTRA_DIST = GL27 nad.lst proj_def.dat nad27 nad83 pj_out27.dist pj_out83.dist td_out.dist \
 		test27 test83 world epsg esri tv_out.dist tf_out.dist \
 		testflaky testvarious testdatumfile testntv2 ntv2_out.dist \
 		esri.extra other.extra \


### PR DESCRIPTION
Adding `proj_def.dat` to `pkgdata_DATA` in ef4c492 is not sufficient to also
have the file included in the tarballs generated via `make dist-all`.
