### PR TITLE
Don't return values when doing inverse projections outside of the mollweide map

### DIFF
--- a/src/PJ_moll.c
+++ b/src/PJ_moll.c
@@ -29,8 +29,12 @@ FORWARD(s_forward); /* spheroid */
 INVERSE(s_inverse); /* spheroid */
 	lp.phi = aasin(P->ctx, xy.y / P->C_y);
 	lp.lam = xy.x / (P->C_x * cos(lp.phi));
-	lp.phi += lp.phi;
-	lp.phi = aasin(P->ctx, (lp.phi + sin(lp.phi)) / P->C_p);
+        if (fabs(lp.lam) < PI) {
+            lp.phi += lp.phi;
+            lp.phi = aasin(P->ctx, (lp.phi + sin(lp.phi)) / P->C_p);
+        } else {
+            lp.lam = lp.phi = HUGE_VAL;
+        }
 	return (lp);
 }
 FREEUP; if (P) pj_dalloc(P); }


### PR DESCRIPTION
When doing invproj outside of the map with +proj=mollweide, valid lon/lat values were returned:
eg:

```
~$ invproj +proj=moll +a=6371000
-9000000 -9000000
113d0'27.032"W    89d27'43.361"S
^C
~$ proj +proj=moll +a=6371000
113d0'27.032"W    89d27'43.361"S
-0.00    -9009954.61
```

The effect of this can be seen here:
![mollweide_bad](https://cloud.githubusercontent.com/assets/167802/9772956/b4909b7e-573f-11e5-8a17-0768e1f3ad50.png)

This patch fixes the behaviour by returning HUGE_VAL in the invproj call when outside the map.
