### PR TITLE
#warning pragma fix for VC++ for pj_strtod.c

### DIFF
--- a/src/pj_strtod.c
+++ b/src/pj_strtod.c
@@ -76,7 +76,13 @@ static char* pj_replace_point_by_locale_point(const char* pszNumber, char point,
                                               char* pszWorkBuffer)
 {
 #if !defined(HAVE_LOCALECONV) || defined(_WIN32_WCE)
+
+#if defined(_MSC_VER)  /* Visual C++ */
+#pragma message("localeconv not available")
+#else
 #warning "localeconv not available"
+#endif
+
     static char byPoint = 0;
     if (byPoint == 0)
     {


### PR DESCRIPTION
This patch is to address PR #341 in which Visual C++ stops compile due to encountering a `#warning` pragma statement.

Here is a snippet of my after fix Visual C++ compilation log, which successfully compiled (and installed).

```
  C:\Users\mcochran\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\Bin\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -Isrc -IC:\OSGeo4W\apps\Python27\include -IC:\OSGeo4W\\apps\Python27\PC /Tcsrc\pj_strtod.c /Fobuild\temp.win32-2.7\Release\src\pj_strtod.obj
  pj_strtod.c
  localeconv not available
  C:\Users\mcochran\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\Bin\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -Isrc -IC:\OSGeo4W\apps\Python27\include -IC:\OSGeo4W\\apps\Python27\PC /Tcsrc\PJ_sts.c /Fobuild\temp.win32-2.7\Release\src\PJ_sts.obj
  PJ_sts.c
```
