### PR TITLE
GTX grids: ignore shift values whose abs value is > 1000

### DIFF
--- a/src/pj_apply_vgridshift.c
+++ b/src/pj_apply_vgridshift.c
@@ -151,7 +151,11 @@ int pj_apply_vgridshift( PJ *defn, const char *listname,
                 + cvs[grid_ix + 1 + (grid_iy+1) * ct->lim.lam] 
                 * (grid_x) * (grid_y);
 
-            if( value == -88.88880f ) /* nodata? */
+            /* nodata?  */
+            /* GTX official nodata value if  -88.88880f, but some grids also */
+            /* use other  big values for nodata (e.g naptrans2008.gtx has */
+            /* nodata values like -2147479936), so test them too */
+            if( value > 1000 || value < -1000 || value == -88.88880f )
                 value = HUGE_VAL;
             else
             {


### PR DESCRIPTION
This partially reverts https://github.com/OSGeo/proj.4/commit/338ea581
(#271) to solve issue with naptrans2008.gtx grid mentioned in
http://lists.maptools.org/pipermail/proj/2016-February/007327.html
