### PR TITLE
Use autoconf for PTHREAD_MUTEX_RECURSIVE (#302)

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -98,6 +98,10 @@ if test "$with_mutex" = yes -o x"$with_mutex" = x ; then
         THREAD_LIB="-lpthread"
     fi
     AC_CHECK_LIB(pthread,pthread_mutexattr_settype,,,)
+    AC_CHECK_DECL(PTHREAD_MUTEX_RECURSIVE,
+                  AC_DEFINE(HAVE_PTHREAD_MUTEX_RECURSIVE, [], [Define if your pthreads implementation have PTHREAD_MUTEX_RECURSIVE]),
+                  ,
+                  [#include <pthread.h>])
     AC_MSG_RESULT([enabled, pthread])
 else
     MUTEX_SETTING=stub

--- a/src/pj_mutex.c
+++ b/src/pj_mutex.c
@@ -33,6 +33,8 @@
 #define _XOPEN_SOURCE 500
 #endif
 
+#include "proj_config.h"
+
 #ifndef _WIN32
 #include <projects.h>
 #else
@@ -120,10 +122,10 @@ void pj_acquire_lock()
         pthread_mutex_lock( &pj_precreated_lock);
 
         pthread_mutexattr_init(&mutex_attr);
-#ifndef PTHREAD_MUTEX_RECURSIVE
-        pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE_NP);
-#else
+#ifdef HAVE_PTHREAD_MUTEX_RECURSIVE
         pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+#else
+        pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE_NP);
 #endif
         pthread_mutex_init(&pj_core_lock, &mutex_attr);
         pj_core_lock_created = 1;

--- a/src/pj_mutex.c
+++ b/src/pj_mutex.c
@@ -33,9 +33,9 @@
 #define _XOPEN_SOURCE 500
 #endif
 
-#include "proj_config.h"
 
 #ifndef _WIN32
+#include "proj_config.h"
 #include <projects.h>
 #else
 #include <proj_api.h>


### PR DESCRIPTION
On FreeBSD 10, PTHREAD_MUTEX_RECURSIVE exists, but as an enum constant,
not a #define macro, so it cannot be detected using #ifdef.
