### PR TITLE
Complete overhaul of Krovak projection code (was "Remove unused C_x parameter from krovak projection.")

### DIFF
--- a/src/PJ_krovak.c
+++ b/src/PJ_krovak.c
@@ -239,8 +239,7 @@ int pj_krovak_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    /* No need to specify an ellipsoid as the projection is hard-coded to Bessel */
-    char e_args[] = {"+proj=krovak"};
+    char e_args[] = {"+proj=krovak +ellps=GRS80"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_krovak.c
+++ b/src/PJ_krovak.c
@@ -1,6 +1,4 @@
-/******************************************************************************
- * $Id$
- *
+ /*
  * Project:  PROJ.4
  * Purpose:  Implementation of the krovak (Krovak) projection.
  *           Definition: http://www.ihsenergy.com/epsg/guid7.html#1.4.3
@@ -27,177 +25,141 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ ******************************************************************************
+ * A description of the (forward) projection is found in:
+ *
+ *      Bohuslav Veverka,
+ *
+ *      KROVAK’S PROJECTION AND ITS USE FOR THE
+ *      CZECH REPUBLIC AND THE SLOVAK REPUBLIC,
+ *
+ *      50 years of the Research Institute of
+ *      and the Slovak Republic Geodesy, Topography and Cartography
+ *
+ * which can be found via the Wayback Machine:
+ *
+ *      https://web.archive.org/web/20150216143806/https://www.vugtk.cz/odis/sborniky/sb2005/Sbornik_50_let_VUGTK/Part_1-Scientific_Contribution/16-Veverka.pdf
+ *
+ * Further info, including the inverse projection, is given by EPSG:
+ *
+ *      Guidance Note 7 part 2
+ *      Coordinate Conversions and Transformations including Formulas
+ *
+ *      http://www.iogp.org/pubs/373-07-2.pdf
+ *
+ * Variable names in this file mostly follows what is used in the
+ * paper by Veverka.
+ *
+ * According to EPSG the full Krovak projection method should have
+ * the following parameters.  Within PROJ.4 the azimuth, and pseudo
+ * standard parallel are hardcoded in the algorithm and can't be
+ * altered from outside. The others all have defaults to match the
+ * common usage with Krovak projection.
+ *
+ *      lat_0 = latitude of centre of the projection
+ *
+ *      lon_0 = longitude of centre of the projection
+ *
+ *      ** = azimuth (true) of the centre line passing through the
+ *           centre of the projection
+ *
+ *      ** = latitude of pseudo standard parallel
+ *
+ *      k  = scale factor on the pseudo standard parallel
+ *
+ *      x_0 = False Easting of the centre of the projection at the
+ *            apex of the cone
+ *
+ *      y_0 = False Northing of the centre of the projection at
+ *            the apex of the cone
+ *
  *****************************************************************************/
+
 
 #define PJ_LIB__
 #include <projects.h>
-#include <string.h>
-#include <stdio.h>
 
 PROJ_HEAD(krovak, "Krovak") "\n\tPCyl., Ellps.";
 
+#define EPS 1e-15
+#define S45 0.785398163397448  /* 45 deg */
+#define S90 1.570796326794896  /* 90 deg */
+#define UQ  1.04216856380474   /* DU(2, 59, 42, 42.69689) */
+#define S0  1.37008346281555   /* Latitude of pseudo standard parallel 78deg 30'00" N */
 
-/**
-   NOTES: According to EPSG the full Krovak projection method should have
-          the following parameters.  Within PROJ.4 the azimuth, and pseudo
-          standard parallel are hardcoded in the algorithm and can't be
-          altered from outside.  The others all have defaults to match the
-          common usage with Krovak projection.
-
-  lat_0 = latitude of centre of the projection
-
-  lon_0 = longitude of centre of the projection
-
-  ** = azimuth (true) of the centre line passing through the centre of the projection
-
-  ** = latitude of pseudo standard parallel
-
-  k  = scale factor on the pseudo standard parallel
-
-  x_0 = False Easting of the centre of the projection at the apex of the cone
-
-  y_0 = False Northing of the centre of the projection at the apex of the cone
-
- **/
+struct pj_opaque {
+    double alpha;
+    double k;
+    double n;
+    double rho0;
+    double ad;
+    int czech;
+};
 
 
-static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static XY e_forward (LP lp, PJ *P) {                /* Ellipsoidal, forward */
+    struct pj_opaque *Q = P->opaque;
     XY xy = {0.0,0.0};
 
-    /* calculate xy from lat/lon */
+    double gfi, u, deltav, s, d, eps, rho;
 
-    /* Constants, identical to inverse transform function */
-    double s45, s90, e2, e, alfa, uq, u0, g, k, k1, n0, ro0, ad, a, s0, n;
-    double gfi, u, fi0, deltav, s, d, eps, ro;
+    gfi = pow ( (1. + P->e * sin(lp.phi)) / (1. - P->e * sin(lp.phi)), Q->alpha * P->e / 2.);
 
+    u = 2. * (atan(Q->k * pow( tan(lp.phi / 2. + S45), Q->alpha) / gfi)-S45);
+    deltav = -lp.lam * Q->alpha;
 
-    s45 = 0.785398163397448;    /* 45deg */
-    s90 = 2 * s45;
-    fi0 = P->phi0;    /* Latitude of projection centre 49deg 30' */
-
-    /* Ellipsoid is used as Parameter in for.c and inv.c, therefore a must
-      be set to 1 here.
-      Ellipsoid Bessel 1841 a = 6377397.155m 1/f = 299.1528128,
-      e2=0.006674372230614;
-    */
-    a =  1; /* 6377397.155; */
-    /* e2 = P->es;*/       /* 0.006674372230614; */
-    e2 = 0.006674372230614;
-    e = sqrt(e2);
-
-    alfa = sqrt(1. + (e2 * pow(cos(fi0), 4)) / (1. - e2));
-
-    uq = 1.04216856380474;      /* DU(2, 59, 42, 42.69689) */
-    u0 = asin(sin(fi0) / alfa);
-    g = pow(   (1. + e * sin(fi0)) / (1. - e * sin(fi0)) , alfa * e / 2.  );
-
-    k = tan( u0 / 2. + s45) / pow  (tan(fi0 / 2. + s45) , alfa) * g;
-
-    k1 = P->k0;
-    n0 = a * sqrt(1. - e2) / (1. - e2 * pow(sin(fi0), 2));
-    s0 = 1.37008346281555;       /* Latitude of pseudo standard parallel 78deg 30'00" N */
-    n = sin(s0);
-    ro0 = k1 * n0 / tan(s0);
-    ad = s90 - uq;
-
-    /* Transformation */
-    gfi = pow ( ((1. + e * sin(lp.phi)) /
-                (1. - e * sin(lp.phi))) , (alfa * e / 2.));
-
-    u = 2. * (atan(k * pow( tan(lp.phi / 2. + s45), alfa) / gfi)-s45);
-
-    deltav = - lp.lam * alfa;
-
-    s = asin(cos(ad) * sin(u) + sin(ad) * cos(u) * cos(deltav));
+    s = asin(cos(Q->ad) * sin(u) + sin(Q->ad) * cos(u) * cos(deltav));
     d = asin(cos(u) * sin(deltav) / cos(s));
-    eps = n * d;
-    ro = ro0 * pow(tan(s0 / 2. + s45) , n) / pow(tan(s / 2. + s45) , n);
 
-   /* x and y are reverted! */
-    xy.y = ro * cos(eps) / a;
-    xy.x = ro * sin(eps) / a;
+    eps = Q->n * d;
+    rho = Q->rho0 * pow(tan(S0 / 2. + S45) , Q->n) / pow(tan(s / 2. + S45) , Q->n);
 
-    if( !pj_param(P->ctx, P->params, "tczech").i ) {
-        xy.y *= -1.0;
-        xy.x *= -1.0;
-    }
+    xy.y = rho * cos(eps);
+    xy.x = rho * sin(eps);
+
+    xy.y *= Q->czech;
+    xy.x *= Q->czech;
 
     return xy;
 }
 
 
-static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static LP e_inverse (XY xy, PJ *P) {                /* Ellipsoidal, inverse */
+    struct pj_opaque *Q = P->opaque;
     LP lp = {0.0,0.0};
 
-    /* calculate lat/lon from xy */
-
-    /* Constants, identisch wie in der Umkehrfunktion */
-    double s45, s90, fi0, e2, e, alfa, uq, u0, g, k, k1, n0, ro0, ad, a, s0, n;
-    double u, deltav, s, d, eps, ro, fi1, xy0;
+    double u, deltav, s, d, eps, rho, fi1, xy0;
     int ok;
 
-    s45 = 0.785398163397448;    /* 45deg */
-    s90 = 2 * s45;
-    fi0 = P->phi0;    /* Latitude of projection centre 49deg 30' */
-
-
-   /* Ellipsoid is used as Parameter in for.c and inv.c, therefore a must
-      be set to 1 here.
-      Ellipsoid Bessel 1841 a = 6377397.155m 1/f = 299.1528128,
-      e2=0.006674372230614;
-   */
-    a = 1; /* 6377397.155; */
-    /* e2 = P->es; */      /* 0.006674372230614; */
-    e2 = 0.006674372230614;
-    e = sqrt(e2);
-
-    alfa = sqrt(1. + (e2 * pow(cos(fi0), 4)) / (1. - e2));
-    uq = 1.04216856380474;      /* DU(2, 59, 42, 42.69689) */
-    u0 = asin(sin(fi0) / alfa);
-    g = pow(   (1. + e * sin(fi0)) / (1. - e * sin(fi0)) , alfa * e / 2.  );
-
-    k = tan( u0 / 2. + s45) / pow  (tan(fi0 / 2. + s45) , alfa) * g;
-
-    k1 = P->k0;
-    n0 = a * sqrt(1. - e2) / (1. - e2 * pow(sin(fi0), 2));
-    s0 = 1.37008346281555;       /* Latitude of pseudo standard parallel 78deg 30'00" N */
-    n = sin(s0);
-    ro0 = k1 * n0 / tan(s0);
-    ad = s90 - uq;
-
-
-    /* Transformation */
-   /* revert y, x*/
     xy0 = xy.x;
     xy.x = xy.y;
     xy.y = xy0;
 
-    if( !pj_param(P->ctx, P->params, "tczech").i ) {
-        xy.x *= -1.0;
-        xy.y *= -1.0;
-    }
+    xy.x *= Q->czech;
+    xy.y *= Q->czech;
 
-    ro = sqrt(xy.x * xy.x + xy.y * xy.y);
+    rho = sqrt(xy.x * xy.x + xy.y * xy.y);
     eps = atan2(xy.y, xy.x);
-    d = eps / sin(s0);
-    s = 2. * (atan(  pow(ro0 / ro, 1. / n) * tan(s0 / 2. + s45)) - s45);
 
-    u = asin(cos(ad) * sin(s) - sin(ad) * cos(s) * cos(d));
+    d = eps / sin(S0);
+    s = 2. * (atan(  pow(Q->rho0 / rho, 1. / Q->n) * tan(S0 / 2. + S45)) - S45);
+
+    u = asin(cos(Q->ad) * sin(s) - sin(Q->ad) * cos(s) * cos(d));
     deltav = asin(cos(s) * sin(d) / cos(u));
 
-    lp.lam = P->lam0 - deltav / alfa;
+    lp.lam = P->lam0 - deltav / Q->alpha;
 
     /* ITERATION FOR lp.phi */
     fi1 = u;
 
     ok = 0;
     do {
-        lp.phi = 2. * ( atan( pow( k, -1. / alfa)  *
-                              pow( tan(u / 2. + s45) , 1. / alfa)  *
-                              pow( (1. + e * sin(fi1)) / (1. - e * sin(fi1)) , e / 2.)
-                            )  - s45);
+        lp.phi = 2. * ( atan( pow( Q->k, -1. / Q->alpha)  *
+                              pow( tan(u / 2. + S45) , 1. / Q->alpha)  *
+                              pow( (1. + P->e * sin(fi1)) / (1. - P->e * sin(fi1)) , P->e / 2.)
+                            )  - S45);
 
-        if (fabs(fi1 - lp.phi) < 0.000000000000001) ok=1;
+        if (fabs(fi1 - lp.phi) < EPS) ok=1;
         fi1 = lp.phi;
    } while (ok==0);
 
@@ -207,10 +169,13 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static void *freeup_new (PJ *P) {                       /* Destructor */
+static void *freeup_new (PJ *P) {                   /* Destructor */
     if (0==P)
         return 0;
+    if (0==P->opaque)
+        return pj_dealloc(P);
 
+    pj_dealloc(P->opaque);
     return pj_dealloc(P);
 }
 
@@ -221,6 +186,12 @@ static void freeup (PJ *P) {
 
 
 PJ *PROJECTION(krovak) {
+    double u0, n0, g;
+    struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
+    if (0==Q)
+        return freeup_new (P);
+    P->opaque = Q;
+
     /* we want Bessel as fixed ellipsoid */
     P->a = 6377397.155;
     P->e = sqrt(P->es = 0.006674372230614);
@@ -239,7 +210,20 @@ PJ *PROJECTION(krovak) {
     if (!pj_param(P->ctx, P->params, "tk").i)
             P->k0 = 0.9999;
 
-    /* always the same */
+    Q->czech = 1;
+    if( !pj_param(P->ctx, P->params, "tczech").i )
+        Q->czech = -1;
+
+    /* Set up shared parameters between forward and inverse */
+    Q->alpha = sqrt(1. + (P->es * pow(cos(P->phi0), 4)) / (1. - P->es));
+    u0 = asin(sin(P->phi0) / Q->alpha);
+    g = pow( (1. + P->e * sin(P->phi0)) / (1. - P->e * sin(P->phi0)) , Q->alpha * P->e / 2. );
+    Q->k = tan( u0 / 2. + S45) / pow  (tan(P->phi0 / 2. + S45) , Q->alpha) * g;
+    n0 = sqrt(1. - P->es) / (1. - P->es * pow(sin(P->phi0), 2));
+    Q->n = sin(S0);
+    Q->rho0 = P->k0 * n0 / tan(S0);
+    Q->ad = S90 - UQ;
+
     P->inv = e_inverse;
     P->fwd = e_forward;
 
@@ -255,7 +239,8 @@ int pj_krovak_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    char e_args[] = {"+proj=krovak   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
+    /* No need to specify an ellipsoid as the projection is hard-coded to Bessel */
+    char e_args[] = {"+proj=krovak"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_krovak.c
+++ b/src/PJ_krovak.c
@@ -36,9 +36,6 @@
 
 PROJ_HEAD(krovak, "Krovak") "\n\tPCyl., Ellps.";
 
-struct pj_opaque {
-    double  C_x;
-};
 
 /**
    NOTES: According to EPSG the full Krovak projection method should have
@@ -213,10 +210,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 static void *freeup_new (PJ *P) {                       /* Destructor */
     if (0==P)
         return 0;
-    if (0==P->opaque)
-        return pj_dealloc (P);
 
-    pj_dealloc (P->opaque);
     return pj_dealloc(P);
 }
 
@@ -227,33 +221,21 @@ static void freeup (PJ *P) {
 
 
 PJ *PROJECTION(krovak) {
-    double ts;
-    struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
-    if (0==Q)
-        return freeup_new (P);
-    P->opaque = Q;
-
-    /* read some Parameters,
-     * here Latitude Truescale */
-
-    ts = pj_param(P->ctx, P->params, "rlat_ts").f;
-    Q->C_x = ts;
-
     /* we want Bessel as fixed ellipsoid */
     P->a = 6377397.155;
     P->e = sqrt(P->es = 0.006674372230614);
 
-        /* if latitude of projection center is not set, use 49d30'N */
+    /* if latitude of projection center is not set, use 49d30'N */
     if (!pj_param(P->ctx, P->params, "tlat_0").i)
             P->phi0 = 0.863937979737193;
 
-        /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
-        /* that will correspond to using longitudes relative to greenwich    */
-        /* as input and output, instead of lat/long relative to Ferro */
+    /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
+    /* that will correspond to using longitudes relative to greenwich    */
+    /* as input and output, instead of lat/long relative to Ferro */
     if (!pj_param(P->ctx, P->params, "tlon_0").i)
             P->lam0 = 0.7417649320975901 - 0.308341501185665;
 
-        /* if scale not set default to 0.9999 */
+    /* if scale not set default to 0.9999 */
     if (!pj_param(P->ctx, P->params, "tk").i)
             P->k0 = 0.9999;
 


### PR DESCRIPTION
Spurred on by #377, which suggests that the projection has an unused parameter, I had a closer look at the code. It turns out that the C_x parameter was indeed unused. Further more the code looked like it was copy/pasted from another source into a piece of already existing proj-code (which must be where C_x came from...). The resulting code was note very proj-like, had unused includes, variable names and comments in German and a large chunk of duplicate code.

I have cleaned all that up and hopefully made a more readable version of the projection implementation.
On top of that there is a slight speed up as well (mostly the forward projection and to be honest not very significant).

I recognize that this is quite intrusive, so I have followed my changes up with a some tests to prove
that the results are the same as before. By generating a list of a million random coordinates and running them through proj get the exact same output
with the overhauled Krovak projection and the one currently in master. The same goes for the inverse projection.

Generating the random coordinates:

```
§ awk -v min_phi=15 -v max_phi=35 -v min_lam=35 -v max_lam=55 -v n=1000000 \
  'BEGIN{for(i=1; i<n; ++i) print min_phi+rand()*(max_phi-min_phi+1) " " min_lam+rand()*(max_lam-min_lam+1)}' \
  > coords.txt
```

Forward calculations with new and old versions of proj:

```
$ ./proj +proj=krovak coords.txt > new_out.txt
$ ./proj_master +proj=krovak coords.txt > old_out.txt

```

Inverse calculations with new and old versions of proj:

```
$ ./proj -I +proj=krovak new_out.txt > new_out_inv.txt
$ ./proj_master -I +proj=krovak old_out.txt > old_out_inv.txt
```

Check that results are the same for both forward and inverse calculations:

```
$ diff old_out.txt new_out.txt
$ diff old_out_inv.txt new_out_inv.txt
```

No output from the diff's -> No difference in the calculations.
