### PR TITLE
Make nad2bin output reproducible.

### DIFF
--- a/src/nad2bin.c
+++ b/src/nad2bin.c
@@ -98,6 +98,7 @@ int main(int argc, char **argv) {
 /*      Read the ASCII Table                                            */
 /* ==================================================================== */
 
+    memset(ct.id,0,MAX_TAB_ID);
     if ( NULL == fgets(ct.id, MAX_TAB_ID, stdin) ) {
         perror("fgets");
         exit(1);


### PR DESCRIPTION
As reported by Alexis Bienvenüe in [​Debian Bug #825088](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825088):

> While working on the [reproducible builds](https://wiki.debian.org/ReproducibleBuilds) effort, we have noticed that the `nad2bin` binary has unreproducible output, as it includes uninitialized memory state when `CTABLE.id`'s length is less than the available 80 bytes.

This issue in `nad2bin` is one of causes for unreproducible builds of GRASS as reported in [Debian Bug #825092](https://bugs.debian.org/825092) and illustrated in its [diffoscope output](https://tests.reproducible-builds.org/dbd/unstable/amd64/grass_7.0.4-1.diffoscope.html).
