### PR TITLE
Change math constants, similar to PR #372.  Use M_ namespace with the…

### DIFF
--- a/src/PJ_aea.c
+++ b/src/PJ_aea.c
@@ -107,15 +107,15 @@ static LP e_inverse (XY xy, PJ *P) {   /* Ellipsoid/spheroid, inverse */
 				if ((lp.phi = phi1_(lp.phi, P->e, P->one_es)) == HUGE_VAL)
 					I_ERROR
 			} else
-				lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+				lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
 		} else if (fabs(lp.phi = (Q->c - lp.phi * lp.phi) / Q->n2) <= 1.)
 			lp.phi = asin(lp.phi);
 		else
-			lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+			lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
 		lp.lam = atan2(xy.x, xy.y) / Q->n;
 	} else {
 		lp.lam = 0.;
-		lp.phi = Q->n > 0. ? HALFPI : - HALFPI;
+		lp.phi = Q->n > 0. ? M_HALFPI : - M_HALFPI;
 	}
 	return lp;
 }
@@ -205,7 +205,7 @@ PJ *PROJECTION(leac) {
     P->opaque = Q;
 
 	Q->phi2 = pj_param(P->ctx, P->params, "rlat_1").f;
-	Q->phi1 = pj_param(P->ctx, P->params, "bsouth").i ? - HALFPI: HALFPI;
+	Q->phi1 = pj_param(P->ctx, P->params, "bsouth").i ? - M_HALFPI: M_HALFPI;
     setup (P);
     return P;
 }

--- a/src/PJ_aeqd.c
+++ b/src/PJ_aeqd.c
@@ -139,8 +139,8 @@ oblcon:
         lp.phi = -lp.phi;
         coslam = -coslam;
     case S_POLE:
-        if (fabs(lp.phi - HALFPI) < EPS10) F_ERROR;
-        xy.x = (xy.y = (HALFPI + lp.phi)) * sin(lp.lam);
+        if (fabs(lp.phi - M_HALFPI) < EPS10) F_ERROR;
+        xy.x = (xy.y = (M_HALFPI + lp.phi)) * sin(lp.lam);
         xy.y *= coslam;
         break;
     }
@@ -203,9 +203,9 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     struct pj_opaque *Q = P->opaque;
     double cosc, c_rh, sinc;
 
-    if ((c_rh = hypot(xy.x, xy.y)) > PI) {
-        if (c_rh - EPS10 > PI) I_ERROR;
-        c_rh = PI;
+    if ((c_rh = hypot(xy.x, xy.y)) > M_PI) {
+        if (c_rh - EPS10 > M_PI) I_ERROR;
+        c_rh = M_PI;
     } else if (c_rh < EPS10) {
         lp.phi = P->phi0;
         lp.lam = 0.;
@@ -226,10 +226,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         }
         lp.lam = xy.y == 0. ? 0. : atan2(xy.x, xy.y);
     } else if (Q->mode == N_POLE) {
-        lp.phi = HALFPI - c_rh;
+        lp.phi = M_HALFPI - c_rh;
         lp.lam = atan2(xy.x, -xy.y);
     } else {
-        lp.phi = c_rh - HALFPI;
+        lp.phi = c_rh - M_HALFPI;
         lp.lam = atan2(xy.x, xy.y);
     }
     return lp;
@@ -263,7 +263,7 @@ PJ *PROJECTION(aeqd) {
 
     geod_init(&Q->g, P->a, P->es / (1 + sqrt(P->one_es)));
     P->phi0 = pj_param(P->ctx, P->params, "rlat_0").f;
-    if (fabs(fabs(P->phi0) - HALFPI) < EPS10) {
+    if (fabs(fabs(P->phi0) - M_HALFPI) < EPS10) {
         Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
         Q->sinph0 = P->phi0 < 0. ? -1. : 1.;
         Q->cosph0 = 0.;
@@ -288,10 +288,10 @@ PJ *PROJECTION(aeqd) {
         } else {
             switch (Q->mode) {
             case N_POLE:
-                Q->Mp = pj_mlfn(HALFPI, 1., 0., Q->en);
+                Q->Mp = pj_mlfn(M_HALFPI, 1., 0., Q->en);
                 break;
             case S_POLE:
-                Q->Mp = pj_mlfn(-HALFPI, -1., 0., Q->en);
+                Q->Mp = pj_mlfn(-M_HALFPI, -1., 0., Q->en);
                 break;
             case EQUIT:
             case OBLIQ:

--- a/src/PJ_airy.c
+++ b/src/PJ_airy.c
@@ -82,7 +82,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 	case S_POLE:
 	case N_POLE:
 		lp.phi = fabs(Q->p_halfpi - lp.phi);
-		if (!Q->no_cut && (lp.phi - EPS) > HALFPI)
+		if (!Q->no_cut && (lp.phi - EPS) > M_HALFPI)
 			F_ERROR;
 		if ((lp.phi *= 0.5) > EPS) {
 			t = tan(lp.phi);
@@ -125,7 +125,7 @@ PJ *PROJECTION(airy) {
     P->opaque = Q;
 
 	Q->no_cut = pj_param(P->ctx, P->params, "bno_cut").i;
-	beta = 0.5 * (HALFPI - pj_param(P->ctx, P->params, "rlat_b").f);
+	beta = 0.5 * (M_HALFPI - pj_param(P->ctx, P->params, "rlat_b").f);
 	if (fabs(beta) < EPS)
 		Q->Cb = -0.5;
 	else {
@@ -133,12 +133,12 @@ PJ *PROJECTION(airy) {
 		Q->Cb *= Q->Cb * log(cos(beta));
 	}
 
-	if (fabs(fabs(P->phi0) - HALFPI) < EPS)
+	if (fabs(fabs(P->phi0) - M_HALFPI) < EPS)
 		if (P->phi0 < 0.) {
-			Q->p_halfpi = -HALFPI;
+			Q->p_halfpi = -M_HALFPI;
 			Q->mode = S_POLE;
 		} else {
-			Q->p_halfpi =  HALFPI;
+			Q->p_halfpi =  M_HALFPI;
 			Q->mode = N_POLE;
 		}
 	else {

--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -37,12 +37,6 @@ struct pj_opaque {
 	int		mode;
 };
 
-#ifndef M_PI
-#  define M_PI 3.14159265358979323846
-#endif
-#ifndef M_PI_2
-#  define M_PI_2 1.57079632679489661923
-#endif
 
 PROJ_HEAD(aitoff, "Aitoff") "\n\tMisc Sph";
 PROJ_HEAD(wintri, "Winkel Tripel") "\n\tMisc Sph\n\tlat_1";

--- a/src/PJ_bacon.c
+++ b/src/PJ_bacon.c
@@ -1,4 +1,4 @@
-# define HLFPI2	2.46740110027233965467
+# define HLFPI2	2.46740110027233965467      /* (pi/2)^2 */
 # define EPS	1e-10
 #define PJ_LIB__
 #include	<projects.h>
@@ -19,10 +19,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     struct pj_opaque *Q = P->opaque;
 	double ax, f;
 
-	xy.y = Q->bacn ? HALFPI * sin(lp.phi) : lp.phi;
+	xy.y = Q->bacn ? M_HALFPI * sin(lp.phi) : lp.phi;
 	if ((ax = fabs(lp.lam)) >= EPS) {
-		if (Q->ortl && ax >= HALFPI)
-			xy.x = sqrt(HLFPI2 - lp.phi * lp.phi + EPS) + ax - HALFPI;
+		if (Q->ortl && ax >= M_HALFPI)
+			xy.x = sqrt(HLFPI2 - lp.phi * lp.phi + EPS) + ax - M_HALFPI;
 		else {
 			f = 0.5 * (HLFPI2 / ax + ax);
 			xy.x = ax - f + sqrt(f * f - xy.y * xy.y);

--- a/src/PJ_bipc.c
+++ b/src/PJ_bipc.c
@@ -39,8 +39,8 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     sphi = sin(lp.phi);
     cdlam = cos(sdlam = lamB - lp.lam);
     sdlam = sin(sdlam);
-    if (fabs(fabs(lp.phi) - HALFPI) < EPS10) {
-        Az = lp.phi < 0. ? PI : 0.;
+    if (fabs(fabs(lp.phi) - M_HALFPI) < EPS10) {
+        Az = lp.phi < 0. ? M_PI : 0.;
         tphi = HUGE_VAL;
     } else {
         tphi = sphi / cphi;

--- a/src/PJ_boggs.c
+++ b/src/PJ_boggs.c
@@ -7,7 +7,6 @@ PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl., no inv., Sph.";
 # define FXC	2.00276
 # define FXC2	1.11072
 # define FYC	0.49931
-# define FYC2	1.41421356237309504880
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
@@ -17,10 +16,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 	(void) P;
 
 	theta = lp.phi;
-	if (fabs(fabs(lp.phi) - HALFPI) < EPS)
+	if (fabs(fabs(lp.phi) - M_HALFPI) < EPS)
 		xy.x = 0.;
 	else {
-		c = sin(theta) * PI;
+		c = sin(theta) * M_PI;
 		for (i = NITER; i; --i) {
 			theta -= th1 = (theta + sin(theta) - c) /
 				(1. + cos(theta));
@@ -29,7 +28,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 		theta *= 0.5;
 		xy.x = FXC * lp.lam / (1. / cos(lp.phi) + FXC2 / cos(theta));
 	}
-	xy.y = FYC * (lp.phi + FYC2 * sin(theta));
+	xy.y = FYC * (lp.phi + M_SQRT2 * sin(theta));
 	return (xy);
 }
 

--- a/src/PJ_bonne.c
+++ b/src/PJ_bonne.c
@@ -49,8 +49,8 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 	rh = hypot(xy.x, xy.y = Q->cphi1 - xy.y);
 	lp.phi = Q->cphi1 + Q->phi1 - rh;
-	if (fabs(lp.phi) > HALFPI) I_ERROR;
-	if (fabs(fabs(lp.phi) - HALFPI) <= EPS10)
+	if (fabs(lp.phi) > M_HALFPI) I_ERROR;
+	if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10)
 		lp.lam = 0.;
 	else
 		lp.lam = rh * atan2(xy.x, xy.y) / cos(lp.phi);
@@ -65,11 +65,11 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 
 	rh = hypot(xy.x, xy.y = Q->am1 - xy.y);
 	lp.phi = pj_inv_mlfn(P->ctx, Q->am1 + Q->m1 - rh, P->es, Q->en);
-	if ((s = fabs(lp.phi)) < HALFPI) {
+	if ((s = fabs(lp.phi)) < M_HALFPI) {
 		s = sin(lp.phi);
 		lp.lam = rh * atan2(xy.x, xy.y) *
 		   sqrt(1. - P->es * s * s) / cos(lp.phi);
-	} else if (fabs(s - HALFPI) <= EPS10)
+	} else if (fabs(s - M_HALFPI) <= EPS10)
 		lp.lam = 0.;
 	else I_ERROR;
 	return lp;
@@ -110,7 +110,7 @@ PJ *PROJECTION(bonne) {
 		P->inv = e_inverse;
 		P->fwd = e_forward;
 	} else {
-		if (fabs(Q->phi1) + EPS10 >= HALFPI)
+		if (fabs(Q->phi1) + EPS10 >= M_HALFPI)
 			Q->cphi1 = 0.;
 		else
 			Q->cphi1 = 1. / tan(Q->phi1);

--- a/src/PJ_calcofi.c
+++ b/src/PJ_calcofi.c
@@ -46,7 +46,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     /* if the user has specified +lon_0 or +k0 for some reason,
     we're going to ignore it so that xy is consistent with point O */
     lp.lam = lp.lam + P->lam0;
-    if (fabs(fabs(lp.phi) - HALFPI) <= EPS10) F_ERROR;
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
     xy.x = lp.lam;
     xy.y = -log(pj_tsfn(lp.phi, sin(lp.phi), P->e)); /* Mercator transform xy*/
     oy = -log(pj_tsfn(PT_O_PHI, sin(PT_O_PHI), P->e));
@@ -74,14 +74,14 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     double l2;
     double ry;
     lp.lam = lp.lam + P->lam0;
-    if (fabs(fabs(lp.phi) - HALFPI) <= EPS10) F_ERROR;
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
     xy.x = lp.lam;
-    xy.y = log(tan(FORTPI + .5 * lp.phi));
-    oy = log(tan(FORTPI + .5 * PT_O_PHI));
+    xy.y = log(tan(M_FORTPI + .5 * lp.phi));
+    oy = log(tan(M_FORTPI + .5 * PT_O_PHI));
     l1 = (xy.y - oy) * tan(ROTATION_ANGLE);
     l2 = -xy.x - l1 + PT_O_LAMBDA;
     ry = l2 * cos(ROTATION_ANGLE) * sin(ROTATION_ANGLE) + xy.y;
-    ry = HALFPI - 2. * atan(exp(-ry));
+    ry = M_HALFPI - 2. * atan(exp(-ry));
     xy.x = PT_O_LINE - RAD_TO_DEG *
         (ry - PT_O_PHI) * DEG_TO_LINE / cos(ROTATION_ANGLE);
     xy.y = PT_O_STATION + RAD_TO_DEG *
@@ -131,9 +131,9 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     ry = PT_O_PHI - LINE_TO_RAD * (xy.x - PT_O_LINE) *
         cos(ROTATION_ANGLE);
     lp.phi = ry - STATION_TO_RAD * (xy.y - PT_O_STATION) * sin(ROTATION_ANGLE);
-    oymctr = log(tan(FORTPI + .5 * PT_O_PHI));
-    rymctr = log(tan(FORTPI + .5 * ry));
-    xymctr = log(tan(FORTPI + .5 * lp.phi));
+    oymctr = log(tan(M_FORTPI + .5 * PT_O_PHI));
+    rymctr = log(tan(M_FORTPI + .5 * ry));
+    xymctr = log(tan(M_FORTPI + .5 * lp.phi));
     l1 = (xymctr - oymctr) * tan(ROTATION_ANGLE);
     l2 = (rymctr - xymctr) / (cos(ROTATION_ANGLE) * sin(ROTATION_ANGLE));
     lp.lam = PT_O_LAMBDA - (l1 + l2);

--- a/src/PJ_cc.c
+++ b/src/PJ_cc.c
@@ -7,7 +7,7 @@ PROJ_HEAD(cc, "Central Cylindrical") "\n\tCyl, Sph";
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
-	if (fabs (fabs(lp.phi) - HALFPI) <= EPS10) F_ERROR;
+	if (fabs (fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
 	xy.x = lp.lam;
 	xy.y = tan(lp.phi);
 	return xy;

--- a/src/PJ_cea.c
+++ b/src/PJ_cea.c
@@ -40,7 +40,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 
     if ((t = fabs(xy.y *= P->k0)) - EPS <= 1.) {
         if (t >= 1.)
-            lp.phi = xy.y < 0. ? -HALFPI : HALFPI;
+            lp.phi = xy.y < 0. ? -M_HALFPI : M_HALFPI;
         else
             lp.phi = asin(xy.y);
         lp.lam = xy.x / P->k0;

--- a/src/PJ_chamb.c
+++ b/src/PJ_chamb.c
@@ -135,7 +135,7 @@ PJ *PROJECTION(chamb) {
     }
     Q->beta_0 = lc(P->ctx,Q->c[0].v.r, Q->c[2].v.r, Q->c[1].v.r);
     Q->beta_1 = lc(P->ctx,Q->c[0].v.r, Q->c[1].v.r, Q->c[2].v.r);
-    Q->beta_2 = PI - Q->beta_0;
+    Q->beta_2 = M_PI - Q->beta_0;
     Q->p.y = 2. * (Q->c[0].p.y = Q->c[1].p.y = Q->c[2].v.r * sin(Q->beta_0));
     Q->c[2].p.y = 0.;
     Q->c[0].p.x = - (Q->c[1].p.x = 0.5 * Q->c[0].v.r);

--- a/src/PJ_collg.c
+++ b/src/PJ_collg.c
@@ -26,7 +26,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 	if (fabs(lp.phi = 1. - lp.phi * lp.phi) < 1.)
 		lp.phi = asin(lp.phi);
 	else if (fabs(lp.phi) > ONEEPS) I_ERROR
-	else	lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+	else	lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
 	if ((lp.lam = 1. - sin(lp.phi)) <= 0.)
 		lp.lam = 0.;
 	else

--- a/src/PJ_comill.c
+++ b/src/PJ_comill.c
@@ -18,7 +18,7 @@ PROJ_HEAD(comill, "Compact Miller") "\n\tCyl., Sph.";
 #define C2 (3 * K2)
 #define C3 (5 * K3)
 #define EPS 1e-11
-#define MAX_Y (0.6000207669862655 * PI)
+#define MAX_Y (0.6000207669862655 * M_PI)
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */

--- a/src/PJ_eck2.c
+++ b/src/PJ_eck2.c
@@ -30,7 +30,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     if (fabs(lp.phi) >= 1.) {
         if (fabs(lp.phi) > ONEEPS)  I_ERROR
         else
-            lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+            lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
     } else
         lp.phi = asin(lp.phi);
     if (xy.y < 0)

--- a/src/PJ_eqdc.c
+++ b/src/PJ_eqdc.c
@@ -46,7 +46,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         lp.lam = atan2(xy.x, xy.y) / Q->n;
     } else {
         lp.lam = 0.;
-        lp.phi = Q->n > 0. ? HALFPI : - HALFPI;
+        lp.phi = Q->n > 0. ? M_HALFPI : -M_HALFPI;
     }
     return lp;
 }

--- a/src/PJ_fouc_s.c
+++ b/src/PJ_fouc_s.c
@@ -38,7 +38,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
                 break;
         }
         if (!i)
-            lp.phi = xy.y < 0. ? -HALFPI : HALFPI;
+            lp.phi = xy.y < 0. ? -M_HALFPI : M_HALFPI;
     } else
         lp.phi = aasin(P->ctx,xy.y);
     V = cos(lp.phi);

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -30,10 +30,10 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     LP lp = {0.0,0.0};
     double s;
 
-    if ((s = fabs(lp.phi = pj_inv_mlfn(P->ctx, xy.y, P->es, P->opaque->en))) < HALFPI) {
+    if ((s = fabs(lp.phi = pj_inv_mlfn(P->ctx, xy.y, P->es, P->opaque->en))) < M_HALFPI) {
         s = sin(lp.phi);
         lp.lam = xy.x * sqrt(1. - P->es * s * s) / cos(lp.phi);
-    } else if ((s - EPS10) < HALFPI) {
+    } else if ((s - EPS10) < M_HALFPI) {
         lp.lam = 0.;
     } else {
         I_ERROR;

--- a/src/PJ_gnom.c
+++ b/src/PJ_gnom.c
@@ -77,7 +77,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
             case OBLIQ:
                 lp.phi = cosz * Q->sinph0 + xy.y * sinz * Q->cosph0 / rh;
                 if (fabs(lp.phi) >= 1.)
-                    lp.phi = lp.phi > 0. ? HALFPI : - HALFPI;
+                    lp.phi = lp.phi > 0. ? M_HALFPI : - M_HALFPI;
                 else
                     lp.phi = asin(lp.phi);
                 xy.y = (cosz - Q->sinph0 * sin(lp.phi)) * rh;
@@ -86,17 +86,17 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
             case EQUIT:
                 lp.phi = xy.y * sinz / rh;
                 if (fabs(lp.phi) >= 1.)
-                    lp.phi = lp.phi > 0. ? HALFPI : - HALFPI;
+                    lp.phi = lp.phi > 0. ? M_HALFPI : - M_HALFPI;
                 else
                     lp.phi = asin(lp.phi);
                 xy.y = cosz * rh;
                 xy.x *= sinz;
                 break;
             case S_POLE:
-                lp.phi -= HALFPI;
+                lp.phi -= M_HALFPI;
                 break;
             case N_POLE:
-                lp.phi = HALFPI - lp.phi;
+                lp.phi = M_HALFPI - lp.phi;
                 xy.y = -xy.y;
                 break;
         }
@@ -129,7 +129,7 @@ PJ *PROJECTION(gnom) {
         return freeup_new (P);
     P->opaque = Q;
 
-    if (fabs(fabs(P->phi0) - HALFPI) < EPS10) {
+    if (fabs(fabs(P->phi0) - M_HALFPI) < EPS10) {
         Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
     } else if (fabs(P->phi0) < EPS10) {
         Q->mode = EQUIT;

--- a/src/PJ_hatano.c
+++ b/src/PJ_hatano.c
@@ -45,7 +45,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         if (fabs(th) > ONETOL) {
             I_ERROR;
         } else {
-            th = th > 0. ? HALFPI : - HALFPI;
+            th = th > 0. ? M_HALFPI : - M_HALFPI;
         }
     } else {
         th = asin(th);
@@ -58,7 +58,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         if (fabs(lp.phi) > ONETOL) {
            I_ERROR;
         } else {
-            lp.phi = lp.phi > 0. ? HALFPI : - HALFPI;
+            lp.phi = lp.phi > 0. ? M_HALFPI : - M_HALFPI;
         }
     } else {
         lp.phi = asin(lp.phi);

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -160,41 +160,41 @@ static int pnpoly(int nvert, double vert[][2], double testx, double testy) {
 int in_image(double x, double y, int proj, int north_square, int south_square) {
     if (proj == 0) {
         double healpixVertsJit[][2] = {
-            {-1.0*PI- EPS, PI/4.0},
-            {-3.0*PI/4.0, PI/2.0 + EPS},
-            {-1.0*PI/2.0, PI/4.0 + EPS},
-            {-1.0*PI/4.0, PI/2.0 + EPS},
-            {0.0, PI/4.0 + EPS},
-            {PI/4.0, PI/2.0 + EPS},
-            {PI/2.0, PI/4.0 + EPS},
-            {3.0*PI/4.0, PI/2.0 + EPS},
-            {PI+ EPS, PI/4.0},
-            {PI+ EPS, -1.0*PI/4.0},
-            {3.0*PI/4.0, -1.0*PI/2.0 - EPS},
-            {PI/2.0, -1.0*PI/4.0 - EPS},
-            {PI/4.0, -1.0*PI/2.0 - EPS},
-            {0.0, -1.0*PI/4.0 - EPS},
-            {-1.0*PI/4.0, -1.0*PI/2.0 - EPS},
-            {-1.0*PI/2.0, -1.0*PI/4.0 - EPS},
-            {-3.0*PI/4.0, -1.0*PI/2.0 - EPS},
-            {-1.0*PI - EPS, -1.0*PI/4.0}
+            {-1.0*M_PI- EPS, M_PI/4.0},
+            {-3.0*M_PI/4.0, M_PI/2.0 + EPS},
+            {-1.0*M_PI/2.0, M_PI/4.0 + EPS},
+            {-1.0*M_PI/4.0, M_PI/2.0 + EPS},
+            {0.0, M_PI/4.0 + EPS},
+            {M_PI/4.0, M_PI/2.0 + EPS},
+            {M_PI/2.0, M_PI/4.0 + EPS},
+            {3.0*M_PI/4.0, M_PI/2.0 + EPS},
+            {M_PI+ EPS, M_PI/4.0},
+            {M_PI+ EPS, -1.0*M_PI/4.0},
+            {3.0*M_PI/4.0, -1.0*M_PI/2.0 - EPS},
+            {M_PI/2.0, -1.0*M_PI/4.0 - EPS},
+            {M_PI/4.0, -1.0*M_PI/2.0 - EPS},
+            {0.0, -1.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI/4.0, -1.0*M_PI/2.0 - EPS},
+            {-1.0*M_PI/2.0, -1.0*M_PI/4.0 - EPS},
+            {-3.0*M_PI/4.0, -1.0*M_PI/2.0 - EPS},
+            {-1.0*M_PI - EPS, -1.0*M_PI/4.0}
         };
         return pnpoly((int)sizeof(healpixVertsJit)/
                       sizeof(healpixVertsJit[0]), healpixVertsJit, x, y);
     } else {
         double rhealpixVertsJit[][2] = {
-            {-1.0*PI - EPS, PI/4.0 + EPS},
-            {-1.0*PI + north_square*PI/2.0- EPS, PI/4.0 + EPS},
-            {-1.0*PI + north_square*PI/2.0- EPS, 3*PI/4.0 + EPS},
-            {-1.0*PI + (north_square + 1.0)*PI/2.0 + EPS, 3*PI/4.0 + EPS},
-            {-1.0*PI + (north_square + 1.0)*PI/2.0 + EPS, PI/4.0 + EPS},
-            {PI + EPS, PI/4.0 + EPS},
-            {PI + EPS, -1.0*PI/4.0 - EPS},
-            {-1.0*PI + (south_square + 1.0)*PI/2.0 + EPS, -1.0*PI/4.0 - EPS},
-            {-1.0*PI + (south_square + 1.0)*PI/2.0 + EPS, -3.0*PI/4.0 - EPS},
-            {-1.0*PI + south_square*PI/2.0 - EPS, -3.0*PI/4.0 - EPS},
-            {-1.0*PI + south_square*PI/2.0 - EPS, -1.0*PI/4.0 - EPS},
-            {-1.0*PI - EPS, -1.0*PI/4.0 - EPS}};
+            {-1.0*M_PI - EPS, M_PI/4.0 + EPS},
+            {-1.0*M_PI + north_square*M_PI/2.0- EPS, M_PI/4.0 + EPS},
+            {-1.0*M_PI + north_square*M_PI/2.0- EPS, 3*M_PI/4.0 + EPS},
+            {-1.0*M_PI + (north_square + 1.0)*M_PI/2.0 + EPS, 3*M_PI/4.0 + EPS},
+            {-1.0*M_PI + (north_square + 1.0)*M_PI/2.0 + EPS, M_PI/4.0 + EPS},
+            {M_PI + EPS, M_PI/4.0 + EPS},
+            {M_PI + EPS, -1.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI + (south_square + 1.0)*M_PI/2.0 + EPS, -1.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI + (south_square + 1.0)*M_PI/2.0 + EPS, -3.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI + south_square*M_PI/2.0 - EPS, -3.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI + south_square*M_PI/2.0 - EPS, -1.0*M_PI/4.0 - EPS},
+            {-1.0*M_PI - EPS, -1.0*M_PI/4.0 - EPS}};
         return pnpoly((int)sizeof(rhealpixVertsJit)/
                       sizeof(rhealpixVertsJit[0]), rhealpixVertsJit, x, y);
     }
@@ -239,17 +239,17 @@ XY healpix_sphere(LP lp) {
     /* equatorial region */
     if ( fabsl(phi) <= phi0) {
         xy.x = lam;
-        xy.y = 3.0*PI/8.0*sin(phi);
+        xy.y = 3.0*M_PI/8.0*sin(phi);
     } else {
         double lamc;
         double sigma = sqrt(3.0*(1 - fabsl(sin(phi))));
-        double cn = floor(2*lam / PI + 2);
+        double cn = floor(2*lam / M_PI + 2);
         if (cn >= 4) {
             cn = 3;
         }
-        lamc = -3*PI/4 + (PI/2)*cn;
+        lamc = -3*M_PI/4 + (M_PI/2)*cn;
         xy.x = lamc + (lam - lamc)*sigma;
-        xy.y = pj_sign(phi)*PI/4*(2 - sigma);
+        xy.y = pj_sign(phi)*M_PI/4*(2 - sigma);
     }
     return xy;
 }
@@ -262,25 +262,25 @@ LP healpix_sphere_inverse(XY xy) {
     LP lp;
     double x = xy.x;
     double y = xy.y;
-    double y0 = PI/4.0;
+    double y0 = M_PI/4.0;
 
     /* Equatorial region. */
     if (fabsl(y) <= y0) {
         lp.lam = x;
-        lp.phi = asin(8.0*y/(3.0*PI));
-    } else if (fabsl(y) < PI/2.0) {
-        double cn = floor(2.0*x/PI + 2.0);
+        lp.phi = asin(8.0*y/(3.0*M_PI));
+    } else if (fabsl(y) < M_PI/2.0) {
+        double cn = floor(2.0*x/M_PI + 2.0);
         double xc, tau;
         if (cn >= 4) {
             cn = 3;
         }
-        xc = -3.0*PI/4.0 + (PI/2.0)*cn;
-        tau = 2.0 - 4.0*fabsl(y)/PI;
+        xc = -3.0*M_PI/4.0 + (M_PI/2.0)*cn;
+        tau = 2.0 - 4.0*fabsl(y)/M_PI;
         lp.lam = xc + (x - xc)/tau;
         lp.phi = pj_sign(y)*asin(1.0 - pow(tau , 2.0)/3.0);
     } else {
-        lp.lam = -1.0*PI;
-        lp.phi = pj_sign(y)*PI/2.0;
+        lp.lam = -1.0*M_PI;
+        lp.phi = pj_sign(y)*M_PI/2.0;
     }
     return (lp);
 }
@@ -343,48 +343,48 @@ static CapMap get_cap(double x, double y, int north_square, int south_square,
     capmap.x = x;
     capmap.y = y;
     if (inverse == 0) {
-        if (y > PI/4.0) {
+        if (y > M_PI/4.0) {
             capmap.region = north;
-            c = PI/2.0;
-        } else if (y < -1*PI/4.0) {
+            c = M_PI/2.0;
+        } else if (y < -1*M_PI/4.0) {
             capmap.region = south;
-            c = -1*PI/2.0;
+            c = -1*M_PI/2.0;
         } else {
             capmap.region = equatorial;
             capmap.cn = 0;
             return capmap;
         }
         /* polar region */
-        if (x < -1*PI/2.0) {
+        if (x < -1*M_PI/2.0) {
             capmap.cn = 0;
-            capmap.x = (-1*3.0*PI/4.0);
+            capmap.x = (-1*3.0*M_PI/4.0);
             capmap.y = c;
-        } else if (x >= -1*PI/2.0 && x < 0) {
+        } else if (x >= -1*M_PI/2.0 && x < 0) {
             capmap.cn = 1;
-            capmap.x = -1*PI/4.0;
+            capmap.x = -1*M_PI/4.0;
             capmap.y = c;
-        } else if (x >= 0 && x < PI/2.0) {
+        } else if (x >= 0 && x < M_PI/2.0) {
             capmap.cn = 2;
-            capmap.x = PI/4.0;
+            capmap.x = M_PI/4.0;
             capmap.y = c;
         } else {
             capmap.cn = 3;
-            capmap.x = 3.0*PI/4.0;
+            capmap.x = 3.0*M_PI/4.0;
             capmap.y = c;
         }
         return capmap;
     } else {
         double eps;
-        if (y > PI/4.0) {
+        if (y > M_PI/4.0) {
             capmap.region = north;
-            capmap.x = (-3.0*PI/4.0 + north_square*PI/2.0);
-            capmap.y = PI/2.0;
-            x = x - north_square*PI/2.0;
-        } else if (y < -1*PI/4.0) {
+            capmap.x = (-3.0*M_PI/4.0 + north_square*M_PI/2.0);
+            capmap.y = M_PI/2.0;
+            x = x - north_square*M_PI/2.0;
+        } else if (y < -1*M_PI/4.0) {
             capmap.region = south;
-            capmap.x = (-3.0*PI/4.0 + south_square*PI/2);
-            capmap.y = -1*PI/2.0;
-            x = x - south_square*PI/2.0;
+            capmap.x = (-3.0*M_PI/4.0 + south_square*M_PI/2);
+            capmap.y = -1*M_PI/2.0;
+            x = x - south_square*M_PI/2.0;
         } else {
             capmap.region = equatorial;
             capmap.cn = 0;
@@ -394,21 +394,21 @@ static CapMap get_cap(double x, double y, int north_square, int south_square,
            x, y moves to when rHEALPix polar square is disassembled. */
         eps = 1e-15; /* Kludge.  Fuzz to avoid some rounding errors. */
         if (capmap.region == north) {
-            if (y >= -1*x - PI/4.0 - eps && y < x + 5.0*PI/4.0 - eps) {
+            if (y >= -1*x - M_PI/4.0 - eps && y < x + 5.0*M_PI/4.0 - eps) {
                 capmap.cn = (north_square + 1) % 4;
-            } else if (y > -1*x -1*PI/4.0 + eps && y >= x + 5.0*PI/4.0 - eps) {
+            } else if (y > -1*x -1*M_PI/4.0 + eps && y >= x + 5.0*M_PI/4.0 - eps) {
                 capmap.cn = (north_square + 2) % 4;
-            } else if (y <= -1*x -1*PI/4.0 + eps && y > x + 5.0*PI/4.0 + eps) {
+            } else if (y <= -1*x -1*M_PI/4.0 + eps && y > x + 5.0*M_PI/4.0 + eps) {
                 capmap.cn = (north_square + 3) % 4;
             } else {
                 capmap.cn = north_square;
             }
         } else if (capmap.region == south) {
-            if (y <= x + PI/4.0 + eps && y > -1*x - 5.0*PI/4 + eps) {
+            if (y <= x + M_PI/4.0 + eps && y > -1*x - 5.0*M_PI/4 + eps) {
                 capmap.cn = (south_square + 1) % 4;
-            } else if (y < x + PI/4.0 - eps && y <= -1*x - 5.0*PI/4.0 + eps) {
+            } else if (y < x + M_PI/4.0 - eps && y <= -1*x - 5.0*M_PI/4.0 + eps) {
                 capmap.cn = (south_square + 2) % 4;
-            } else if (y >= x + PI/4.0 - eps && y < -1*x - 5.0*PI/4.0 - eps) {
+            } else if (y >= x + M_PI/4.0 - eps && y < -1*x - 5.0*M_PI/4.0 - eps) {
                 capmap.cn = (south_square + 3) % 4;
             } else {
                 capmap.cn = south_square;
@@ -453,16 +453,16 @@ static XY combine_caps(double x, double y, int north_square, int south_square,
         double c[2] = {capmap.x, capmap.y};
         if (capmap.region == north) {
             pole = north_square;
-            a[0] =  (-3.0*PI/4.0 + pole*PI/2);
-            a[1] =  (PI/2.0 + pole*0);
+            a[0] =  (-3.0*M_PI/4.0 + pole*M_PI/2);
+            a[1] =  (M_PI/2.0 + pole*0);
             tmpRot = rot[get_rotate_index(capmap.cn - pole)];
             vector_sub(v, c, v_min_c);
             dot_product(tmpRot, v_min_c, ret_dot);
             vector_add(ret_dot, a, vector);
         } else {
             pole = south_square;
-            a[0] =  (-3.0*PI/4.0 + pole*PI/2);
-            a[1] =  (PI/-2.0 + pole*0);
+            a[0] =  (-3.0*M_PI/4.0 + pole*M_PI/2);
+            a[1] =  (M_PI/-2.0 + pole*0);
             tmpRot = rot[get_rotate_index(-1*(capmap.cn - pole))];
             vector_sub(v, c, v_min_c);
             dot_product(tmpRot, v_min_c, ret_dot);
@@ -480,16 +480,16 @@ static XY combine_caps(double x, double y, int north_square, int south_square,
         /* disassemble */
         if (capmap.region == north) {
             pole = north_square;
-            a[0] =  (-3.0*PI/4.0 + capmap.cn*PI/2);
-            a[1] =  (PI/2.0 + capmap.cn*0);
+            a[0] =  (-3.0*M_PI/4.0 + capmap.cn*M_PI/2);
+            a[1] =  (M_PI/2.0 + capmap.cn*0);
             tmpRot = rot[get_rotate_index(-1*(capmap.cn - pole))];
             vector_sub(v, c, v_min_c);
             dot_product(tmpRot, v_min_c, ret_dot);
             vector_add(ret_dot, a, vector);
         } else {
             pole = south_square;
-            a[0] =  (-3.0*PI/4.0 + capmap.cn*PI/2);
-            a[1] =  (PI/-2.0 + capmap.cn*0);
+            a[0] =  (-3.0*M_PI/4.0 + capmap.cn*M_PI/2);
+            a[1] =  (M_PI/-2.0 + capmap.cn*0);
             tmpRot = rot[get_rotate_index(capmap.cn - pole)];
             vector_sub(v, c, v_min_c);
             dot_product(tmpRot, v_min_c, ret_dot);

--- a/src/PJ_labrd.c
+++ b/src/PJ_labrd.c
@@ -16,10 +16,10 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     double V1, V2, ps, sinps, cosps, sinps2, cosps2;
     double I1, I2, I3, I4, I5, I6, x2, y2, t;
 
-    V1 = Q->A * log( tan(FORTPI + .5 * lp.phi) );
+    V1 = Q->A * log( tan(M_FORTPI + .5 * lp.phi) );
     t = P->e * sin(lp.phi);
     V2 = .5 * P->e * Q->A * log ((1. + t)/(1. - t));
-    ps = 2. * (atan(exp(V1 - V2 + Q->C)) - FORTPI);
+    ps = 2. * (atan(exp(V1 - V2 + Q->C)) - M_FORTPI);
     I1 = ps - Q->p0s;
     cosps = cos(ps);    cosps2 = cosps * cosps;
     sinps = sin(ps);    sinps2 = sinps * sinps;
@@ -61,10 +61,10 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     ps = Q->p0s + xy.y / Q->kRg;
     pe = ps + P->phi0 - Q->p0s;
     for ( i = 20; i; --i) {
-        V1 = Q->A * log(tan(FORTPI + .5 * pe));
+        V1 = Q->A * log(tan(M_FORTPI + .5 * pe));
         tpe = P->e * sin(pe);
         V2 = .5 * P->e * Q->A * log((1. + tpe)/(1. - tpe));
-        t = ps - 2. * (atan(exp(V1 - V2 + Q->C)) - FORTPI);
+        t = ps - 2. * (atan(exp(V1 - V2 + Q->C)) - M_FORTPI);
         pe += t;
         if (fabs(t) < EPS)
             break;
@@ -126,8 +126,8 @@ PJ *PROJECTION(labrd) {
     Q->A = sinp / sin(Q->p0s);
     t = P->e * sinp;
     Q->C = .5 * P->e * Q->A * log((1. + t)/(1. - t)) +
-          - Q->A * log( tan(FORTPI + .5 * P->phi0))
-          + log( tan(FORTPI + .5 * Q->p0s));
+          - Q->A * log( tan(M_FORTPI + .5 * P->phi0))
+          + log( tan(M_FORTPI + .5 * Q->p0s));
     t = Az + Az;
     Q->Ca = (1. - cos(t)) * ( Q->Cb = 1. / (12. * Q->kRg * Q->kRg) );
     Q->Cb *= sin(t);

--- a/src/PJ_laea.c
+++ b/src/PJ_laea.c
@@ -47,11 +47,11 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
         b = 1. + cosb * coslam;
         break;
     case N_POLE:
-        b = HALFPI + lp.phi;
+        b = M_HALFPI + lp.phi;
         q = Q->qp - q;
         break;
     case S_POLE:
-        b = lp.phi - HALFPI;
+        b = lp.phi - M_HALFPI;
         q = Q->qp + q;
         break;
     }
@@ -108,7 +108,7 @@ oblcon:
         coslam = -coslam;
     case S_POLE:
         if (fabs(lp.phi + P->phi0) < EPS10) F_ERROR;
-        xy.y = FORTPI - lp.phi * .5;
+        xy.y = M_FORTPI - lp.phi * .5;
         xy.y = 2. * (Q->mode == S_POLE ? cos(xy.y) : sin(xy.y));
         xy.x = xy.y * sin(lp.lam);
         xy.y *= coslam;
@@ -192,10 +192,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         break;
     case N_POLE:
         xy.y = -xy.y;
-        lp.phi = HALFPI - lp.phi;
+        lp.phi = M_HALFPI - lp.phi;
         break;
     case S_POLE:
-        lp.phi -= HALFPI;
+        lp.phi -= M_HALFPI;
         break;
     }
     lp.lam = (xy.y == 0. && (Q->mode == EQUIT || Q->mode == OBLIQ)) ?
@@ -229,7 +229,7 @@ PJ *PROJECTION(laea) {
     P->opaque = Q;
 
     t = fabs(P->phi0);
-    if (fabs(t - HALFPI) < EPS10)
+    if (fabs(t - M_HALFPI) < EPS10)
         Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
     else if (fabs(t) < EPS10)
         Q->mode = EQUIT;

--- a/src/PJ_lagrng.c
+++ b/src/PJ_lagrng.c
@@ -17,7 +17,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     struct pj_opaque *Q = P->opaque;
     double v, c;
 
-    if (fabs(fabs(lp.phi) - HALFPI) < TOL) {
+    if (fabs(fabs(lp.phi) - M_HALFPI) < TOL) {
         xy.x = 0;
         xy.y = lp.phi < 0 ? -2. : 2.;
     } else {

--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -21,12 +21,12 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     struct pj_opaque *Q = P->opaque;
     double rho;
 
-    if (fabs(fabs(lp.phi) - HALFPI) < EPS10) {
+    if (fabs(fabs(lp.phi) - M_HALFPI) < EPS10) {
         if ((lp.phi * Q->n) <= 0.) F_ERROR;
         rho = 0.;
     } else {
         rho = Q->c * (Q->ellips ? pow(pj_tsfn(lp.phi, sin(lp.phi),
-            P->e), Q->n) : pow(tan(FORTPI + .5 * lp.phi), -Q->n));
+            P->e), Q->n) : pow(tan(M_FORTPI + .5 * lp.phi), -Q->n));
     }
     lp.lam *= Q->n;
     xy.x = P->k0 * (rho * sin( lp.lam) );
@@ -56,11 +56,11 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
             if (lp.phi == HUGE_VAL)
                 I_ERROR;
         } else
-            lp.phi = 2. * atan(pow(Q->c / rho, 1./Q->n)) - HALFPI;
+            lp.phi = 2. * atan(pow(Q->c / rho, 1./Q->n)) - M_HALFPI;
         lp.lam = atan2(xy.x, xy.y) / Q->n;
     } else {
         lp.lam = 0.;
-        lp.phi = Q->n > 0. ? HALFPI : - HALFPI;
+        lp.phi = Q->n > 0. ? M_HALFPI : -M_HALFPI;
     }
     return lp;
 }
@@ -68,12 +68,12 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 static void special(LP lp, PJ *P, struct FACTORS *fac) {
     struct pj_opaque *Q = P->opaque;
     double rho;
-    if (fabs(fabs(lp.phi) - HALFPI) < EPS10) {
+    if (fabs(fabs(lp.phi) - M_HALFPI) < EPS10) {
         if ((lp.phi * Q->n) <= 0.) return;
         rho = 0.;
     } else
         rho = Q->c * (Q->ellips ? pow(pj_tsfn(lp.phi, sin(lp.phi),
-            P->e), Q->n) : pow(tan(FORTPI + .5 * lp.phi), -Q->n));
+            P->e), Q->n) : pow(tan(M_FORTPI + .5 * lp.phi), -Q->n));
     fac->code |= IS_ANAL_HK + IS_ANAL_CONV;
     fac->k = fac->h = P->k0 * Q->n * rho /
         pj_msfn(sin(lp.phi), cos(lp.phi), P->es);
@@ -131,16 +131,16 @@ PJ *PROJECTION(lcc) {
             Q->n /= log(ml1 / pj_tsfn(Q->phi2, sinphi, P->e));
         }
         Q->c = (Q->rho0 = m1 * pow(ml1, -Q->n) / Q->n);
-        Q->rho0 *= (fabs(fabs(P->phi0) - HALFPI) < EPS10) ? 0. :
+        Q->rho0 *= (fabs(fabs(P->phi0) - M_HALFPI) < EPS10) ? 0. :
             pow(pj_tsfn(P->phi0, sin(P->phi0), P->e), Q->n);
     } else {
         if (secant)
             Q->n = log(cosphi / cos(Q->phi2)) /
-               log(tan(FORTPI + .5 * Q->phi2) /
-               tan(FORTPI + .5 * Q->phi1));
-        Q->c = cosphi * pow(tan(FORTPI + .5 * Q->phi1), Q->n) / Q->n;
-        Q->rho0 = (fabs(fabs(P->phi0) - HALFPI) < EPS10) ? 0. :
-            Q->c * pow(tan(FORTPI + .5 * P->phi0), -Q->n);
+               log(tan(M_FORTPI + .5 * Q->phi2) /
+               tan(M_FORTPI + .5 * Q->phi1));
+        Q->c = cosphi * pow(tan(M_FORTPI + .5 * Q->phi1), Q->n) / Q->n;
+        Q->rho0 = (fabs(fabs(P->phi0) - M_HALFPI) < EPS10) ? 0. :
+            Q->c * pow(tan(M_FORTPI + .5 * P->phi0), -Q->n);
     }
 
     P->inv = e_inverse;

--- a/src/PJ_loxim.c
+++ b/src/PJ_loxim.c
@@ -20,8 +20,8 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     if (fabs(xy.y) < EPS)
         xy.x = lp.lam * Q->cosphi1;
     else {
-        xy.x = FORTPI + 0.5 * lp.phi;
-        if (fabs(xy.x) < EPS || fabs(fabs(xy.x) - HALFPI) < EPS)
+        xy.x = M_FORTPI + 0.5 * lp.phi;
+        if (fabs(xy.x) < EPS || fabs(fabs(xy.x) - M_HALFPI) < EPS)
             xy.x = 0.;
         else
             xy.x = lp.lam * xy.y / log( tan(xy.x) / Q->tanphi1 );
@@ -38,8 +38,8 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     if (fabs(xy.y) < EPS) {
         lp.lam = xy.x / Q->cosphi1;
     } else {
-        lp.lam = FORTPI + 0.5 * lp.phi;
-        if (fabs(lp.lam) < EPS || fabs(fabs(lp.lam) - HALFPI) < EPS)
+        lp.lam = M_FORTPI + 0.5 * lp.phi;
+        if (fabs(lp.lam) < EPS || fabs(fabs(lp.lam) - M_HALFPI) < EPS)
             lp.lam = 0.;
         else
             lp.lam = xy.x * log( tan(lp.lam) / Q->tanphi1 ) / xy.y ;
@@ -75,7 +75,7 @@ PJ *PROJECTION(loxim) {
     if (Q->cosphi1 < EPS)
         E_ERROR(-22);
 
-    Q->tanphi1 = tan(FORTPI + 0.5 * Q->phi1);
+    Q->tanphi1 = tan(M_FORTPI + 0.5 * Q->phi1);
 
     P->inv = s_inverse;
     P->fwd = s_forward;

--- a/src/PJ_lsat.c
+++ b/src/PJ_lsat.c
@@ -6,8 +6,6 @@ PROJ_HEAD(lsat, "Space oblique for LANDSAT")
     "\n\tCyl, Sph&Ell\n\tlsat= path=";
 
 #define TOL 1e-7
-#define PI_HALFPI 4.71238898038468985766
-#define TWOPI_HALFPI 7.85398163397448309610
 
 struct pj_opaque {
     double a2, a4, b, c1, c3;
@@ -45,12 +43,12 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     double lamt, xlam, sdsq, c, d, s, lamdp, phidp, lampp, tanph;
     double lamtp, cl, sd, sp, fac, sav, tanphi;
 
-    if (lp.phi > HALFPI)
-        lp.phi = HALFPI;
-    else if (lp.phi < -HALFPI)
-        lp.phi = -HALFPI;
+    if (lp.phi > M_HALFPI)
+        lp.phi = M_HALFPI;
+    else if (lp.phi < -M_HALFPI)
+        lp.phi = -M_HALFPI;
 
-    lampp = lp.phi >= 0. ? HALFPI : PI_HALFPI;
+    lampp = lp.phi >= 0. ? M_HALFPI : M_PI_HALFPI;
     tanphi = tan(lp.phi);
     for (nn = 0;;) {
         sav = lampp;
@@ -58,7 +56,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
         cl = cos(lamtp);
         if (fabs(cl) < TOL)
             lamtp -= TOL;
-        fac = lampp - sin(lampp) * (cl < 0. ? -HALFPI : HALFPI);
+        fac = lampp - sin(lampp) * (cl < 0. ? -M_HALFPI : M_HALFPI);
         for (l = 50; l; --l) {
             lamt = lp.lam + Q->p22 * sav;
             c = cos(lamt);
@@ -73,15 +71,15 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
         if (!l || ++nn >= 3 || (lamdp > Q->rlm && lamdp < Q->rlm2))
             break;
         if (lamdp <= Q->rlm)
-            lampp = TWOPI_HALFPI;
+            lampp = M_TWOPI_HALFPI;
         else if (lamdp >= Q->rlm2)
-            lampp = HALFPI;
+            lampp = M_HALFPI;
     }
     if (l) {
         sp = sin(lp.phi);
         phidp = aasin(P->ctx,(P->one_es * Q->ca * sp - Q->sa * cos(lp.phi) *
             sin(lamt)) / sqrt(1. - P->es * sp * sp));
-        tanph = log(tan(FORTPI + .5 * phidp));
+        tanph = log(tan(M_FORTPI + .5 * phidp));
         sd = sin(lamdp);
         sdsq = sd * sd;
         s = Q->p22 * Q->sa * cos(lamdp) * sqrt((1. + Q->t * sdsq)
@@ -118,7 +116,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     sl = sin(lamdp);
     fac = exp(sqrt(1. + s * s / Q->xj / Q->xj) * (xy.y -
         Q->c1 * sl - Q->c3 * sin(lamdp * 3.)));
-    phidp = 2. * (atan(fac) - FORTPI);
+    phidp = 2. * (atan(fac) - M_FORTPI);
     dd = sl * sl;
     if (fabs(cos(lamdp)) < TOL)
         lamdp -= TOL;
@@ -130,7 +128,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         * (1. + Q->u)));
     sl = lamt >= 0. ? 1. : -1.;
     scl = cos(lamdp) >= 0. ? 1. : -1;
-    lamt -= HALFPI * (1. - scl) * sl;
+    lamt -= M_HALFPI * (1. - scl) * sl;
     lp.lam = lamt - Q->p22 * lamdp;
     if (fabs(Q->sa) < TOL)
         lp.phi = aasin(P->ctx,spp / sqrt(P->one_es * P->one_es + P->es * sppsq));
@@ -170,11 +168,11 @@ PJ *PROJECTION(lsat) {
     path = pj_param(P->ctx, P->params, "ipath").i;
     if (path <= 0 || path > (land <= 3 ? 251 : 233)) E_ERROR(-29);
     if (land <= 3) {
-        P->lam0 = DEG_TO_RAD * 128.87 - TWOPI / 251. * path;
+        P->lam0 = DEG_TO_RAD * 128.87 - M_TWOPI / 251. * path;
         Q->p22 = 103.2669323;
         alf = DEG_TO_RAD * 99.092;
     } else {
-        P->lam0 = DEG_TO_RAD * 129.3 - TWOPI / 233. * path;
+        P->lam0 = DEG_TO_RAD * 129.3 - M_TWOPI / 233. * path;
         Q->p22 = 98.8841202;
         alf = DEG_TO_RAD * 98.2;
     }
@@ -191,8 +189,8 @@ PJ *PROJECTION(lsat) {
     Q->t = ess * (2. - P->es) * P->rone_es * P->rone_es;
     Q->u = esc * P->rone_es;
     Q->xj = P->one_es * P->one_es * P->one_es;
-    Q->rlm = PI * (1. / 248. + .5161290322580645);
-    Q->rlm2 = Q->rlm + TWOPI;
+    Q->rlm = M_PI * (1. / 248. + .5161290322580645);
+    Q->rlm2 = Q->rlm + M_TWOPI;
     Q->a2 = Q->a4 = Q->b = Q->c1 = Q->c3 = 0.;
     seraz0(0., 1., P);
     for (lam = 9.; lam <= 81.0001; lam += 18.)

--- a/src/PJ_mbtfpp.c
+++ b/src/PJ_mbtfpp.c
@@ -30,7 +30,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         if (fabs(lp.phi) > ONEEPS)
             I_ERROR
         else
-            lp.phi = (lp.phi < 0.) ? -HALFPI : HALFPI;
+            lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
     } else
         lp.phi = asin(lp.phi);
 
@@ -39,7 +39,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         if (fabs(lp.phi) > ONEEPS)
             I_ERROR
         else
-            lp.phi = (lp.phi < 0.) ? -HALFPI : HALFPI;
+            lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
     } else
         lp.phi = asin(lp.phi);
 

--- a/src/PJ_mbtfpq.c
+++ b/src/PJ_mbtfpq.c
@@ -39,15 +39,15 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     lp.phi = RYC * xy.y;
     if (fabs(lp.phi) > 1.) {
         if (fabs(lp.phi) > ONETOL)  I_ERROR
-        else if (lp.phi < 0.) { t = -1.; lp.phi = -PI; }
-        else { t = 1.; lp.phi = PI; }
+        else if (lp.phi < 0.) { t = -1.; lp.phi = -M_PI; }
+        else { t = 1.; lp.phi = M_PI; }
     } else
         lp.phi = 2. * asin(t = lp.phi);
     lp.lam = RXC * xy.x / (1. + 2. * cos(lp.phi)/cos(0.5 * lp.phi));
     lp.phi = RC * (t + sin(lp.phi));
     if (fabs(lp.phi) > 1.)
         if (fabs(lp.phi) > ONETOL)  I_ERROR
-        else            lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+        else            lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
     else
         lp.phi = asin(lp.phi);
     return lp;

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -7,7 +7,7 @@ PROJ_HEAD(merc, "Mercator") "\n\tCyl, Sph&Ell\n\tlat_ts=";
 
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     XY xy = {0.0,0.0};
-    if (fabs(fabs(lp.phi) - HALFPI) <= EPS10)
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10)
         F_ERROR;
     xy.x = P->k0 * lp.lam;
     xy.y = - P->k0 * log(pj_tsfn(lp.phi, sin(lp.phi), P->e));
@@ -17,10 +17,10 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
-    if (fabs(fabs(lp.phi) - HALFPI) <= EPS10)
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10)
         F_ERROR;
     xy.x = P->k0 * lp.lam;
-    xy.y = P->k0 * log(tan(FORTPI + .5 * lp.phi));
+    xy.y = P->k0 * log(tan(M_FORTPI + .5 * lp.phi));
     return xy;
 }
 
@@ -36,7 +36,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
-    lp.phi = HALFPI - 2. * atan(exp(-xy.y / P->k0));
+    lp.phi = M_HALFPI - 2. * atan(exp(-xy.y / P->k0));
     lp.lam = xy.x / P->k0;
     return lp;
 }
@@ -53,7 +53,7 @@ PJ *PROJECTION(merc) {
 
     if( (is_phits = pj_param(P->ctx, P->params, "tlat_ts").i) ) {
         phits = fabs(pj_param(P->ctx, P->params, "rlat_ts").f);
-        if (phits >= HALFPI) E_ERROR(-24);
+        if (phits >= M_HALFPI) E_ERROR(-24);
     }
 
     if (P->es) { /* ellipsoid */

--- a/src/PJ_mill.c
+++ b/src/PJ_mill.c
@@ -8,7 +8,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     (void) P;
 
     xy.x = lp.lam;
-    xy.y = log(tan(FORTPI + lp.phi * .4)) * 1.25;
+    xy.y = log(tan(M_FORTPI + lp.phi * .4)) * 1.25;
 
     return (xy);
 }
@@ -19,7 +19,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     (void) P;
 
     lp.lam = xy.x;
-    lp.phi = 2.5 * (atan(exp(.8 * xy.y)) - FORTPI);
+    lp.phi = 2.5 * (atan(exp(.8 * xy.y)) - M_FORTPI);
 
     return (lp);
 }

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -27,8 +27,6 @@ PROJ_HEAD(misrsom, "Space oblique for MISR")
         "\n\tCyl, Sph&Ell\n\tpath=";
 
 #define TOL 1e-7
-#define PI_HALFPI 4.71238898038468985766
-#define TWOPI_HALFPI 7.85398163397448309610
 
 struct pj_opaque {
     double a2, a4, b, c1, c3;
@@ -64,11 +62,11 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     double lamt, xlam, sdsq, c, d, s, lamdp, phidp, lampp, tanph;
     double lamtp, cl, sd, sp, fac, sav, tanphi;
 
-    if (lp.phi > HALFPI)
-        lp.phi = HALFPI;
-    else if (lp.phi < -HALFPI)
-        lp.phi = -HALFPI;
-    lampp = lp.phi >= 0. ? HALFPI : PI_HALFPI;
+    if (lp.phi > M_HALFPI)
+        lp.phi = M_HALFPI;
+    else if (lp.phi < -M_HALFPI)
+        lp.phi = -M_HALFPI;
+    lampp = lp.phi >= 0. ? M_HALFPI : M_PI_HALFPI;
     tanphi = tan(lp.phi);
     for (nn = 0;;) {
             sav = lampp;
@@ -76,7 +74,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
             cl = cos(lamtp);
             if (fabs(cl) < TOL)
                 lamtp -= TOL;
-            fac = lampp - sin(lampp) * (cl < 0. ? -HALFPI : HALFPI);
+            fac = lampp - sin(lampp) * (cl < 0. ? -M_HALFPI : M_HALFPI);
             for (l = 50; l; --l) {
                     lamt = lp.lam + Q->p22 * sav;
                     if (fabs(c = cos(lamt)) < TOL)
@@ -90,15 +88,15 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
             if (!l || ++nn >= 3 || (lamdp > Q->rlm && lamdp < Q->rlm2))
                     break;
             if (lamdp <= Q->rlm)
-                lampp = TWOPI_HALFPI;
+                lampp = M_TWOPI_HALFPI;
             else if (lamdp >= Q->rlm2)
-                lampp = HALFPI;
+                lampp = M_HALFPI;
     }
     if (l) {
             sp = sin(lp.phi);
             phidp = aasin(P->ctx,(P->one_es * Q->ca * sp - Q->sa * cos(lp.phi) *
                     sin(lamt)) / sqrt(1. - P->es * sp * sp));
-            tanph = log(tan(FORTPI + .5 * phidp));
+            tanph = log(tan(M_FORTPI + .5 * phidp));
             sd = sin(lamdp);
             sdsq = sd * sd;
             s = Q->p22 * Q->sa * cos(lamdp) * sqrt((1. + Q->t * sdsq)
@@ -135,7 +133,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     sl = sin(lamdp);
     fac = exp(sqrt(1. + s * s / Q->xj / Q->xj) * (xy.y -
             Q->c1 * sl - Q->c3 * sin(lamdp * 3.)));
-    phidp = 2. * (atan(fac) - FORTPI);
+    phidp = 2. * (atan(fac) - M_FORTPI);
     dd = sl * sl;
     if (fabs(cos(lamdp)) < TOL)
         lamdp -= TOL;
@@ -147,7 +145,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
             * (1. + Q->u)));
     sl = lamt >= 0. ? 1. : -1.;
     scl = cos(lamdp) >= 0. ? 1. : -1;
-    lamt -= HALFPI * (1. - scl) * sl;
+    lamt -= M_HALFPI * (1. - scl) * sl;
     lp.lam = lamt - Q->p22 * lamdp;
     if (fabs(Q->sa) < TOL)
         lp.phi = aasin(P->ctx,spp / sqrt(P->one_es * P->one_es + P->es * sppsq));
@@ -185,7 +183,7 @@ PJ *PROJECTION(misrsom) {
 
     path = pj_param(P->ctx, P->params, "ipath").i;
     if (path <= 0 || path > 233) E_ERROR(-29);
-    P->lam0 = DEG_TO_RAD * 129.3056 - TWOPI / 233. * path;
+    P->lam0 = DEG_TO_RAD * 129.3056 - M_TWOPI / 233. * path;
     alf = 98.30382 * DEG_TO_RAD;
     Q->p22 = 98.88 / 1440.0;
 
@@ -202,7 +200,7 @@ PJ *PROJECTION(misrsom) {
     Q->u = esc * P->rone_es;
     Q->xj = P->one_es * P->one_es * P->one_es;
     Q->rlm = 0;
-    Q->rlm2 = Q->rlm + TWOPI;
+    Q->rlm2 = Q->rlm + M_TWOPI;
     Q->a2 = Q->a4 = Q->b = Q->c1 = Q->c3 = 0.;
     seraz0(0., 1., P);
     for (lam = 9.; lam <= 81.0001; lam += 18.)

--- a/src/PJ_mod_ster.c
+++ b/src/PJ_mod_ster.c
@@ -26,8 +26,8 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     sinlon = sin(lp.lam);
     coslon = cos(lp.lam);
     esphi = P->e * sin(lp.phi);
-    chi = 2. * atan(tan((HALFPI + lp.phi) * .5) *
-        pow((1. - esphi) / (1. + esphi), P->e * .5)) - HALFPI;
+    chi = 2. * atan(tan((M_HALFPI + lp.phi) * .5) *
+        pow((1. - esphi) / (1. + esphi), P->e * .5)) - M_HALFPI;
     schi = sin(chi);
     cchi = cos(chi);
     s = 2. / (1. + Q->schio * schi + Q->cchio * cchi * coslon);
@@ -76,8 +76,8 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         phi = chi;
         for (nn = 20; nn ;--nn) {
             esphi = P->e * sin(phi);
-            dphi = 2. * atan(tan((HALFPI + chi) * .5) *
-                pow((1. + esphi) / (1. - esphi), P->e * .5)) - HALFPI - phi;
+            dphi = 2. * atan(tan((M_HALFPI + chi) * .5) *
+                pow((1. + esphi) / (1. - esphi), P->e * .5)) - M_HALFPI - phi;
             phi += dphi;
             if (fabs(dphi) <= EPSLN)
                 break;
@@ -114,8 +114,8 @@ static PJ *setup(PJ *P) { /* general initialization */
 
     if (P->es) {
         esphi = P->e * sin(P->phi0);
-        chio = 2. * atan(tan((HALFPI + P->phi0) * .5) *
-            pow((1. - esphi) / (1. + esphi), P->e * .5)) - HALFPI;
+        chio = 2. * atan(tan((M_HALFPI + P->phi0) * .5) *
+            pow((1. - esphi) / (1. + esphi), P->e * .5)) - M_HALFPI;
     } else
         chio = P->phi0;
     Q->schio = sin(chio);

--- a/src/PJ_moll.c
+++ b/src/PJ_moll.c
@@ -27,7 +27,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
             break;
     }
     if (!i)
-        lp.phi = (lp.phi < 0.) ? -HALFPI : HALFPI;
+        lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
     else
         lp.phi *= 0.5;
     xy.x = Q->C_x * lp.lam * cos(lp.phi);
@@ -41,7 +41,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     struct pj_opaque *Q = P->opaque;
     lp.phi = aasin(P->ctx, xy.y / Q->C_y);
     lp.lam = xy.x / (Q->C_x * cos(lp.phi));
-        if (fabs(lp.lam) < PI) {
+        if (fabs(lp.lam) < M_PI) {
             lp.phi += lp.phi;
             lp.phi = aasin(P->ctx, (lp.phi + sin(lp.phi)) / Q->C_p);
         } else {
@@ -74,9 +74,9 @@ static PJ * setup(PJ *P, double p) {
 
     P->es = 0;
     sp = sin(p);
-    r = sqrt(TWOPI * sp / (p2 + sin(p2)));
+    r = sqrt(M_TWOPI * sp / (p2 + sin(p2)));
 
-    Q->C_x = 2. * r / PI;
+    Q->C_x = 2. * r / M_PI;
     Q->C_y = r / sp;
     Q->C_p = p2 + sin(p2);
 
@@ -92,7 +92,7 @@ PJ *PROJECTION(moll) {
         return freeup_new (P);
     P->opaque = Q;
 
-    return setup(P, HALFPI);
+    return setup(P, M_HALFPI);
 }
 
 
@@ -102,7 +102,7 @@ PJ *PROJECTION(wag4) {
         return freeup_new (P);
     P->opaque = Q;
 
-    return setup(P, PI/3.);
+    return setup(P, M_PI/3.);
 }
 
 PJ *PROJECTION(wag5) {

--- a/src/PJ_natearth.c
+++ b/src/PJ_natearth.c
@@ -33,7 +33,7 @@ PROJ_HEAD(natearth, "Natural Earth") "\n\tPCyl., Sph.";
 #define C3 (9 * B3)
 #define C4 (11 * B4)
 #define EPS 1e-11
-#define MAX_Y (0.8707 * 0.52 * PI)
+#define MAX_Y (0.8707 * 0.52 * M_PI)
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */

--- a/src/PJ_natearth2.c
+++ b/src/PJ_natearth2.c
@@ -25,7 +25,7 @@ PROJ_HEAD(natearth2, "Natural Earth 2") "\n\tPCyl., Sph.";
 #define C2 (11 * B2)
 #define C3 (13 * B3)
 #define EPS 1e-11
-#define MAX_Y (0.84719 * 0.535117535153096 * PI)
+#define MAX_Y (0.84719 * 0.535117535153096 * M_PI)
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */

--- a/src/PJ_nell_h.c
+++ b/src/PJ_nell_h.c
@@ -32,7 +32,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
             break;
     }
     if (!i) {
-        lp.phi = p < 0. ? -HALFPI : HALFPI;
+        lp.phi = p < 0. ? -M_HALFPI : M_HALFPI;
         lp.lam = 2. * xy.x;
     } else
         lp.lam = 2. * xy.x / (1. + cos(lp.phi));

--- a/src/PJ_nocol.c
+++ b/src/PJ_nocol.c
@@ -16,17 +16,17 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     } else if (fabs(lp.phi) < EPS) {
         xy.x = lp.lam;
         xy.y = 0.;
-    } else if (fabs(fabs(lp.lam) - HALFPI) < EPS) {
+    } else if (fabs(fabs(lp.lam) - M_HALFPI) < EPS) {
         xy.x = lp.lam * cos(lp.phi);
-        xy.y = HALFPI * sin(lp.phi);
-    } else if (fabs(fabs(lp.phi) - HALFPI) < EPS) {
+        xy.y = M_HALFPI * sin(lp.phi);
+    } else if (fabs(fabs(lp.phi) - M_HALFPI) < EPS) {
         xy.x = 0;
         xy.y = lp.phi;
     } else {
         double tb, c, d, m, n, r2, sp;
 
-        tb = HALFPI / lp.lam - lp.lam / HALFPI;
-        c = lp.phi / HALFPI;
+        tb = M_HALFPI / lp.lam - lp.lam / M_HALFPI;
+        c = lp.phi / M_HALFPI;
         d = (1 - c * c)/((sp = sin(lp.phi)) - c);
         r2 = tb / d;
         r2 *= r2;
@@ -34,10 +34,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         n = (sp / r2 + 0.5 * d)/(1. + 1./r2);
         xy.x = cos(lp.phi);
         xy.x = sqrt(m * m + xy.x * xy.x / (1. + r2));
-        xy.x = HALFPI * ( m + (lp.lam < 0. ? -xy.x : xy.x));
+        xy.x = M_HALFPI * ( m + (lp.lam < 0. ? -xy.x : xy.x));
         xy.y = sqrt(n * n - (sp * sp / r2 + d * sp - 1.) /
             (1. + 1./r2));
-        xy.y = HALFPI * ( n + (lp.phi < 0. ? xy.y : -xy.y ));
+        xy.y = M_HALFPI * ( n + (lp.phi < 0. ? xy.y : -xy.y ));
     }
     return (xy);
 }

--- a/src/PJ_nsper.c
+++ b/src/PJ_nsper.c
@@ -146,7 +146,7 @@ static PJ *setup(PJ *P) {
     struct pj_opaque *Q = P->opaque;
 
     if ((Q->height = pj_param(P->ctx, P->params, "dh").f) <= 0.) E_ERROR(-30);
-    if (fabs(fabs(P->phi0) - HALFPI) < EPS10)
+    if (fabs(fabs(P->phi0) - M_HALFPI) < EPS10)
         Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
     else if (fabs(P->phi0) < EPS10)
         Q->mode = EQUIT;

--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -144,7 +144,7 @@ PJ *PROJECTION(ob_tran) {
             fabs(fabs(phic) - HALFPI) <= TOL ||
             fabs(fabs(alpha) - HALFPI) <= TOL)
 */
-        if (fabs(fabs(phic) - HALFPI) <= TOL)
+        if (fabs(fabs(phic) - M_HALFPI) <= TOL)
             E_ERROR(-32);
         Q->lamp = lamc + aatan2(-cos(alpha), -sin(alpha) * sin(phic));
         phip = aasin(P->ctx,cos(phic) * sin(alpha));
@@ -160,8 +160,8 @@ PJ *PROJECTION(ob_tran) {
         phi2 = pj_param(P->ctx, P->params, "ro_lat_2").f;
         if (fabs(phi1 - phi2) <= TOL ||
             (con = fabs(phi1)) <= TOL ||
-            fabs(con - HALFPI) <= TOL ||
-            fabs(fabs(phi2) - HALFPI) <= TOL) E_ERROR(-33);
+            fabs(con - M_HALFPI) <= TOL ||
+            fabs(fabs(phi2) - M_HALFPI) <= TOL) E_ERROR(-33);
         Q->lamp = atan2(cos(phi1) * sin(phi2) * cos(lam1) -
             sin(phi1) * cos(phi2) * cos(lam2),
             sin(phi1) * cos(phi2) * sin(lam2) -

--- a/src/PJ_ocea.c
+++ b/src/PJ_ocea.c
@@ -23,7 +23,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     t = cos(lp.lam);
     xy.x = atan((tan(lp.phi) * Q->cosphi + Q->sinphi * xy.y) / t);
     if (t < 0.)
-        xy.x += PI;
+        xy.x += M_PI;
     xy.x *= Q->rtk;
     xy.y = Q->rok * (Q->sinphi * sin(lp.phi) - Q->cosphi * cos(lp.phi) * xy.y);
     return xy;
@@ -95,7 +95,7 @@ PJ *PROJECTION(ocea) {
         /*Equation 9-2 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
         Q->sinphi = atan(-cos(Q->singam - lam_1) / tan(phi_1));
     }
-    P->lam0 = Q->singam + HALFPI;
+    P->lam0 = Q->singam + M_HALFPI;
     Q->cosphi = cos(Q->sinphi);
     Q->sinphi = sin(Q->sinphi);
     Q->cosgam = cos(Q->singam);

--- a/src/PJ_omerc.c
+++ b/src/PJ_omerc.c
@@ -43,7 +43,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     struct pj_opaque *Q = P->opaque;
     double S, T, U, V, W, temp, u, v;
 
-    if (fabs(fabs(lp.phi) - HALFPI) > EPS) {
+    if (fabs(fabs(lp.phi) - M_HALFPI) > EPS) {
         W = Q->E / pow(pj_tsfn(lp.phi, sin(lp.phi), P->e), Q->B);
         temp = 1. / W;
         S = .5 * (W - temp);
@@ -94,7 +94,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     Up = (Vp * Q->cosgam + Sp * Q->singam) / Tp;
     if (fabs(fabs(Up) - 1.) < EPS) {
         lp.lam = 0.;
-        lp.phi = Up < 0. ? -HALFPI : HALFPI;
+        lp.phi = Up < 0. ? -M_HALFPI : M_HALFPI;
     } else {
         lp.phi = Q->E / sqrt((1. + Up) / (1. - Up));
         if ((lp.phi = pj_phi2(P->ctx, pow(lp.phi, 1. / Q->B), P->e)) == HUGE_VAL)
@@ -157,9 +157,9 @@ PJ *PROJECTION(omerc) {
         phi2 = pj_param(P->ctx, P->params, "rlat_2").f;
         if (fabs(phi1 - phi2) <= TOL ||
             (con = fabs(phi1)) <= TOL ||
-            fabs(con - HALFPI) <= TOL ||
-            fabs(fabs(P->phi0) - HALFPI) <= TOL ||
-            fabs(fabs(phi2) - HALFPI) <= TOL) E_ERROR(-33);
+            fabs(con - M_HALFPI) <= TOL ||
+            fabs(fabs(P->phi0) - M_HALFPI) <= TOL ||
+            fabs(fabs(phi2) - M_HALFPI) <= TOL) E_ERROR(-33);
     }
     com = sqrt(P->one_es);
     if (fabs(P->phi0) > EPS) {
@@ -192,8 +192,8 @@ PJ *PROJECTION(omerc) {
         } else
             alpha_c = asin(D*sin(gamma0 = gamma));
         if ((con = fabs(alpha_c)) <= TOL ||
-            fabs(con - PI) <= TOL ||
-            fabs(fabs(P->phi0) - HALFPI) <= TOL)
+            fabs(con - M_PI) <= TOL ||
+            fabs(fabs(P->phi0) - M_HALFPI) <= TOL)
             E_ERROR(-32);
         P->lam0 = lamc - asin(.5 * (F - 1. / F) *
            tan(gamma0)) / Q->B;
@@ -204,10 +204,10 @@ PJ *PROJECTION(omerc) {
         p = (L - H) / (L + H);
         J = Q->E * Q->E;
         J = (J - L * H) / (J + L * H);
-        if ((con = lam1 - lam2) < -PI)
-            lam2 -= TWOPI;
-        else if (con > PI)
-            lam2 += TWOPI;
+        if ((con = lam1 - lam2) < -M_PI)
+            lam2 -= M_TWOPI;
+        else if (con > M_PI)
+            lam2 += M_TWOPI;
         P->lam0 = adjlon(.5 * (lam1 + lam2) - atan(
            J * tan(.5 * Q->B * (lam1 - lam2)) / p) / Q->B);
         gamma0 = atan(2. * sin(Q->B * adjlon(lam1 - P->lam0)) /
@@ -228,8 +228,8 @@ PJ *PROJECTION(omerc) {
             Q->u_0 = - Q->u_0;
     }
     F = 0.5 * gamma0;
-    Q->v_pole_n = Q->ArB * log(tan(FORTPI - F));
-    Q->v_pole_s = Q->ArB * log(tan(FORTPI + F));
+    Q->v_pole_n = Q->ArB * log(tan(M_FORTPI - F));
+    Q->v_pole_s = Q->ArB * log(tan(M_FORTPI + F));
     P->inv = e_inverse;
     P->fwd = e_forward;
 

--- a/src/PJ_ortho.c
+++ b/src/PJ_ortho.c
@@ -36,7 +36,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 	case N_POLE:
 		coslam = - coslam;
 	case S_POLE:
-		if (fabs(lp.phi - P->phi0) - EPS10 > HALFPI) F_ERROR;
+		if (fabs(lp.phi - P->phi0) - EPS10 > M_HALFPI) F_ERROR;
 		xy.y = cosphi * coslam;
 		break;
 	}
@@ -78,13 +78,13 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
             xy.x *= sinc * Q->cosph0;
         sinchk:
             if (fabs(lp.phi) >= 1.)
-                lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+                lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
             else
                 lp.phi = asin(lp.phi);
             break;
         }
         lp.lam = (xy.y == 0. && (Q->mode == OBLIQ || Q->mode == EQUIT))
-             ? (xy.x == 0. ? 0. : xy.x < 0. ? -HALFPI : HALFPI)
+             ? (xy.x == 0. ? 0. : xy.x < 0. ? -M_HALFPI : M_HALFPI)
                            : atan2(xy.x, xy.y);
     }
     return lp;
@@ -113,7 +113,7 @@ PJ *PROJECTION(ortho) {
         return freeup_new (P);
     P->opaque = Q;
 
-	if (fabs(fabs(P->phi0) - HALFPI) <= EPS10)
+	if (fabs(fabs(P->phi0) - M_HALFPI) <= EPS10)
 		Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
 	else if (fabs(P->phi0) > EPS10) {
 		Q->mode = OBLIQ;

--- a/src/PJ_qsc.c
+++ b/src/PJ_qsc.c
@@ -76,17 +76,17 @@ static double qsc_fwd_equat_face_theta(double phi, double y, double x, int *area
         theta = 0.0;
     } else {
         theta = atan2(y, x);
-        if (fabs(theta) <= FORTPI) {
+        if (fabs(theta) <= M_FORTPI) {
             *area = AREA_0;
-        } else if (theta > FORTPI && theta <= HALFPI + FORTPI) {
+        } else if (theta > M_FORTPI && theta <= M_HALFPI + M_FORTPI) {
             *area = AREA_1;
-            theta -= HALFPI;
-        } else if (theta > HALFPI + FORTPI || theta <= -(HALFPI + FORTPI)) {
+            theta -= M_HALFPI;
+        } else if (theta > M_HALFPI + M_FORTPI || theta <= -(M_HALFPI + M_FORTPI)) {
             *area = AREA_2;
-            theta = (theta >= 0.0 ? theta - PI : theta + PI);
+            theta = (theta >= 0.0 ? theta - M_PI : theta + M_PI);
         } else {
             *area = AREA_3;
-            theta += HALFPI;
+            theta += M_HALFPI;
         }
     }
     return theta;
@@ -95,10 +95,10 @@ static double qsc_fwd_equat_face_theta(double phi, double y, double x, int *area
 /* Helper function: shift the longitude. */
 static double qsc_shift_lon_origin(double lon, double offset) {
     double slon = lon + offset;
-    if (slon < -PI) {
-        slon += TWOPI;
-    } else if (slon > +PI) {
-        slon -= TWOPI;
+    if (slon < -M_PI) {
+        slon += M_TWOPI;
+    } else if (slon > +M_PI) {
+        slon -= M_TWOPI;
     }
     return slon;
 }
@@ -128,34 +128,34 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
      * unit sphere cartesian coordinates as an intermediate step. */
     lon = lp.lam;
     if (Q->face == FACE_TOP) {
-        phi = HALFPI - lat;
-        if (lon >= FORTPI && lon <= HALFPI + FORTPI) {
+        phi = M_HALFPI - lat;
+        if (lon >= M_FORTPI && lon <= M_HALFPI + M_FORTPI) {
             area = AREA_0;
-            theta = lon - HALFPI;
-        } else if (lon > HALFPI + FORTPI || lon <= -(HALFPI + FORTPI)) {
+            theta = lon - M_HALFPI;
+        } else if (lon > M_HALFPI + M_FORTPI || lon <= -(M_HALFPI + M_FORTPI)) {
             area = AREA_1;
-            theta = (lon > 0.0 ? lon - PI : lon + PI);
-        } else if (lon > -(HALFPI + FORTPI) && lon <= -FORTPI) {
+            theta = (lon > 0.0 ? lon - M_PI : lon + M_PI);
+        } else if (lon > -(M_HALFPI + M_FORTPI) && lon <= -M_FORTPI) {
             area = AREA_2;
-            theta = lon + HALFPI;
+            theta = lon + M_HALFPI;
         } else {
             area = AREA_3;
             theta = lon;
         }
     } else if (Q->face == FACE_BOTTOM) {
-        phi = HALFPI + lat;
-        if (lon >= FORTPI && lon <= HALFPI + FORTPI) {
+        phi = M_HALFPI + lat;
+        if (lon >= M_FORTPI && lon <= M_HALFPI + M_FORTPI) {
             area = AREA_0;
-            theta = -lon + HALFPI;
-        } else if (lon < FORTPI && lon >= -FORTPI) {
+            theta = -lon + M_HALFPI;
+        } else if (lon < M_FORTPI && lon >= -M_FORTPI) {
             area = AREA_1;
             theta = -lon;
-        } else if (lon < -FORTPI && lon >= -(HALFPI + FORTPI)) {
+        } else if (lon < -M_FORTPI && lon >= -(M_HALFPI + M_FORTPI)) {
             area = AREA_2;
-            theta = -lon - HALFPI;
+            theta = -lon - M_HALFPI;
         } else {
             area = AREA_3;
-            theta = (lon > 0.0 ? -lon + PI : -lon - PI);
+            theta = (lon > 0.0 ? -lon + M_PI : -lon - M_PI);
         }
     } else {
         double q, r, s;
@@ -163,11 +163,11 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
         double sinlon, coslon;
 
         if (Q->face == FACE_RIGHT) {
-            lon = qsc_shift_lon_origin(lon, +HALFPI);
+            lon = qsc_shift_lon_origin(lon, +M_HALFPI);
         } else if (Q->face == FACE_BACK) {
-            lon = qsc_shift_lon_origin(lon, +PI);
+            lon = qsc_shift_lon_origin(lon, +M_PI);
         } else if (Q->face == FACE_LEFT) {
-            lon = qsc_shift_lon_origin(lon, -HALFPI);
+            lon = qsc_shift_lon_origin(lon, -M_HALFPI);
         }
         sinlat = sin(lat);
         coslat = cos(lat);
@@ -199,17 +199,17 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     /* Compute mu and nu for the area of definition.
      * For mu, see Eq. (3-21) in [OL76], but note the typos:
      * compare with Eq. (3-14). For nu, see Eq. (3-38). */
-    mu = atan((12.0 / PI) * (theta + acos(sin(theta) * cos(FORTPI)) - HALFPI));
+    mu = atan((12.0 / M_PI) * (theta + acos(sin(theta) * cos(M_FORTPI)) - M_HALFPI));
     t = sqrt((1.0 - cos(phi)) / (cos(mu) * cos(mu)) / (1.0 - cos(atan(1.0 / cos(theta)))));
     /* nu = atan(t);        We don't really need nu, just t, see below. */
 
     /* Apply the result to the real area. */
     if (area == AREA_1) {
-        mu += HALFPI;
+        mu += M_HALFPI;
     } else if (area == AREA_2) {
-        mu += PI;
+        mu += M_PI;
     } else if (area == AREA_3) {
-        mu += HALFPI + PI;
+        mu += M_PI_HALFPI;
     }
 
     /* Now compute x, y from mu and nu */
@@ -236,13 +236,13 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         area = AREA_0;
     } else if (xy.y >= 0.0 && xy.y >= fabs(xy.x)) {
         area = AREA_1;
-        mu -= HALFPI;
+        mu -= M_HALFPI;
     } else if (xy.x < 0.0 && -xy.x >= fabs(xy.y)) {
         area = AREA_2;
-        mu = (mu < 0.0 ? mu + PI : mu - PI);
+        mu = (mu < 0.0 ? mu + M_PI : mu - M_PI);
     } else {
         area = AREA_3;
-        mu += HALFPI;
+        mu += M_HALFPI;
     }
 
     /* Compute phi and theta for the area of definition.
@@ -250,7 +250,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
      * good hints can be found here (as of 2011-12-14):
      * http://fits.gsfc.nasa.gov/fitsbits/saf.93/saf.9302
      * (search for "Message-Id: <9302181759.AA25477 at fits.cv.nrao.edu>") */
-    t = (PI / 12.0) * tan(mu);
+    t = (M_PI / 12.0) * tan(mu);
     tantheta = sin(t) / (cos(t) - (1.0 / sqrt(2.0)));
     theta = atan(tantheta);
     cosmu = cos(mu);
@@ -268,27 +268,27 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
      * as an intermediate step. */
     if (Q->face == FACE_TOP) {
         phi = acos(cosphi);
-        lp.phi = HALFPI - phi;
+        lp.phi = M_HALFPI - phi;
         if (area == AREA_0) {
-            lp.lam = theta + HALFPI;
+            lp.lam = theta + M_HALFPI;
         } else if (area == AREA_1) {
-            lp.lam = (theta < 0.0 ? theta + PI : theta - PI);
+            lp.lam = (theta < 0.0 ? theta + M_PI : theta - M_PI);
         } else if (area == AREA_2) {
-            lp.lam = theta - HALFPI;
+            lp.lam = theta - M_HALFPI;
         } else /* area == AREA_3 */ {
             lp.lam = theta;
         }
     } else if (Q->face == FACE_BOTTOM) {
         phi = acos(cosphi);
-        lp.phi = phi - HALFPI;
+        lp.phi = phi - M_HALFPI;
         if (area == AREA_0) {
-            lp.lam = -theta + HALFPI;
+            lp.lam = -theta + M_HALFPI;
         } else if (area == AREA_1) {
             lp.lam = -theta;
         } else if (area == AREA_2) {
-            lp.lam = -theta - HALFPI;
+            lp.lam = -theta - M_HALFPI;
         } else /* area == AREA_3 */ {
-            lp.lam = (theta < 0.0 ? -theta - PI : -theta + PI);
+            lp.lam = (theta < 0.0 ? -theta - M_PI : -theta + M_PI);
         }
     } else {
         /* Compute phi and lam via cartesian unit sphere coordinates. */
@@ -333,14 +333,14 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
             r = -t;
         }
         /* Now compute phi and lam from the unit sphere coordinates. */
-        lp.phi = acos(-s) - HALFPI;
+        lp.phi = acos(-s) - M_HALFPI;
         lp.lam = atan2(r, q);
         if (Q->face == FACE_RIGHT) {
-            lp.lam = qsc_shift_lon_origin(lp.lam, -HALFPI);
+            lp.lam = qsc_shift_lon_origin(lp.lam, -M_HALFPI);
         } else if (Q->face == FACE_BACK) {
-            lp.lam = qsc_shift_lon_origin(lp.lam, -PI);
+            lp.lam = qsc_shift_lon_origin(lp.lam, -M_PI);
         } else if (Q->face == FACE_LEFT) {
-            lp.lam = qsc_shift_lon_origin(lp.lam, +HALFPI);
+            lp.lam = qsc_shift_lon_origin(lp.lam, +M_HALFPI);
         }
     }
 
@@ -387,13 +387,13 @@ PJ *PROJECTION(qsc) {
     P->inv = e_inverse;
     P->fwd = e_forward;
     /* Determine the cube face from the center of projection. */
-    if (P->phi0 >= HALFPI - FORTPI / 2.0) {
+    if (P->phi0 >= M_HALFPI - M_FORTPI / 2.0) {
         Q->face = FACE_TOP;
-    } else if (P->phi0 <= -(HALFPI - FORTPI / 2.0)) {
+    } else if (P->phi0 <= -(M_HALFPI - M_FORTPI / 2.0)) {
         Q->face = FACE_BOTTOM;
-    } else if (fabs(P->lam0) <= FORTPI) {
+    } else if (fabs(P->lam0) <= M_FORTPI) {
         Q->face = FACE_FRONT;
-    } else if (fabs(P->lam0) <= HALFPI + FORTPI) {
+    } else if (fabs(P->lam0) <= M_HALFPI + M_FORTPI) {
         Q->face = (P->lam0 > 0.0 ? FACE_RIGHT : FACE_LEFT);
     } else {
         Q->face = FACE_BACK;

--- a/src/PJ_robin.c
+++ b/src/PJ_robin.c
@@ -100,7 +100,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     if (lp.phi >= 1.) { /* simple pathologic cases */
         if (lp.phi > ONEEPS) I_ERROR
         else {
-            lp.phi = xy.y < 0. ? -HALFPI : HALFPI;
+            lp.phi = xy.y < 0. ? -M_HALFPI : M_HALFPI;
             lp.lam /= X[NODES].c0;
         }
     } else { /* general problem */

--- a/src/PJ_sconics.c
+++ b/src/PJ_sconics.c
@@ -169,7 +169,7 @@ static PJ *setup(PJ *P, int type) {
         Q->n = sin (Q->sig);
         Q->c2 = cos (del);
         Q->c1 = 1./tan (Q->sig);
-        if (fabs (del = P->phi0 - Q->sig) - EPS10 >= HALFPI)
+        if (fabs (del = P->phi0 - Q->sig) - EPS10 >= M_HALFPI)
             E_ERROR(-43);
         Q->rho_0 = Q->c2 * (Q->c1 - tan (del));
         break;

--- a/src/PJ_somerc.c
+++ b/src/PJ_somerc.c
@@ -18,14 +18,14 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
 
     sp = P->e * sin (lp.phi);
     phip = 2.* atan ( exp ( Q->c * (
-        log (tan (FORTPI + 0.5 * lp.phi)) - Q->hlf_e * log ((1. + sp)/(1. - sp)))
-        + Q->K)) - HALFPI;
+        log (tan (M_FORTPI + 0.5 * lp.phi)) - Q->hlf_e * log ((1. + sp)/(1. - sp)))
+        + Q->K)) - M_HALFPI;
     lamp = Q->c * lp.lam;
     cp = cos(phip);
     phipp = aasin (P->ctx, Q->cosp0 * sin (phip) - Q->sinp0 * cp * cos (lamp));
     lampp = aasin (P->ctx, cp * sin (lamp) / cos (phipp));
     xy.x = Q->kR * lampp;
-    xy.y = Q->kR * log (tan (FORTPI + 0.5 * phipp));
+    xy.y = Q->kR * log (tan (M_FORTPI + 0.5 * phipp));
     return xy;
 }
 
@@ -36,15 +36,15 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     double phip, lamp, phipp, lampp, cp, esp, con, delp;
     int i;
 
-    phipp = 2. * (atan (exp (xy.y / Q->kR)) - FORTPI);
+    phipp = 2. * (atan (exp (xy.y / Q->kR)) - M_FORTPI);
     lampp = xy.x / Q->kR;
     cp = cos (phipp);
     phip = aasin (P->ctx, Q->cosp0 * sin (phipp) + Q->sinp0 * cp * cos (lampp));
     lamp = aasin (P->ctx, cp * sin (lampp) / cos (phip));
-    con = (Q->K - log (tan (FORTPI + 0.5 * phip)))/Q->c;
+    con = (Q->K - log (tan (M_FORTPI + 0.5 * phip)))/Q->c;
     for (i = NITER; i ; --i) {
         esp = P->e * sin(phip);
-        delp = (con + log(tan(FORTPI + 0.5 * phip)) - Q->hlf_e *
+        delp = (con + log(tan(M_FORTPI + 0.5 * phip)) - Q->hlf_e *
             log((1. + esp)/(1. - esp)) ) *
             (1. - esp * esp) * cos(phip) * P->rone_es;
         phip -= delp;
@@ -95,8 +95,8 @@ PJ *PROJECTION(somerc) {
     sp = sin (P->phi0);
     Q->cosp0 = cos( phip0 = aasin (P->ctx, Q->sinp0 = sp / Q->c) );
     sp *= P->e;
-    Q->K = log (tan (FORTPI + 0.5 * phip0)) - Q->c * (
-        log (tan (FORTPI + 0.5 * P->phi0)) - Q->hlf_e *
+    Q->K = log (tan (M_FORTPI + 0.5 * phip0)) - Q->c * (
+        log (tan (M_FORTPI + 0.5 * P->phi0)) - Q->hlf_e *
         log ((1. + sp) / (1. - sp)));
     Q->kR = P->k0 * sqrt(P->one_es) / (1. - sp * sp);
     P->inv = e_inverse;

--- a/src/PJ_stere.c
+++ b/src/PJ_stere.c
@@ -26,7 +26,7 @@ struct pj_opaque {
 
 static double ssfn_ (double phit, double sinphi, double eccen) {
     sinphi *= eccen;
-    return (tan (.5 * (HALFPI + phit)) *
+    return (tan (.5 * (M_HALFPI + phit)) *
        pow ((1. - sinphi) / (1. + sinphi), .5 * eccen));
 }
 
@@ -40,7 +40,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     sinlam = sin (lp.lam);
     sinphi = sin (lp.phi);
     if (Q->mode == OBLIQ || Q->mode == EQUIT) {
-        sinX = sin (X = 2. * atan(ssfn_(lp.phi, sinphi, P->e)) - HALFPI);
+        sinX = sin (X = 2. * atan(ssfn_(lp.phi, sinphi, P->e)) - M_HALFPI);
         cosX = cos (X);
     }
 
@@ -99,8 +99,8 @@ oblcon:
         coslam = - coslam;
         lp.phi = - lp.phi;
     case S_POLE:
-        if (fabs (lp.phi - HALFPI) < TOL) F_ERROR;
-        xy.x = sinlam * ( xy.y = Q->akm1 * tan (FORTPI + .5 * lp.phi) );
+        if (fabs (lp.phi - M_HALFPI) < TOL) F_ERROR;
+        xy.x = sinlam * ( xy.y = Q->akm1 * tan (M_FORTPI + .5 * lp.phi) );
         xy.y *= coslam;
         break;
     }
@@ -126,17 +126,17 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
                 else
             phi_l = asin (cosphi * Q->sinX1 + (xy.y * sinphi * Q->cosX1 / rho));
 
-        tp = tan (.5 * (HALFPI + phi_l));
+        tp = tan (.5 * (M_HALFPI + phi_l));
         xy.x *= sinphi;
         xy.y = rho * Q->cosX1 * cosphi - xy.y * Q->sinX1* sinphi;
-        halfpi = HALFPI;
+        halfpi = M_HALFPI;
         halfe = .5 * P->e;
         break;
     case N_POLE:
         xy.y = -xy.y;
     case S_POLE:
-        phi_l = HALFPI - 2. * atan (tp = - rho / Q->akm1);
-        halfpi = -HALFPI;
+        phi_l = M_HALFPI - 2. * atan (tp = - rho / Q->akm1);
+        halfpi = -M_HALFPI;
         halfe = -.5 * P->e;
         break;
     }
@@ -212,7 +212,7 @@ static PJ *setup(PJ *P) {                   /* general initialization */
     double t;
     struct pj_opaque *Q = P->opaque;
 
-    if (fabs ((t = fabs (P->phi0)) - HALFPI) < EPS10)
+    if (fabs ((t = fabs (P->phi0)) - M_HALFPI) < EPS10)
         Q->mode = P->phi0 < 0. ? S_POLE : N_POLE;
     else
         Q->mode = t > EPS10 ? OBLIQ : EQUIT;
@@ -224,7 +224,7 @@ static PJ *setup(PJ *P) {                   /* general initialization */
         switch (Q->mode) {
         case N_POLE:
         case S_POLE:
-            if (fabs (Q->phits - HALFPI) < EPS10)
+            if (fabs (Q->phits - M_HALFPI) < EPS10)
                 Q->akm1 = 2. * P->k0 /
                    sqrt (pow (1+P->e,1+P->e) * pow (1-P->e,1-P->e));
             else {
@@ -237,7 +237,7 @@ static PJ *setup(PJ *P) {                   /* general initialization */
         case EQUIT:
         case OBLIQ:
             t = sin (P->phi0);
-            X = 2. * atan (ssfn_(P->phi0, t, P->e)) - HALFPI;
+            X = 2. * atan (ssfn_(P->phi0, t, P->e)) - M_HALFPI;
             t *= P->e;
             Q->akm1 = 2. * P->k0 * cos (P->phi0) / sqrt(1. - t * t);
             Q->sinX1 = sin (X);
@@ -256,8 +256,8 @@ static PJ *setup(PJ *P) {                   /* general initialization */
             break;
         case S_POLE:
         case N_POLE:
-            Q->akm1 = fabs (Q->phits - HALFPI) >= EPS10 ?
-               cos (Q->phits) / tan (FORTPI - .5 * Q->phits) :
+            Q->akm1 = fabs (Q->phits - M_HALFPI) >= EPS10 ?
+               cos (Q->phits) / tan (M_FORTPI - .5 * Q->phits) :
                2. * P->k0 ;
             break;
         }
@@ -276,7 +276,7 @@ PJ *PROJECTION(stere) {
     P->opaque = Q;
 
     Q->phits = pj_param (P->ctx, P->params, "tlat_ts").i ?
-               pj_param (P->ctx, P->params, "rlat_ts").f : HALFPI;
+               pj_param (P->ctx, P->params, "rlat_ts").f : M_HALFPI;
 
     return setup(P);
 }
@@ -289,12 +289,12 @@ PJ *PROJECTION(ups) {
     P->opaque = Q;
 
 	/* International Ellipsoid */
-	P->phi0 = pj_param(P->ctx, P->params, "bsouth").i ? - HALFPI: HALFPI;
+	P->phi0 = pj_param(P->ctx, P->params, "bsouth").i ? - M_HALFPI: M_HALFPI;
 	if (!P->es) E_ERROR(-34);
 	P->k0 = .994;
 	P->x0 = 2000000.;
 	P->y0 = 2000000.;
-	Q->phits = HALFPI;
+	Q->phits = M_HALFPI;
 	P->lam0 = 0.;
 
     return setup(P);

--- a/src/PJ_tmerc.c
+++ b/src/PJ_tmerc.c
@@ -33,7 +33,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
      *
      *  http://trac.osgeo.org/proj/ticket/5
      */
-    if( lp.lam < -HALFPI || lp.lam > HALFPI ) {
+    if( lp.lam < -M_HALFPI || lp.lam > M_HALFPI ) {
         xy.x = HUGE_VAL;
         xy.y = HUGE_VAL;
         pj_ctx_set_errno( P->ctx, -14 );
@@ -74,7 +74,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
      *
      *  http://trac.osgeo.org/proj/ticket/5
      */
-    if( lp.lam < -HALFPI || lp.lam > HALFPI ) {
+    if( lp.lam < -M_HALFPI || lp.lam > M_HALFPI ) {
         xy.x = HUGE_VAL;
         xy.y = HUGE_VAL;
         pj_ctx_set_errno( P->ctx, -14 );
@@ -110,8 +110,8 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     double n, con, cosphi, d, ds, sinphi, t;
 
     lp.phi = pj_inv_mlfn(P->ctx, Q->ml0 + xy.y / P->k0, P->es, Q->en);
-    if (fabs(lp.phi) >= HALFPI) {
-        lp.phi = xy.y < 0. ? -HALFPI : HALFPI;
+    if (fabs(lp.phi) >= M_HALFPI) {
+        lp.phi = xy.y < 0. ? -M_HALFPI : M_HALFPI;
         lp.lam = 0.;
     } else {
         sinphi = sin(lp.phi);

--- a/src/PJ_tpeqd.c
+++ b/src/PJ_tpeqd.c
@@ -103,7 +103,7 @@ PJ *PROJECTION(tpeqd) {
 	Q->sa = sin(pp);
 	Q->lp = adjlon ( atan2 (Q->cp1 * cos(A12), Q->sp1) - Q->hz0);
 	Q->dlam2 *= .5;
-	Q->lamc = HALFPI - atan2(sin(A12) * Q->sp1, cos(A12)) - Q->dlam2;
+	Q->lamc = M_HALFPI - atan2(sin(A12) * Q->sp1, cos(A12)) - Q->dlam2;
 	Q->thz0 = tan (Q->hz0);
 	Q->rhshz0 = .5 / sin (Q->hz0);
 	Q->r2z0 = 0.5 / Q->z02;

--- a/src/PJ_vandg.c
+++ b/src/PJ_vandg.c
@@ -17,7 +17,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
     double  al, al2, g, g2, p2;
 
-    p2 = fabs(lp.phi / HALFPI);
+    p2 = fabs(lp.phi / M_HALFPI);
     if ((p2 - TOL) > 1.) F_ERROR;
     if (p2 > 1.)
         p2 = 1.;
@@ -26,10 +26,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         xy.y = 0.;
     } else if (fabs(lp.lam) <= TOL || fabs(p2 - 1.) < TOL) {
         xy.x = 0.;
-        xy.y = PI * tan(.5 * asin(p2));
+        xy.y = M_PI * tan(.5 * asin(p2));
         if (lp.phi < 0.) xy.y = -xy.y;
     } else {
-        al = .5 * fabs(PI / lp.lam - lp.lam / PI);
+        al = .5 * fabs(M_PI / lp.lam - lp.lam / M_PI);
         al2 = al * al;
         g = sqrt(1. - p2 * p2);
         g = g / (p2 + g - 1.);
@@ -37,15 +37,15 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         p2 = g * (2. / p2 - 1.);
         p2 = p2 * p2;
         xy.x = g - p2; g = p2 + al2;
-        xy.x = PI * (al * xy.x + sqrt(al2 * xy.x * xy.x - g * (g2 - p2))) / g;
+        xy.x = M_PI * (al * xy.x + sqrt(al2 * xy.x * xy.x - g * (g2 - p2))) / g;
         if (lp.lam < 0.) xy.x = -xy.x;
-        xy.y = fabs(xy.x / PI);
+        xy.y = fabs(xy.x / M_PI);
         xy.y = 1. - xy.y * (xy.y + 2. * al);
         if (xy.y < -TOL) F_ERROR;
         if (xy.y < 0.)
             xy.y = 0.;
         else
-            xy.y = sqrt(xy.y) * (lp.phi < 0. ? -PI : PI);
+            xy.y = sqrt(xy.y) * (lp.phi < 0. ? -M_PI : M_PI);
     }
 
     return xy;
@@ -66,17 +66,17 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     }
     y2 = xy.y * xy.y;
     r = x2 + y2;    r2 = r * r;
-    c1 = - PI * ay * (r + PISQ);
-    c3 = r2 + TWOPI * (ay * r + PI * (y2 + PI * (ay + HALFPI)));
+    c1 = - M_PI * ay * (r + PISQ);
+    c3 = r2 + M_TWOPI * (ay * r + M_PI * (y2 + M_PI * (ay + M_HALFPI)));
     c2 = c1 + PISQ * (r - 3. *  y2);
-    c0 = PI * ay;
+    c0 = M_PI * ay;
     c2 /= c3;
     al = c1 / c3 - THIRD * c2 * c2;
     m = 2. * sqrt(-THIRD * al);
     d = C2_27 * c2 * c2 * c2 + (c0 * c0 - THIRD * c2 * c1) / c3;
     if (((t = fabs(d = 3. * d / (al * m))) - TOL) <= 1.) {
-        d = t > 1. ? (d > 0. ? 0. : PI) : acos(d);
-        lp.phi = PI * (m * cos(d * THIRD + PI4_3) - THIRD * c2);
+        d = t > 1. ? (d > 0. ? 0. : M_PI) : acos(d);
+        lp.phi = M_PI * (m * cos(d * THIRD + PI4_3) - THIRD * c2);
         if (xy.y < 0.) lp.phi = -lp.phi;
         t = r2 + TPISQ * (x2 - y2 + HPISQ);
         lp.lam = fabs(xy.x) <= TOL ? 0. :

--- a/src/PJ_vandg2.c
+++ b/src/PJ_vandg2.c
@@ -9,7 +9,6 @@ PROJ_HEAD(vandg2, "van der Grinten II") "\n\tMisc Sph, no inv.";
 PROJ_HEAD(vandg3, "van der Grinten III") "\n\tMisc Sph, no inv.";
 
 #define TOL    1e-10
-#define TWORPI 0.63661977236758134308
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
@@ -17,25 +16,25 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     struct pj_opaque *Q = P->opaque;
     double x1, at, bt, ct;
 
-    bt = fabs(TWORPI * lp.phi);
+    bt = fabs(M_TWO_D_PI * lp.phi);
     if ((ct = 1. - bt * bt) < 0.)
         ct = 0.;
     else
         ct = sqrt(ct);
     if (fabs(lp.lam) < TOL) {
         xy.x = 0.;
-        xy.y = PI * (lp.phi < 0. ? -bt : bt) / (1. + ct);
+        xy.y = M_PI * (lp.phi < 0. ? -bt : bt) / (1. + ct);
     } else {
-        at = 0.5 * fabs(PI / lp.lam - lp.lam / PI);
+        at = 0.5 * fabs(M_PI / lp.lam - lp.lam / M_PI);
         if (Q->vdg3) {
             x1 = bt / (1. + ct);
-            xy.x = PI * (sqrt(at * at + 1. - x1 * x1) - at);
-            xy.y = PI * x1;
+            xy.x = M_PI * (sqrt(at * at + 1. - x1 * x1) - at);
+            xy.y = M_PI * x1;
         } else {
             x1 = (ct * sqrt(1. + at * at) - at * ct * ct) /
                 (1. + at * at * bt * bt);
-            xy.x = PI * x1;
-            xy.y = PI * sqrt(1. - x1 * (x1 + 2. * at) + TOL);
+            xy.x = M_PI * x1;
+            xy.y = M_PI * sqrt(1. - x1 * (x1 + 2. * at) + TOL);
         }
         if ( lp.lam < 0.) xy.x = -xy.x;
         if ( lp.phi < 0.) xy.y = -xy.y;

--- a/src/PJ_vandg4.c
+++ b/src/PJ_vandg4.c
@@ -4,7 +4,6 @@
 PROJ_HEAD(vandg4, "van der Grinten IV") "\n\tMisc Sph, no inv.";
 
 #define TOL 1e-10
-#define TWORPI  0.63661977236758134308
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
@@ -15,19 +14,19 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     if (fabs(lp.phi) < TOL) {
         xy.x = lp.lam;
         xy.y = 0.;
-    } else if (fabs(lp.lam) < TOL || fabs(fabs(lp.phi) - HALFPI) < TOL) {
+    } else if (fabs(lp.lam) < TOL || fabs(fabs(lp.phi) - M_HALFPI) < TOL) {
         xy.x = 0.;
         xy.y = lp.phi;
     } else {
-        bt = fabs(TWORPI * lp.phi);
+        bt = fabs(M_TWO_D_PI * lp.phi);
         bt2 = bt * bt;
         ct = 0.5 * (bt * (8. - bt * (2. + bt2)) - 5.)
             / (bt2 * (bt - 1.));
         ct2 = ct * ct;
-        dt = TWORPI * lp.lam;
+        dt = M_TWO_D_PI * lp.lam;
         dt = dt + 1. / dt;
         dt = sqrt(dt * dt - 4.);
-        if ((fabs(lp.lam) - HALFPI) < 0.) dt = -dt;
+        if ((fabs(lp.lam) - M_HALFPI) < 0.) dt = -dt;
         dt2 = dt * dt;
         x1 = bt + ct; x1 *= x1;
         t = bt + 3.*ct;
@@ -36,8 +35,8 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
             ct2 * (12. * bt * ct + 4. * ct2) );
         x1 = (dt*(x1 + ct2 - 1.) + 2.*sqrt(ft)) /
             (4.* x1 + dt2);
-        xy.x = HALFPI * x1;
-        xy.y = HALFPI * sqrt(1. + dt * fabs(x1) - x1 * x1);
+        xy.x = M_HALFPI * x1;
+        xy.y = M_HALFPI * sqrt(1. + dt * fabs(x1) - x1 * x1);
         if (lp.lam < 0.) xy.x = -xy.x;
         if (lp.phi < 0.) xy.y = -xy.y;
     }

--- a/src/PJ_wink2.c
+++ b/src/PJ_wink2.c
@@ -7,7 +7,6 @@ struct pj_opaque { double	cosphi1; };
 
 #define MAX_ITER    10
 #define LOOP_TOL    1e-7
-#define TWO_D_PI 0.636619772367581343
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
@@ -15,8 +14,8 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 	double k, V;
 	int i;
 
-	xy.y = lp.phi * TWO_D_PI;
-	k = PI * sin (lp.phi);
+	xy.y = lp.phi * M_TWO_D_PI;
+	k = M_PI * sin (lp.phi);
 	lp.phi *= 1.8;
 	for (i = MAX_ITER; i ; --i) {
 		lp.phi -= V = (lp.phi + sin (lp.phi) - k) /
@@ -25,11 +24,11 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
 			break;
 	}
 	if (!i)
-		lp.phi = (lp.phi < 0.) ? -HALFPI : HALFPI;
+		lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
 	else
 		lp.phi *= 0.5;
 	xy.x = 0.5 * lp.lam * (cos (lp.phi) + P->opaque->cosphi1);
-	xy.y = FORTPI * (sin (lp.phi) + xy.y);
+	xy.y = M_FORTPI * (sin (lp.phi) + xy.y);
 	return xy;
 }
 

--- a/src/aasincos.c
+++ b/src/aasincos.c
@@ -11,7 +11,7 @@ aasin(projCtx ctx,double v) {
 	if ((av = fabs(v)) >= 1.) {
 		if (av > ONE_TOL)
                         pj_ctx_set_errno( ctx, -19 );
-		return (v < 0. ? -HALFPI : HALFPI);
+		return (v < 0. ? -M_HALFPI : M_HALFPI);
 	}
 	return asin(v);
 }
@@ -23,7 +23,7 @@ aacos(projCtx ctx, double v) {
 	if ((av = fabs(v)) >= 1.) {
 		if (av > ONE_TOL)
                         pj_ctx_set_errno( ctx, -19 );
-		return (v < 0. ? PI : 0.);
+		return (v < 0. ? M_PI : 0.);
 	}
 	return acos(v);
 }

--- a/src/bchgen.c
+++ b/src/bchgen.c
@@ -9,9 +9,9 @@ bchgen(projUV a, projUV b, int nu, int nv, projUV **f, projUV(*func)(projUV)) {
 	bma.u = 0.5 * (b.u - a.u); bma.v = 0.5 * (b.v - a.v);
 	bpa.u = 0.5 * (b.u + a.u); bpa.v = 0.5 * (b.v + a.v);
 	for ( i = 0; i < nu; ++i) {
-		arg.u = cos(PI * (i + 0.5) / nu) * bma.u + bpa.u;
+		arg.u = cos(M_PI * (i + 0.5) / nu) * bma.u + bpa.u;
 		for ( j = 0; j < nv; ++j) {
-			arg.v = cos(PI * (j + 0.5) / nv) * bma.v + bpa.v;
+			arg.v = cos(M_PI * (j + 0.5) / nv) * bma.v + bpa.v;
 			f[i][j] = (*func)(arg);
 			if ((f[i][j]).u == HUGE_VAL)
 				return(1);
@@ -23,7 +23,7 @@ bchgen(projUV a, projUV b, int nu, int nv, projUV **f, projUV(*func)(projUV)) {
 		for ( i = 0; i < nu; ++i) {
 			arg.u = arg.v = 0.;
 			for (k = 0; k < nu; ++k) {
-				d = cos(PI * i * (k + .5) / nu);
+				d = cos(M_PI * i * (k + .5) / nu);
 				arg.u += f[k][j].u * d;
 				arg.v += f[k][j].v * d;
 			}
@@ -42,7 +42,7 @@ bchgen(projUV a, projUV b, int nu, int nv, projUV **f, projUV(*func)(projUV)) {
 		for (j = 0; j < nv; ++j) {
 			arg.u = arg.v = 0.;
 			for (k = 0; k < nv; ++k) {
-				d = cos(PI * j * (k + .5) / nv);
+				d = cos(M_PI * j * (k + .5) / nv);
 				arg.u += t[k].u * d;
 				arg.v += t[k].v * d;
 			}

--- a/src/gen_cheb.c
+++ b/src/gen_cheb.c
@@ -48,7 +48,7 @@ gen_cheb(int inverse, projUV (*proj)(projUV), char *s, PJ *P, int iargc, char **
 	if (low.u == upp.u || low.v >= upp.v)
 		emess(16,"approx. argument range error");
 	if (low.u > upp.u)
-		low.u -= TWOPI;
+		low.u -= M_TWOPI;
 	if (NU < 2 || NV < 2)
 		emess(16,"approx. work dimensions (%d %d) too small",NU,NV);
 	if (!(F = mk_cheby(low, upp, pow(10., (double)res)*.5, &resid, proj,

--- a/src/geod.c
+++ b/src/geod.c
@@ -87,8 +87,8 @@ process(FILE *fid) {
 		}
 		if (!*s && (s > line)) --s; /* assumed we gobbled \n */
 		if (pos_azi) {
-			if (al12 < 0.) al12 += TWOPI;
-			if (al21 < 0.) al21 += TWOPI;
+			if (al12 < 0.) al12 += M_TWOPI;
+			if (al21 < 0.) al21 += M_TWOPI;
 		}
 		if (fullout) {
 			printLL(phi1, lam1); TAB;

--- a/src/nad2bin.c
+++ b/src/nad2bin.c
@@ -350,8 +350,8 @@ int main(int argc, char **argv) {
                         + (ct.lim.lam - i - 1);
 
                     /* convert radians to seconds */
-                    row_buf[i*4+0] = cvs->phi * (3600.0 / (PI/180.0));
-                    row_buf[i*4+1] = cvs->lam * (3600.0 / (PI/180.0));
+                    row_buf[i*4+0] = cvs->phi * (3600.0 / (M_PI/180.0));
+                    row_buf[i*4+1] = cvs->lam * (3600.0 / (M_PI/180.0));
 
                     /* We leave the accuracy values as zero */
                 }

--- a/src/nad_cvt.c
+++ b/src/nad_cvt.c
@@ -12,7 +12,7 @@ nad_cvt(LP in, int inverse, struct CTABLE *ct) {
 	tb = in;
 	tb.lam -= ct->ll.lam;
 	tb.phi -= ct->ll.phi;
-	tb.lam = adjlon(tb.lam - PI) + PI;
+	tb.lam = adjlon(tb.lam - M_PI) + M_PI;
 	t = nad_intr(tb, ct);
 	if (inverse) {
 		LP del, dif;

--- a/src/pj_deriv.c
+++ b/src/pj_deriv.c
@@ -7,13 +7,13 @@ pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
 
 	lp.lam += h;
 	lp.phi += h;
-	if (fabs(lp.phi) > HALFPI) return 1;
+	if (fabs(lp.phi) > M_HALFPI) return 1;
 	h += h;
 	t = (*P->fwd)(lp, P);
 	if (t.x == HUGE_VAL) return 1;
 	der->x_l = t.x; der->y_p = t.y; der->x_p = -t.x; der->y_l = -t.y;
 	lp.phi -= h;
-	if (fabs(lp.phi) > HALFPI) return 1;
+	if (fabs(lp.phi) > M_HALFPI) return 1;
 	t = (*P->fwd)(lp, P);
 	if (t.x == HUGE_VAL) return 1;
 	der->x_l += t.x; der->y_p -= t.y; der->x_p += t.x; der->y_l -= t.y;

--- a/src/pj_ell_set.c
+++ b/src/pj_ell_set.c
@@ -77,7 +77,7 @@ pj_ell_set(projCtx ctx, paralist *pl, double *a, double *es) {
 			double tmp;
 
 			tmp = sin(pj_param(ctx,pl, i ? "rR_lat_a" : "rR_lat_g").f);
-			if (fabs(tmp) > HALFPI) {
+			if (fabs(tmp) > M_HALFPI) {
                                 pj_ctx_set_errno(ctx,-11);
 				goto bomb;
 			}

--- a/src/pj_factors.c
+++ b/src/pj_factors.c
@@ -12,7 +12,7 @@ pj_factors(LP lp, PJ *P, double h, struct FACTORS *fac) {
 	double cosphi, t, n, r;
 
 	/* check for forward and latitude or longitude overange */
-	if ((t = fabs(lp.phi)-HALFPI) > EPS || fabs(lp.lam) > 10.) {
+	if ((t = fabs(lp.phi)-M_HALFPI) > EPS || fabs(lp.lam) > 10.) {
                 pj_ctx_set_errno( P->ctx, -14);
 		return 1;
 	} else { /* proceed */
@@ -21,9 +21,9 @@ pj_factors(LP lp, PJ *P, double h, struct FACTORS *fac) {
 
 		if (h < EPS)
 			h = DEFAULT_H;
-		if (fabs(lp.phi) > (HALFPI - h)) 
+		if (fabs(lp.phi) > (M_HALFPI - h)) 
                 /* adjust to value around pi/2 where derived still exists*/
-		        lp.phi = lp.phi < 0. ? (-HALFPI+h) : (HALFPI-h);
+		        lp.phi = lp.phi < 0. ? (-M_HALFPI+h) : (M_HALFPI-h);
 		else if (P->geoc)
 			lp.phi = atan(P->rone_es * tan(lp.phi));
 		lp.lam -= P->lam0;	/* compute del lp.lam */

--- a/src/pj_fwd.c
+++ b/src/pj_fwd.c
@@ -9,7 +9,7 @@ pj_fwd(LP lp, PJ *P) {
 	double t;
 
 	/* check for forward and latitude or longitude overange */
-	if ((t = fabs(lp.phi)-HALFPI) > EPS || fabs(lp.lam) > 10.) {
+	if ((t = fabs(lp.phi)-M_HALFPI) > EPS || fabs(lp.lam) > 10.) {
 		xy.x = xy.y = HUGE_VAL;
 		pj_ctx_set_errno( P->ctx, -14);
 	} else { /* proceed with projection */
@@ -18,7 +18,7 @@ pj_fwd(LP lp, PJ *P) {
                 errno = 0;
 
 		if (fabs(t) <= EPS)
-			lp.phi = lp.phi < 0. ? -HALFPI : HALFPI;
+			lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
 		else if (P->geoc)
 			lp.phi = atan(P->rone_es * tan(lp.phi));
 		lp.lam -= P->lam0;	/* compute del lp.lam */

--- a/src/pj_fwd3d.c
+++ b/src/pj_fwd3d.c
@@ -9,7 +9,7 @@ pj_fwd3d(LPZ lpz, PJ *P) {
 	double t;
 
 	/* check for forward and latitude or longitude overange */
-	if ((t = fabs(lpz.phi)-HALFPI) > EPS || fabs(lpz.lam) > 10.) {
+	if ((t = fabs(lpz.phi)-M_HALFPI) > EPS || fabs(lpz.lam) > 10.) {
 		xyz.x = xyz.y = xyz.z = HUGE_VAL;
 		pj_ctx_set_errno( P->ctx, -14);
 	} else { /* proceed with projection */
@@ -18,7 +18,7 @@ pj_fwd3d(LPZ lpz, PJ *P) {
                 errno = 0;
 
 		if (fabs(t) <= EPS)
-			lpz.phi = lpz.phi < 0. ? -HALFPI : HALFPI;
+			lpz.phi = lpz.phi < 0. ? -M_HALFPI : M_HALFPI;
 		else if (P->geoc)   /* Maybe redundant and never used. */
 			lpz.phi = atan(P->rone_es * tan(lpz.phi));
 		lpz.lam -= P->lam0;	/* compute del lp.lam */

--- a/src/pj_gauss.c
+++ b/src/pj_gauss.c
@@ -56,8 +56,8 @@ pj_gauss_ini(double e, double phi0, double *chi, double *rc) {
 	EN->C = sqrt(1. + es * cphi * cphi / (1. - es));
 	*chi = asin(sphi / EN->C);
 	EN->ratexp = 0.5 * EN->C * e;
-	EN->K = tan(.5 * *chi + FORTPI) / (
-		pow(tan(.5 * phi0 + FORTPI), EN->C) *
+	EN->K = tan(.5 * *chi + M_FORTPI) / (
+		pow(tan(.5 * phi0 + M_FORTPI), EN->C) *
 		srat(EN->e * sphi, EN->ratexp)  );
 	return ((void *)en);
 }
@@ -67,8 +67,8 @@ pj_gauss(projCtx ctx, LP elp, const void *en) {
 	(void) ctx;
 
 	slp.phi = 2. * atan( EN->K *
-		pow(tan(.5 * elp.phi + FORTPI), EN->C) *
-		srat(EN->e * sin(elp.phi), EN->ratexp) ) - HALFPI;
+		pow(tan(.5 * elp.phi + M_FORTPI), EN->C) *
+		srat(EN->e * sin(elp.phi), EN->ratexp) ) - M_HALFPI;
 	slp.lam = EN->C * (elp.lam);
 	return(slp);
 }
@@ -79,10 +79,10 @@ pj_inv_gauss(projCtx ctx, LP slp, const void *en) {
 	int i;
 
 	elp.lam = slp.lam / EN->C;
-	num = pow(tan(.5 * slp.phi + FORTPI)/EN->K, 1./EN->C);
+	num = pow(tan(.5 * slp.phi + M_FORTPI)/EN->K, 1./EN->C);
 	for (i = MAX_ITER; i; --i) {
 		elp.phi = 2. * atan(num * srat(EN->e * sin(slp.phi), -.5 * EN->e))
-			- HALFPI;
+			- M_HALFPI;
 		if (fabs(elp.phi - slp.phi) < DEL_TOL) break;
 			slp.phi = elp.phi;
 	}	

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -244,8 +244,8 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
                 cvs = ct_tmp.cvs + (row) * gi->ct->lim.lam
                     + (gi->ct->lim.lam - i - 1);
 
-                cvs->phi = *(diff_seconds++) * ((PI/180.0) / 3600.0);
-                cvs->lam = *(diff_seconds++) * ((PI/180.0) / 3600.0);
+                cvs->phi = *(diff_seconds++) * ((M_PI/180.0) / 3600.0);
+                cvs->lam = *(diff_seconds++) * ((M_PI/180.0) / 3600.0);
             }
         }
 
@@ -324,8 +324,8 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
                 cvs = ct_tmp.cvs + (row) * gi->ct->lim.lam
                     + (gi->ct->lim.lam - i - 1);
 
-                cvs->phi = *(diff_seconds++) * ((PI/180.0) / 3600.0);
-                cvs->lam = *(diff_seconds++) * ((PI/180.0) / 3600.0);
+                cvs->phi = *(diff_seconds++) * ((M_PI/180.0) / 3600.0);
+                cvs->lam = *(diff_seconds++) * ((M_PI/180.0) / 3600.0);
                 diff_seconds += 2; /* skip accuracy values */
             }
         }

--- a/src/pj_inv.c
+++ b/src/pj_inv.c
@@ -30,7 +30,7 @@ pj_inv(XY xy, PJ *P) {
 		lp.lam += P->lam0; /* reduce from del lp.lam */
 		if (!P->over)
 			lp.lam = adjlon(lp.lam); /* adjust longitude to CM */
-		if (P->geoc && fabs(fabs(lp.phi)-HALFPI) > EPS)
+		if (P->geoc && fabs(fabs(lp.phi)-M_HALFPI) > EPS)
 			lp.phi = atan(P->one_es * tan(lp.phi));
 	    }
         }

--- a/src/pj_inv3d.c
+++ b/src/pj_inv3d.c
@@ -33,7 +33,7 @@ pj_inv3d(XYZ xyz, PJ *P) {
 			lpz.lam = adjlon(lpz.lam); /* adjust longitude to CM */
 
                 /* This may be redundant and never used */
-		if (P->geoc && fabs(fabs(lpz.phi)-HALFPI) > EPS)
+		if (P->geoc && fabs(fabs(lpz.phi)-M_HALFPI) > EPS)
 			lpz.phi = atan(P->one_es * tan(lpz.phi));
 	    }
         }

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,7 +1,6 @@
 /* determine latitude angle phi-2 */
 #include <projects.h>
 
-#define HALFPI		1.5707963267948966
 #define TOL 1.0e-10
 #define N_ITER 15
 
@@ -11,11 +10,11 @@ pj_phi2(projCtx ctx, double ts, double e) {
 	int i;
 
 	eccnth = .5 * e;
-	Phi = HALFPI - 2. * atan (ts);
+	Phi = M_HALFPI - 2. * atan (ts);
 	i = N_ITER;
 	do {
 		con = e * sin (Phi);
-		dphi = HALFPI - 2. * atan (ts * pow((1. - con) /
+		dphi = M_HALFPI - 2. * atan (ts * pow((1. - con) /
 		   (1. + con), eccnth)) - Phi;
 		Phi += dphi;
 	} while ( fabs(dphi) > TOL && --i);

--- a/src/pj_transform.c
+++ b/src/pj_transform.c
@@ -425,10 +425,10 @@ int pj_transform( PJ *srcdefn, PJ *dstdefn, long point_count, int point_offset,
             if( x[point_offset*i] == HUGE_VAL )
                 continue;
 
-            while( x[point_offset*i] < dstdefn->long_wrap_center - PI )
-                x[point_offset*i] += TWOPI;
-            while( x[point_offset*i] > dstdefn->long_wrap_center + PI )
-                x[point_offset*i] -= TWOPI;
+            while( x[point_offset*i] < dstdefn->long_wrap_center - M_PI )
+                x[point_offset*i] += M_TWOPI;
+            while( x[point_offset*i] > dstdefn->long_wrap_center + M_PI )
+                x[point_offset*i] -= M_TWOPI;
         }
     }
 

--- a/src/pj_tsfn.c
+++ b/src/pj_tsfn.c
@@ -1,10 +1,10 @@
 /* determine small t */
 #include <math.h>
 #include <projects.h>
-#define HALFPI		1.5707963267948966
+
 	double
 pj_tsfn(double phi, double sinphi, double e) {
 	sinphi *= e;
-	return (tan (.5 * (HALFPI - phi)) /
+	return (tan (.5 * (M_HALFPI - phi)) /
 	   pow((1. - sinphi) / (1. + sinphi), .5 * e));
 }

--- a/src/proj_etmerc.c
+++ b/src/proj_etmerc.c
@@ -421,11 +421,11 @@ PJ *PROJECTION(utm) {
 		else
 			E_ERROR(-35)
 	else /* nearest central meridian input */
-		if ((zone = (int)(floor ((adjlon (P->lam0) + PI) * 30. / PI))) < 0)
+		if ((zone = (int)(floor ((adjlon (P->lam0) + M_PI) * 30. / M_PI))) < 0)
 			zone = 0;
 		else if (zone >= 60)
 			zone = 59;
-	P->lam0 = (zone + .5) * PI / 30. - PI;
+	P->lam0 = (zone + .5) * M_PI / 30. - M_PI;
 	P->k0 = 0.9996;
 	P->phi0 = 0.;
 

--- a/src/projects.h
+++ b/src/projects.h
@@ -101,7 +101,7 @@ extern double hypot(double, double);
 #define M_FORTPI         M_PI_4                   /* pi/4 */
 #define M_HALFPI         M_PI_2                   /* pi/2 */
 /* M_PI                                               pi */
-#define M_PI_HALFPI      4.71238898038468985766   /* 1.5*pi */
+#define M_PI_HALFPI      4.71238898038468985769   /* 1.5*pi */
 #define M_TWOPI      	 6.28318530717958647693   /* 2*pi */
 #define M_TWO_D_PI       M_2_PI                   /* 2/pi */
 #define M_TWOPI_HALFPI   7.85398163397448309616   /* 2.5*pi */

--- a/src/projects.h
+++ b/src/projects.h
@@ -92,11 +92,21 @@ extern double hypot(double, double);
 #  define hypot _hypot
 #endif
 
-	/* some useful constants */
-#define HALFPI		1.5707963267948966
-#define FORTPI		0.78539816339744833
-#define PI		3.14159265358979323846
-#define TWOPI		6.2831853071795864769
+/* enable predefined math constants M_* for MS Visual Studio workaround */
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+
+/* some more useful math constants and aliases */
+#define M_FORTPI         M_PI_4                   /* pi/4 */
+#define M_HALFPI         M_PI_2                   /* pi/2 */
+/* M_PI                                               pi */
+#define M_PI_HALFPI      4.71238898038468985766   /* 1.5*pi */
+#define M_TWOPI      	 6.28318530717958647693   /* 2*pi */
+#define M_TWO_D_PI       M_2_PI                   /* 2/pi */
+#define M_TWOPI_HALFPI   7.85398163397448309616   /* 2.5*pi */
+/* M_SQRT2                                           sqrt(2) */
+
 
 /* maximum tag id length for +init and default files */
 #ifndef ID_TAG_MAX

--- a/src/rtodms.c
+++ b/src/rtodms.c
@@ -25,7 +25,7 @@ set_rtodms(int fract, int con_w) {
 		for (i = 0; i < fract; ++i)
 			RES *= 10.;
 		RES60 = RES * 60.;
-		CONV = 180. * 3600. * RES / PI;
+		CONV = 180. * 3600. * RES / M_PI;
 		if (! con_w)
 			(void)sprintf(format,"%%dd%%d'%%.%df\"%%c", fract);
 		else


### PR DESCRIPTION
… de facto standard M_PI and its ilk.  

Change names that are widely used in the project to be in the M_ namespace, so HALFPI becomes M_HALFPI. HALFPI is #defined as M_PI_2 (the de facto standard name).  
# defines _USE_MATH_DEFINES for MS Visual Studio (I didn't personally test this part, but Appveyor will not build otherwise).

The response to PR #372 was no strong opinions with perhaps indifference.

Note: this would open the door to allowing the use of M_PI_2 and the other de facto standard math constants defined by the compiler.
