### PR TITLE
Don't include files in proj dist, also included in proj-datumgrids dist.

### DIFF
--- a/nad/Makefile.am
+++ b/nad/Makefile.am
@@ -16,14 +16,15 @@ TESTIGN = $(NADPATH)/testIGNF
 pkgdata_DATA = GL27 nad.lst proj_def.dat nad27 nad83 world epsg esri \
 		esri.extra other.extra \
 		CH IGNF testIGNF proj_outIGNF.dist \
-		null.lla ntf_r93.gsb nzgd2kgrid0005.gsb ntv1_can.dat makefile.vc CMakeLists.txt
+		makefile.vc CMakeLists.txt
 
 EXTRA_DIST = GL27 nad.lst proj_def.dat nad27 nad83 pj_out27.dist pj_out83.dist td_out.dist \
 		test27 test83 world epsg esri tv_out.dist tf_out.dist \
 		testflaky testvarious testdatumfile testntv2 ntv2_out.dist \
 		esri.extra other.extra \
 		CH IGNF testIGNF proj_outIGNF.dist \
-		null.lla ntf_r93.gsb nzgd2kgrid0005.gsb ntv1_can.dat makefile.vc CMakeLists.txt
+		makefile.vc CMakeLists.txt
+
 process-nad2bin:
 	@if [ -f $(NADPATH)/null.lla -a ! -f null ] || [ -f $(NADPATH)/conus.lla -a ! -f conus ] ; then \
 	  for x in $(NADPATH)/*.lla ; do \

--- a/nad/Makefile.am
+++ b/nad/Makefile.am
@@ -15,8 +15,7 @@ TESTIGN = $(NADPATH)/testIGNF
 
 pkgdata_DATA = GL27 nad.lst proj_def.dat nad27 nad83 world epsg esri \
 		esri.extra other.extra \
-		CH IGNF testIGNF proj_outIGNF.dist \
-		makefile.vc CMakeLists.txt
+		CH IGNF
 
 EXTRA_DIST = GL27 nad.lst proj_def.dat nad27 nad83 pj_out27.dist pj_out83.dist td_out.dist \
 		test27 test83 world epsg esri tv_out.dist tf_out.dist \


### PR DESCRIPTION
As discussed in the [Missing proj_def.dat in 4.9.1 release](http://lists.maptools.org/pipermail/proj/2015-September/007229.html) thead on the proj list,
`make dist` for proj shouldn't include the datumgrid files also included in the proj-datumgrid distributions.

The following files shouldn't be included in proj, because they're in proj-datumgrids already:

```
 nad/ntf_r93.gsb        (included in proj-datumgrids <= 1.6RC1)
 nad/ntv1_can.dat       (included in proj-datumgrids <= 1.6RC1)
 nad/null.lla           (included in proj-datumgrids <= 1.5)
 nad/nzgd2kgrid0005.gsb (included in proj-datumgrids <= 1.6RC1)
```

This change comprises two (partial) reverts:

1) Revert "nad/Makefile.am: add missing 'null.lla ntf_r93.gsb nzgd2kgrid0005.gsb ntv1_can.dat' to EXTRA_DIST"

This reverts commit a4c7892a94667e62d62caa053ac4b51ef790741c.

2) Partial Revert "add files to EXTRA_DIST so they are removed by make uninstall"

This partially reverts commit 0a7eda807da1e17f60558acebd89a08872b5b6e9.
