### PR TITLE
unnecessary assignment in Lambert Azimuthal Equal Area

### DIFF
--- a/src/PJ_laea.c
+++ b/src/PJ_laea.c
@@ -115,10 +115,10 @@ INVERSE(e_inverse); /* ellipsoid */
 		cCe = cos(sCe = 2. * asin(.5 * rho / P->rq));
 		xy.x *= (sCe = sin(sCe));
 		if (P->mode == OBLIQ) {
-			q = P->qp * (ab = cCe * P->sinb1 + xy.y * sCe * P->cosb1 / rho);
+			ab = cCe * P->sinb1 + xy.y * sCe * P->cosb1 / rho;
 			xy.y = rho * P->cosb1 * cCe - xy.y * P->sinb1 * sCe;
 		} else {
-			q = P->qp * (ab = xy.y * sCe / rho);
+			ab = xy.y * sCe / rho;
 			xy.y = rho * cCe;
 		}
 		break;


### PR DESCRIPTION
In [PJ_laea.c](https://github.com/OSGeo/proj.4/blob/04058618706b306520f1a4656a521ba555601b3b/src/PJ_laea.c#L118), line 118 and 121, there are assignments to the local variable q, but q is never used afterwards. I verified, that the calculation is correct nevertheless, the multiplication and assignment can simply be dropped (keeping the `ab = ...` part).
