### PR TITLE
SELFTEST: Make proj -VC selftest return exit code of number of test failures.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,11 @@ build_script:
 
 test_script:
   - echo test_script
+  - if "%BUILD_TYPE%" == "nmake" cd C:\PROJ\bin
+  - if "%BUILD_TYPE%" == "cmake" cd C:\projects\proj-4\bin
+  - echo "Contents of current directory:"
+  - dir
+  - proj.exe -VC
 
 deploy: off
 

--- a/src/proj.c
+++ b/src/proj.c
@@ -268,8 +268,7 @@ int main(int argc, char **argv) {
                 bin_in = bin_out = 1;
                 continue;
               case 'C': /* Check - run internal regression tests */
-                pj_run_selftests (very_verby);
-                return 0;
+                return pj_run_selftests (very_verby);
                 continue;
               case 'v': /* monitor dump of initialization */
                 mon = 1;


### PR DESCRIPTION
This change would make Travis-CI and Appveyor mark tests as failures if any of the `proj -VC` selftests fail.  On Travis and Appveyor, `proj -VC` completes running it will abort testing.

Currently, proj.c only returns a zero (0) exit code.  (Some really bad problem might cause a non-zero exit code.)

**EDIT:** Late breaking idea.  This should probably be documented in the man page, too.
