### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 
 language: c
 
+sudo: false
+
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
   - clang
 
 before_install:
- - sudo pip install git+git://github.com/tbonfort/cpp-coveralls.git@extensions
+ - pip install --user cpp-coveralls
 
 install:
 # cmake build


### PR DESCRIPTION
I _think_ there's no need to install the git version of an outdated fork of `cpp-coveralls` (we'll see how the build goes), and switching to the container-based infrastructure should provide a small speedup.
