### PR TITLE
Add BUGS section to manpages & update old URLs.

### DIFF
--- a/man/man1/cs2cs.1
+++ b/man/man1/cs2cs.1
@@ -202,4 +202,4 @@ USGS Bulletin 1532).
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/

--- a/man/man1/cs2cs.1
+++ b/man/man1/cs2cs.1
@@ -198,5 +198,8 @@ USGS Bulletin 1532).
 .br
 .I "An Album of Map Projections"
 (Snyder & Voxland, 1989, USGS Prof. Paper 1453).
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
 https://github.com/OSGeo/proj.4/wiki

--- a/man/man1/geod.1
+++ b/man/man1/geod.1
@@ -224,5 +224,8 @@ http://geographiclib.sf.net/geod-addenda.html
 The \fIonline geodesic bibliography\fR,
 .br
 http://geographiclib.sf.net/geodesic-papers/biblio.html
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
 https://github.com/OSGeo/proj.4/wiki

--- a/man/man1/geod.1
+++ b/man/man1/geod.1
@@ -228,4 +228,4 @@ http://geographiclib.sf.net/geodesic-papers/biblio.html
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/

--- a/man/man1/nad2nad.1
+++ b/man/man1/nad2nad.1
@@ -188,5 +188,8 @@ output data values.
 .br
 .I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual,"
 (Evenden, 1990, Open-file report 90\-284).
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
-http://www.remotesensing.org/proj
+https://github.com/OSGeo/proj.4/wiki

--- a/man/man1/nad2nad.1
+++ b/man/man1/nad2nad.1
@@ -192,4 +192,4 @@ output data values.
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/

--- a/man/man1/proj.1
+++ b/man/man1/proj.1
@@ -305,4 +305,4 @@ USGS Bulletin 1532).
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/

--- a/man/man1/proj.1
+++ b/man/man1/proj.1
@@ -301,5 +301,8 @@ USGS Bulletin 1532).
 .br
 .I "An Album of Map Projections"
 (Snyder & Voxland, 1989, USGS Prof. Paper 1453).
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
 https://github.com/OSGeo/proj.4/wiki

--- a/man/man3/geodesic.3
+++ b/man/man3/geodesic.3
@@ -116,4 +116,4 @@ https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/

--- a/man/man3/geodesic.3
+++ b/man/man3/geodesic.3
@@ -112,5 +112,8 @@ http://geographiclib.sf.net/geodesic-papers/biblio.html
 The Wikipedia page, \fIGeodesics on an ellipsoid\fR,
 .br
 https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
 https://github.com/OSGeo/proj.4/wiki

--- a/man/man3/pj_init.3
+++ b/man/man3/pj_init.3
@@ -103,10 +103,12 @@ main(int argc, char **argv) {
 .SH LIBRARY
 libproj.a \- library of projections and support procedures
 .SH SEE ALSO
-.B http://proj.osgeo.org/ProjAPI, proj(1),
+.B https://github.com/OSGeo/proj.4/wiki/ProjAPI, proj(1),
 .br
 .I "Cartographic Projection Procedures for the UNIX Environment\(emA User's Manual,"
 (Evenden, 1990, Open-file report 90\-284).
+.SH BUGS
+A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
+where new bug reports can be submitted too.
 .SH HOME PAGE
-http://proj.osgeo.org
-
+https://github.com/OSGeo/proj.4/wiki

--- a/man/man3/pj_init.3
+++ b/man/man3/pj_init.3
@@ -111,4 +111,4 @@ libproj.a \- library of projections and support procedures
 A list of known bugs can found at https://github.com/OSGeo/proj.4/issues
 where new bug reports can be submitted too.
 .SH HOME PAGE
-https://github.com/OSGeo/proj.4/wiki
+http://proj4.org/


### PR DESCRIPTION
The common BUGS section is missing as reported by Dan Jacobson in [Debian Bug #809690](https://bugs.debian.org/809690).

Some manpages also still references the homepage on remotesensing.org.
