### PR TITLE
Fix +wgs84 parameters for srid 3844 (Romania)

### DIFF
--- a/nad/epsg
+++ b/nad/epsg
@@ -4645,7 +4645,7 @@
 # Pulkovo 1942(83) / 3-degree Gauss-Kruger zone 8 (deprecated)
 <3843> +proj=tmerc +lat_0=0 +lon_0=18 +k=1 +x_0=6500000 +y_0=0 +ellps=krass +towgs84=26,-121,-78,0,0,0,0 +units=m +no_defs  <>
 # Pulkovo 1942(58) / Stereo70
-<3844> +proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs  <>
+<3844> +proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=2.329,-147.042,-92.08,0.309,0.325,0.497,5.69 +units=m +no_defs  <>
 # SWEREF99 / RT90 7.5 gon V emulation
 <3845> +proj=tmerc +lat_0=0 +lon_0=11.30625 +k=1.000006 +x_0=1500025.141 +y_0=-667.282 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs  <>
 # SWEREF99 / RT90 5 gon V emulation


### PR DESCRIPTION
The Parameters are taken from EPSG 8.9

Relation with https://trac.osgeo.org/postgis/ticket/1851
and https://trac.osgeo.org/geotiff/ticket/52

To quote from the Postgis ticket:

**The transformation parameters between S42 and WGS84 datums wihch are listed inside the EPSG:3844 definition
(TOWGS84[33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84]) are valid for Poland, not for Romania.
You can see this in the EPSG database: Coordinate Transformation with code 1645: Area of use = Poland - onshore.**

```
SELECT c.source_crs_code, c.target_crs_code, c.coord_op_name, c.coord_op_method_code, a.parameter_value,
 b.parameter_name, c.information_source, c.coord_tfm_version, c.remarks
 FROM epsg_coordoperationparamvalue a LEFT JOIN epsg_coordoperationparam b ON a.parameter_code = b.parameter_code
 LEFT JOIN epsg_coordoperation c ON a.coord_op_code = c.coord_op_code
 WHERE a.coord_op_code IN (15994, 15995);
```

outputs

```
 source_crs_code | target_crs_code |          coord_op_name          | coord_op_method_code | parameter_value |   parameter_name   |                           information_source                            | coord_tfm_version |                                                                                         remarks                                                                                          
-----------------+-----------------+---------------------------------+----------------------+-----------------+--------------------+-------------------------------------------------------------------------+-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |          -92.08 | Z-axis translation | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |        -92.0802 | Z-axis translation | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |           0.309 | X-axis rotation    | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |       0.3092483 | X-axis rotation    | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |           2.329 | X-axis translation | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |          2.3287 | X-axis translation | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |        -147.042 | Y-axis translation | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |       -147.0425 | Y-axis translation | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |          -0.325 | Y-axis rotation    | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |     -0.32482185 | Y-axis rotation    | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |          -0.497 | Z-axis rotation    | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |     -0.49729934 | Z-axis rotation    | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
            4179 |            4326 | Pulkovo 1942(58) to WGS 84 (19) |                 9607 |            5.69 |                    | OGP                                                                     | OGP-Rom           | Parameter values taken from Pulkovo 1942(58) to ETRS89 (4) (code 15994) assuming that ETRS89 is equivalent to WGS 84 within the accuracy of the transformation.
            4179 |            4258 | Pulkovo 1942(58) to ETRS89 (4)  |                 9607 |      5.68906266 |                    | National Agency for Cadastre and Land Registration; http://www.ancpi.ro | ANCPI-Rom 2008    | Replaces S-42 to ETRS89 (3) (tfm code 15993). Consistent with Transdat v3.0 to better than 0.5m. May be taken as approximate transformation Pulkovo 1942(58) to WGS 84 - see code 15995.
(14 rows)
```

Thanks a lot for your work!
Tudor
