### PR TITLE
Fix unmatched ')' in man page.

### DIFF
--- a/man/man1/cs2cs.1
+++ b/man/man1/cs2cs.1
@@ -116,7 +116,7 @@ The
 .B +args
 run-line arguments are associated with cartographic parameters
 and usage varies with projection and for a complete description see
-.I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual" )
+.I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual"
 and supplementary documentation for Release 4.
 .PP
 The \fIcs2cs\fR program requires two coordinate system definitions.  The

--- a/man/man1/proj.1
+++ b/man/man1/proj.1
@@ -214,7 +214,7 @@ The
 .B +args
 run-line arguments are associated with cartographic parameters
 and usage varies with projection and for a complete description see
-.I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual" )
+.I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual"
 and supplementary documentation for Release 4.
 .PP
 Additional projection control parameters may be contained in two


### PR DESCRIPTION
Bugreport and patch by Dan Jacobson via [Debian Bug #807145](https://bugs.debian.org/807145).
