### PR TITLE
Increase maximum path size for grid shift loading

### DIFF
--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -43,6 +43,7 @@
 #endif /* _WIN32_WCE */
 
 static PJ_GRIDINFO *grid_list = NULL;
+#define PJ_MAX_PATH_LENGTH 1024
 
 /************************************************************************/
 /*                        pj_deallocate_grids()                         */
@@ -177,9 +178,8 @@ PJ_GRIDINFO **pj_gridlist_from_nadgrids( projCtx ctx, const char *nadgrids,
     for( s = nadgrids; *s != '\0'; )
     {
         size_t end_char;
-        int required = 1;
-        const int max_path_length = 1024;
-        char name[max_path_length];
+        int    required = 1;
+        char   name[PJ_MAX_PATH_LENGTH];
 
         if( *s == '@' )
         {

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -178,7 +178,8 @@ PJ_GRIDINFO **pj_gridlist_from_nadgrids( projCtx ctx, const char *nadgrids,
     {
         size_t end_char;
         int   required = 1;
-        char  name[128];
+        int   max_path_length = 1024;
+        char  name[max_path_length];
 
         if( *s == '@' )
         {

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -177,9 +177,9 @@ PJ_GRIDINFO **pj_gridlist_from_nadgrids( projCtx ctx, const char *nadgrids,
     for( s = nadgrids; *s != '\0'; )
     {
         size_t end_char;
-        int   required = 1;
-        int   max_path_length = 1024;
-        char  name[max_path_length];
+        int required = 1;
+        const int max_path_length = 1024;
+        char name[max_path_length];
 
         if( *s == '@' )
         {


### PR DESCRIPTION
On systems with long paths (e.g. iOS, which uses UUIDs for bundle
directories), the existing maximum path length of 128 resulted in path
truncation, and caused the grid shift file loading to fail.

This change increases the buffer size for the path to 1024 chars,
enabling the nadgrids file to be loaded on such systems.
