### PR TITLE
Move math constants to projects.h.

### DIFF
--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -32,13 +32,6 @@
 #define PJ_LIB__
 #include <projects.h>
 
-#ifndef M_PI
-#  define M_PI 3.14159265358979323846
-#endif
-#ifndef M_PI_2
-#  define M_PI_2 1.57079632679489661923
-#endif
-
 PROJ_HEAD(aitoff, "Aitoff") "\n\tMisc Sph";
 PROJ_HEAD(wintri, "Winkel Tripel") "\n\tMisc Sph\n\tlat_1";
 
@@ -111,13 +104,13 @@ INVERSE(s_inverse); /* sphere */
 			f1 -= xy.x; f2 -= xy.y;
 			dl = (f2 * f1p - f1 * f2p) / (dp = f1p * f2l - f2p * f1l);
 			dp = (f1 * f2l - f2 * f1l) / dp;
-			while (dl > M_PI) dl -= M_PI; /* set to interval [-M_PI, M_PI]  */
-			while (dl < -M_PI) dl += M_PI; /* set to interval [-M_PI, M_PI]  */
+			while (dl > PI) dl -= PI; /* set to interval [-PI, PI]  */
+			while (dl < -PI) dl += PI; /* set to interval [-PI, PI]  */
 			lp.phi -= dp;	lp.lam -= dl;
 		} while ((fabs(dp) > EPSILON || fabs(dl) > EPSILON) && (iter++ < MAXITER));
-		if (lp.phi > M_PI_2) lp.phi -= 2.*(lp.phi-M_PI_2); /* correct if symmetrical solution for Aitoff */ 
-		if (lp.phi < -M_PI_2) lp.phi -= 2.*(lp.phi+M_PI_2); /* correct if symmetrical solution for Aitoff */ 
-		if ((fabs(fabs(lp.phi) - M_PI_2) < EPSILON) && (!P->mode)) lp.lam = 0.; /* if pole in Aitoff, return longitude of 0 */ 
+		if (lp.phi > HALFPI) lp.phi -= 2.*(lp.phi-HALFPI); /* correct if symmetrical solution for Aitoff */
+		if (lp.phi < -HALFPI) lp.phi -= 2.*(lp.phi+HALFPI); /* correct if symmetrical solution for Aitoff */
+		if ((fabs(fabs(lp.phi) - HALFPI) < EPSILON) && (!P->mode)) lp.lam = 0.; /* if pole in Aitoff, return longitude of 0 */
 
 		/* calculate x,y coordinates with solution obtained */
 		if((D = acos(cos(lp.phi) * cos(C = 0.5 * lp.lam)))) {/* Aitoff */

--- a/src/PJ_boggs.c
+++ b/src/PJ_boggs.c
@@ -7,7 +7,6 @@ PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl., no inv., Sph.";
 # define FXC	2.00276
 # define FXC2	1.11072
 # define FYC	0.49931
-# define FYC2	1.41421356237309504880
 FORWARD(s_forward); /* spheroid */
 	double theta, th1, c;
 	int i;
@@ -26,7 +25,7 @@ FORWARD(s_forward); /* spheroid */
 		theta *= 0.5;
 		xy.x = FXC * lp.lam / (1. / cos(lp.phi) + FXC2 / cos(theta));
 	}
-	xy.y = FYC * (lp.phi + FYC2 * sin(theta));
+	xy.y = FYC * (lp.phi + SQRT_TWO * sin(theta));
 	return (xy);
 }
 FREEUP; if (P) pj_dalloc(P); }

--- a/src/PJ_gall.c
+++ b/src/PJ_gall.c
@@ -4,7 +4,6 @@ PROJ_HEAD(gall, "Gall (Gall Stereographic)") "\n\tCyl, Sph";
 #define YF	1.70710678118654752440
 #define XF	0.70710678118654752440
 #define RYF	0.58578643762690495119
-#define RXF	1.41421356237309504880
 FORWARD(s_forward); /* spheroid */
 	(void) P;
 	xy.x = XF * lp.lam;
@@ -13,7 +12,7 @@ FORWARD(s_forward); /* spheroid */
 }
 INVERSE(s_inverse); /* spheroid */
 	(void) P;
-	lp.lam = RXF * xy.x;
+	lp.lam = SQRT_TWO * xy.x;
 	lp.phi = 2. * atan(xy.y * RYF);
 	return (lp);
 }

--- a/src/PJ_lsat.c
+++ b/src/PJ_lsat.c
@@ -7,8 +7,6 @@
 PROJ_HEAD(lsat, "Space oblique for LANDSAT")
 	"\n\tCyl, Sph&Ell\n\tlsat= path=";
 #define TOL 1e-7
-#define PI_HALFPI 4.71238898038468985766
-#define TWOPI_HALFPI 7.85398163397448309610
 	static void
 seraz0(double lam, double mult, PJ *P) {
     double sdsq, h, s, fc, sd, sq, d__1;

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -28,8 +28,6 @@
 PROJ_HEAD(misrsom, "Space oblique for MISR")
         "\n\tCyl, Sph&Ell\n\tpath=";
 #define TOL 1e-7
-#define PI_HALFPI 4.71238898038468985766
-#define TWOPI_HALFPI 7.85398163397448309610
 
 static void
 seraz0(double lam, double mult, PJ *P) {

--- a/src/PJ_vandg2.c
+++ b/src/PJ_vandg2.c
@@ -1,5 +1,4 @@
 # define TOL	1e-10
-# define TWORPI	0.63661977236758134308
 #define PROJ_PARMS__ \
 	int	vdg3;
 #define PJ_LIB__
@@ -9,7 +8,7 @@ PROJ_HEAD(vandg3, "van der Grinten III") "\n\tMisc Sph, no inv.";
 FORWARD(s_forward); /* spheroid */
 	double x1, at, bt, ct;
 
-	bt = fabs(TWORPI * lp.phi);
+	bt = fabs(TWO_D_PI * lp.phi);
 	if ((ct = 1. - bt * bt) < 0.)
 		ct = 0.;
 	else

--- a/src/PJ_vandg4.c
+++ b/src/PJ_vandg4.c
@@ -2,7 +2,6 @@
 #include	<projects.h>
 PROJ_HEAD(vandg4, "van der Grinten IV") "\n\tMisc Sph, no inv.";
 #define TOL	1e-10
-#define TWORPI	0.63661977236758134308
 FORWARD(s_forward); /* spheroid */
 	double x1, t, bt, ct, ft, bt2, ct2, dt, dt2;
 	(void) P;
@@ -14,12 +13,12 @@ FORWARD(s_forward); /* spheroid */
 		xy.x = 0.;
 		xy.y = lp.phi;
 	} else {
-		bt = fabs(TWORPI * lp.phi);
+		bt = fabs(TWO_D_PI * lp.phi);
 		bt2 = bt * bt;
 		ct = 0.5 * (bt * (8. - bt * (2. + bt2)) - 5.)
 			/ (bt2 * (bt - 1.));
 		ct2 = ct * ct;
-		dt = TWORPI * lp.lam;
+		dt = TWO_D_PI * lp.lam;
 		dt = dt + 1. / dt;
 		dt = sqrt(dt * dt - 4.);
 		if ((fabs(lp.lam) - HALFPI) < 0.) dt = -dt;

--- a/src/PJ_wink2.c
+++ b/src/PJ_wink2.c
@@ -5,7 +5,6 @@
 PROJ_HEAD(wink2, "Winkel II") "\n\tPCyl., Sph., no inv.\n\tlat_1=";
 #define MAX_ITER    10
 #define LOOP_TOL    1e-7
-#define TWO_D_PI 0.636619772367581343
 FORWARD(s_forward); /* spheroid */
 	double k, V;
 	int i;

--- a/src/jniproj.c
+++ b/src/jniproj.c
@@ -313,7 +313,7 @@ JNIEXPORT jdouble JNICALL Java_org_proj4_PJ_getGreenwichLongitude
   (JNIEnv *env, jobject object)
 {
     PJ *pj = getPJ(env, object);
-    return (pj) ? (pj->from_greenwich)*(180/M_PI) : javaNaN(env);
+    return (pj) ? (pj->from_greenwich)*(180/PI) : javaNaN(env);
 }
 
 /*!
@@ -415,9 +415,9 @@ JNIEXPORT void JNICALL Java_org_proj4_PJ_transform
             double *x = data + offset;
             double *y = x + 1;
             double *z = (dimension >= 3) ? y+1 : NULL;
-            convertAngularOrdinates(src_pj, x, numPts, dimension, M_PI/180);
+            convertAngularOrdinates(src_pj, x, numPts, dimension, PI/180);
             int err = pj_transform(src_pj, dst_pj, numPts, dimension, x, y, z);
-            convertAngularOrdinates(dst_pj, x, numPts, dimension, 180/M_PI);
+            convertAngularOrdinates(dst_pj, x, numPts, dimension, 180/PI);
             (*env)->ReleasePrimitiveArrayCritical(env, coordinates, data, 0);
             if (err) {
                 jclass c = (*env)->FindClass(env, "org/proj4/PJException");

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,7 +1,6 @@
 /* determine latitude angle phi-2 */
 #include <projects.h>
 
-#define HALFPI		1.5707963267948966
 #define TOL 1.0e-10
 #define N_ITER 15
 

--- a/src/pj_tsfn.c
+++ b/src/pj_tsfn.c
@@ -1,7 +1,7 @@
 /* determine small t */
 #include <math.h>
 #include <projects.h>
-#define HALFPI		1.5707963267948966
+
 	double
 pj_tsfn(double phi, double sinphi, double e) {
 	sinphi *= e;

--- a/src/projects.h
+++ b/src/projects.h
@@ -93,10 +93,16 @@ extern double hypot(double, double);
 #endif
 
 	/* some useful constants */
-#define HALFPI		1.5707963267948966
-#define FORTPI		0.78539816339744833
-#define PI		3.14159265358979323846
-#define TWOPI		6.2831853071795864769
+#define FORTPI         0.78539816339744830961   /* pi/4 */
+#define HALFPI         1.57079632679489661923   /* pi/2 */
+#define PI             3.14159265358979323846   /* pi */
+#define PI_HALFPI      4.71238898038468985766   /* 1.5*pi */
+#define TWOPI          6.28318530717958647693   /* 2*pi */
+#define TWOPI_HALFPI   7.85398163397448309616   /* 2.5*pi */
+
+#define TWO_D_PI       0.63661977236758134308   /* 2/pi */
+
+#define SQRT_TWO       1.41421356237309504880   /* sqrt(2) */
 
 /* maximum tag id length for +init and default files */
 #ifndef ID_TAG_MAX


### PR DESCRIPTION
Any constants used more than once in the project were moved to projects.h. If name was not obvious, I looked mostly looked in "libproj4: A Comprehensive Library of Project Functions" for a formula match to confirm that it is the same constant.  Add pseudocode description for those constants (example: HALFPI means pi/2).  Ensure plenty of precision for constants by using Python gmpy2 library to calculate constants to many digits of precision.  I've have the python console output, if anyone wants to see it.

I tried to make changes to PJ_isea.c, which caused compilation errors.  So, I left it alone.

I did some extra testing in order to ensure that these changes didn't mess anything up.  I used an 80 coordinate test [testpat2.txt](https://github.com/OSGeo/proj.4/files/194462/testpat2.txt).  With the bash script [test_old_new.txt](https://github.com/OSGeo/proj.4/files/194463/test_old_new.txt).

The tests all match.   However, I didn't test the omerc projection nor the JNI code.   I, also, just remember that I didn't test inverse projections (which should be done).  I did have to change the test to exclude latitude of 90, and longitude of 180, which caused tolerance errors for a few projections.

If wanted, the bash script could fairly easily be modified into a unit test.  I think I would be willing to do that.
