### PR TITLE
Changed self-test build behaviour from opt-out to opt-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,9 @@ install:
   - cd ..
 # autoconf build with grids and coverage
   - if [ $TRAVIS_OS_NAME == "osx" ]; then
-      CFLAGS="--coverage" ./configure;
+      CFLAGS="-DPJ_SELFTEST --coverage" ./configure;
     else
-      CFLAGS="--coverage" LDFLAGS="-lgcov" ./configure;
+      CFLAGS="-DPJ_SELFTEST --coverage" LDFLAGS="-lgcov" ./configure;
     fi
   - make -j3
   - make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,15 @@ include(Proj4Mac)
 include(policies)
 
 #################################################################################
+# Self-test build config
+#################################################################################
+
+option(SELFTEST "Include self-test in build" OFF)
+if(SELFTEST)
+    add_definitions(-DPJ_SELFTEST)
+endif(SELFTEST)
+
+#################################################################################
 # threading configuration
 #################################################################################
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,16 +31,16 @@ build_script:
   - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x86" call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat"
   - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
   - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
-  - if "%BUILD_TYPE%" == "nmake" nmake /f makefile.vc
+  - if "%BUILD_TYPE%" == "nmake" nmake /f makefile.vc SELFTEST=1
   - if "%BUILD_TYPE%" == "nmake" nmake /f makefile.vc install-all
   - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" cd src
-  - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" nmake /f makefile.vc multistresstest.exe
+  - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" nmake /f makefile.vc SELFTEST=1 multistresstest.exe
 # Disabled for now as it scales badly
 #  - if "%BUILD_TYPE%" == "nmake" if "%platform%" == "x64" multistresstest.exe
   - if "%BUILD_TYPE%" == "cmake" if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%BUILD_TYPE%" == "cmake" if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
   - if "%BUILD_TYPE%" == "cmake" echo "%VS_FULL%"
-  - if "%BUILD_TYPE%" == "cmake" cmake -G "%VS_FULL%" . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=../bin -DBUILD_LIBPROJ_SHARED=ON
+  - if "%BUILD_TYPE%" == "cmake" cmake -G "%VS_FULL%" . -DSELFTEST=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=../bin -DBUILD_LIBPROJ_SHARED=ON
   - if "%BUILD_TYPE%" == "cmake" cmake --build . --config Release
 
 test_script:

--- a/nmake.opt
+++ b/nmake.opt
@@ -22,10 +22,14 @@ PROJ_LIB_DIR=$(INSTDIR)\SHARE
 # Uncomment the first for an optimized build, or the second for debug.
 !IFNDEF OPTFLAGS
 !IFNDEF DEBUG
-OPTFLAGS=	/nologo /Ox /Op /MD
+OPTFLAGS=	/Ox /Op /MD
 !ELSE
-OPTFLAGS=	/nologo /Zi /MD /Fdproj.pdb
+OPTFLAGS=	/Zi /MD /Fdproj.pdb
 !ENDIF
+!ENDIF
+
+!IFDEF SELFTEST
+OPTFLAGS= $(OPTFLAGS) -DPJ_SELFTEST
 !ENDIF
 
 # Uncomment the first for linking exes against DLL or second for static

--- a/src/PJ_aea.c
+++ b/src/PJ_aea.c
@@ -211,7 +211,7 @@ PJ *PROJECTION(leac) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_aea_selftest (void) {return 10000;}
 #else
 
@@ -271,7 +271,7 @@ int pj_aea_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_leac_selftest (void) {return 10000;}
 #else
 

--- a/src/PJ_aeqd.c
+++ b/src/PJ_aeqd.c
@@ -310,7 +310,7 @@ PJ *PROJECTION(aeqd) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_aeqd_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_airy.c
+++ b/src/PJ_airy.c
@@ -156,7 +156,7 @@ PJ *PROJECTION(airy) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_airy_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -200,7 +200,7 @@ PJ *PROJECTION(wintri) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_aitoff_selftest (void) {return 0;}
 #else
 
@@ -248,7 +248,7 @@ int pj_aitoff_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wintri_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_august.c
+++ b/src/PJ_august.c
@@ -40,7 +40,7 @@ PJ *PROJECTION(august) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_august_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_bacon.c
+++ b/src/PJ_bacon.c
@@ -91,7 +91,7 @@ PJ *PROJECTION(ortel) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_bacon_selftest (void) {return 0;}
 #else
 int pj_bacon_selftest (void) {
@@ -121,7 +121,7 @@ int pj_bacon_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_apian_selftest (void) {return 0;}
 #else
 int pj_apian_selftest (void) {
@@ -151,7 +151,7 @@ int pj_apian_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_ortel_selftest (void) {return 0;}
 #else
 int pj_ortel_selftest (void) {

--- a/src/PJ_bipc.c
+++ b/src/PJ_bipc.c
@@ -164,7 +164,7 @@ PJ *PROJECTION(bipc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_bipc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_boggs.c
+++ b/src/PJ_boggs.c
@@ -49,7 +49,7 @@ PJ *PROJECTION(boggs) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_boggs_selftest (void) {return 0;}
 #else
 int pj_boggs_selftest (void) {

--- a/src/PJ_bonne.c
+++ b/src/PJ_bonne.c
@@ -121,7 +121,7 @@ PJ *PROJECTION(bonne) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_bonne_selftest (void) {return 0;}
 #else
 int pj_bonne_selftest (void) {

--- a/src/PJ_calcofi.c
+++ b/src/PJ_calcofi.c
@@ -166,7 +166,7 @@ PJ *PROJECTION(calcofi) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_calcofi_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_cass.c
+++ b/src/PJ_cass.c
@@ -120,7 +120,7 @@ PJ *PROJECTION(cass) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_cass_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_cc.c
+++ b/src/PJ_cc.c
@@ -44,7 +44,7 @@ PJ *PROJECTION(cc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_cc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_cea.c
+++ b/src/PJ_cea.c
@@ -96,7 +96,7 @@ PJ *PROJECTION(cea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_cea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_chamb.c
+++ b/src/PJ_chamb.c
@@ -148,7 +148,7 @@ PJ *PROJECTION(chamb) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_chamb_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_collg.c
+++ b/src/PJ_collg.c
@@ -53,7 +53,7 @@ PJ *PROJECTION(collg) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_collg_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_comill.c
+++ b/src/PJ_comill.c
@@ -86,7 +86,7 @@ PJ *PROJECTION(comill) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_comill_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_crast.c
+++ b/src/PJ_crast.c
@@ -48,7 +48,7 @@ PJ *PROJECTION(crast) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_crast_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_denoy.c
+++ b/src/PJ_denoy.c
@@ -39,7 +39,7 @@ PJ *PROJECTION(denoy) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_denoy_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eck1.c
+++ b/src/PJ_eck1.c
@@ -48,7 +48,7 @@ PJ *PROJECTION(eck1) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck1_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eck2.c
+++ b/src/PJ_eck2.c
@@ -59,7 +59,7 @@ PJ *PROJECTION(eck2) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck2_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eck3.c
+++ b/src/PJ_eck3.c
@@ -117,7 +117,7 @@ PJ *PROJECTION(putp1) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck3_selftest (void) {return 0;}
 #else
 
@@ -161,7 +161,7 @@ int pj_eck3_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_kav7_selftest (void) {return 0;}
 #else
 
@@ -205,7 +205,7 @@ int pj_kav7_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag6_selftest (void) {return 0;}
 #else
 
@@ -250,7 +250,7 @@ int pj_wag6_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp1_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eck4.c
+++ b/src/PJ_eck4.c
@@ -72,7 +72,7 @@ PJ *PROJECTION(eck4) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck4_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eck5.c
+++ b/src/PJ_eck5.c
@@ -48,7 +48,7 @@ PJ *PROJECTION(eck5) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck5_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eqc.c
+++ b/src/PJ_eqc.c
@@ -63,7 +63,7 @@ PJ *PROJECTION(eqc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eqc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_eqdc.c
+++ b/src/PJ_eqdc.c
@@ -130,7 +130,7 @@ PJ *PROJECTION(eqdc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eqdc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_fahey.c
+++ b/src/PJ_fahey.c
@@ -50,7 +50,7 @@ PJ *PROJECTION(fahey) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_fahey_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_fouc_s.c
+++ b/src/PJ_fouc_s.c
@@ -81,7 +81,7 @@ PJ *PROJECTION(fouc_s) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_fouc_s_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_gall.c
+++ b/src/PJ_gall.c
@@ -55,7 +55,7 @@ PJ *PROJECTION(gall) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gall_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_geos.c
+++ b/src/PJ_geos.c
@@ -239,7 +239,7 @@ PJ *PROJECTION(geos) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_geos_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_gins8.c
+++ b/src/PJ_gins8.c
@@ -44,7 +44,7 @@ PJ *PROJECTION(gins8) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gins8_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -180,7 +180,7 @@ PJ *PROJECTION(gn_sinu) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_sinu_selftest (void) {return 0;}
 #else
 
@@ -239,7 +239,7 @@ int pj_sinu_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_eck6_selftest (void) {return 0;}
 #else
 
@@ -283,7 +283,7 @@ int pj_eck6_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mbtfps_selftest (void) {return 0;}
 #else
 
@@ -328,7 +328,7 @@ int pj_mbtfps_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gn_sinu_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_gnom.c
+++ b/src/PJ_gnom.c
@@ -147,7 +147,7 @@ PJ *PROJECTION(gnom) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gnom_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_goode.c
+++ b/src/PJ_goode.c
@@ -85,7 +85,7 @@ PJ *PROJECTION(goode) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_goode_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_gstmerc.c
+++ b/src/PJ_gstmerc.c
@@ -85,7 +85,7 @@ PJ *PROJECTION(gstmerc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gstmerc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_hammer.c
+++ b/src/PJ_hammer.c
@@ -84,7 +84,7 @@ PJ *PROJECTION(hammer) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_hammer_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_hatano.c
+++ b/src/PJ_hatano.c
@@ -89,7 +89,7 @@ PJ *PROJECTION(hatano) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_hatano_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -662,7 +662,7 @@ PJ *PROJECTION(rhealpix) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_healpix_selftest (void) {return 0;}
 #else
 
@@ -721,7 +721,7 @@ int pj_healpix_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_rhealpix_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_igh.c
+++ b/src/PJ_igh.c
@@ -225,7 +225,7 @@ PJ *PROJECTION(igh) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_igh_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_imw_p.c
+++ b/src/PJ_imw_p.c
@@ -193,7 +193,7 @@ PJ *PROJECTION(imw_p) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_imw_p_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -1145,7 +1145,7 @@ PJ *PROJECTION(isea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_isea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_krovak.c
+++ b/src/PJ_krovak.c
@@ -231,7 +231,7 @@ PJ *PROJECTION(krovak) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_krovak_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_labrd.c
+++ b/src/PJ_labrd.c
@@ -141,7 +141,7 @@ PJ *PROJECTION(labrd) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_labrd_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_laea.c
+++ b/src/PJ_laea.c
@@ -278,7 +278,7 @@ PJ *PROJECTION(laea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_laea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_lagrng.c
+++ b/src/PJ_lagrng.c
@@ -72,7 +72,7 @@ PJ *PROJECTION(lagrng) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lagrng_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_larr.c
+++ b/src/PJ_larr.c
@@ -39,7 +39,7 @@ PJ *PROJECTION(larr) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_larr_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_lask.c
+++ b/src/PJ_lask.c
@@ -50,7 +50,7 @@ PJ *PROJECTION(lask) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lask_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -151,7 +151,7 @@ PJ *PROJECTION(lcc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lcc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_lcca.c
+++ b/src/PJ_lcca.c
@@ -111,7 +111,7 @@ PJ *PROJECTION(lcca) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lcca_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_loxim.c
+++ b/src/PJ_loxim.c
@@ -85,7 +85,7 @@ PJ *PROJECTION(loxim) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_loxim_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_lsat.c
+++ b/src/PJ_lsat.c
@@ -211,7 +211,7 @@ PJ *PROJECTION(lsat) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lsat_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_mbt_fps.c
+++ b/src/PJ_mbt_fps.c
@@ -67,7 +67,7 @@ PJ *PROJECTION(mbt_fps) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mbt_fps_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_mbtfpp.c
+++ b/src/PJ_mbtfpp.c
@@ -69,7 +69,7 @@ PJ *PROJECTION(mbtfpp) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mbtfpp_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_mbtfpq.c
+++ b/src/PJ_mbtfpq.c
@@ -76,7 +76,7 @@ PJ *PROJECTION(mbtfpq) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mbtfpq_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -74,7 +74,7 @@ PJ *PROJECTION(merc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_merc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_mill.c
+++ b/src/PJ_mill.c
@@ -47,7 +47,7 @@ PJ *PROJECTION(mill) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mill_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -221,7 +221,7 @@ PJ *PROJECTION(misrsom) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_misrsom_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_mod_ster.c
+++ b/src/PJ_mod_ster.c
@@ -287,7 +287,7 @@ PJ *PROJECTION(gs50) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mil_os_selftest (void) {return 0;}
 #else
 
@@ -331,7 +331,7 @@ int pj_mil_os_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_lee_os_selftest (void) {return 0;}
 #else
 
@@ -375,7 +375,7 @@ int pj_lee_os_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gs48_selftest (void) {return 0;}
 #else
 
@@ -420,7 +420,7 @@ int pj_gs48_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_alsk_selftest (void) {return 0;}
 #else
 
@@ -481,7 +481,7 @@ int pj_alsk_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_gs50_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_moll.c
+++ b/src/PJ_moll.c
@@ -123,7 +123,7 @@ PJ *PROJECTION(wag5) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_moll_selftest (void) {return 0;}
 #else
 
@@ -167,7 +167,7 @@ int pj_moll_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag4_selftest (void) {return 0;}
 #else
 
@@ -210,7 +210,7 @@ int pj_wag4_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag5_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_natearth.c
+++ b/src/PJ_natearth.c
@@ -105,7 +105,7 @@ PJ *PROJECTION(natearth) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_natearth_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_natearth2.c
+++ b/src/PJ_natearth2.c
@@ -102,7 +102,7 @@ PJ *PROJECTION(natearth2) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_natearth2_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_nell.c
+++ b/src/PJ_nell.c
@@ -61,7 +61,7 @@ PJ *PROJECTION(nell) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_nell_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_nell_h.c
+++ b/src/PJ_nell_h.c
@@ -64,7 +64,7 @@ PJ *PROJECTION(nell_h) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_nell_h_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_nocol.c
+++ b/src/PJ_nocol.c
@@ -65,7 +65,7 @@ PJ *PROJECTION(nicol) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_nicol_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_nsper.c
+++ b/src/PJ_nsper.c
@@ -197,7 +197,7 @@ PJ *PROJECTION(tpers) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_nsper_selftest (void) {return 0;}
 #else
 
@@ -242,7 +242,7 @@ int pj_nsper_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tpers_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_nzmg.c
+++ b/src/PJ_nzmg.c
@@ -132,7 +132,7 @@ PJ *PROJECTION(nzmg) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_nzmg_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -181,7 +181,7 @@ PJ *PROJECTION(ob_tran) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_ob_tran_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_ocea.c
+++ b/src/PJ_ocea.c
@@ -108,7 +108,7 @@ PJ *PROJECTION(ocea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_ocea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_oea.c
+++ b/src/PJ_oea.c
@@ -95,7 +95,7 @@ PJ *PROJECTION(oea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_oea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_omerc.c
+++ b/src/PJ_omerc.c
@@ -237,7 +237,7 @@ PJ *PROJECTION(omerc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_omerc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_ortho.c
+++ b/src/PJ_ortho.c
@@ -129,7 +129,7 @@ PJ *PROJECTION(ortho) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_ortho_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_patterson.c
+++ b/src/PJ_patterson.c
@@ -122,7 +122,7 @@ PJ *PROJECTION(patterson) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_patterson_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_poly.c
+++ b/src/PJ_poly.c
@@ -157,7 +157,7 @@ PJ *PROJECTION(poly) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_poly_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_putp2.c
+++ b/src/PJ_putp2.c
@@ -70,7 +70,7 @@ PJ *PROJECTION(putp2) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp2_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_putp3.c
+++ b/src/PJ_putp3.c
@@ -80,7 +80,7 @@ PJ *PROJECTION(putp3p) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp3_selftest (void) {return 0;}
 #else
 
@@ -125,7 +125,7 @@ int pj_putp3_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp3p_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_putp4p.c
+++ b/src/PJ_putp4p.c
@@ -87,7 +87,7 @@ PJ *PROJECTION(weren) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp4p_selftest (void) {return 0;}
 #else
 
@@ -132,7 +132,7 @@ int pj_putp4p_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_weren_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_putp5.c
+++ b/src/PJ_putp5.c
@@ -84,7 +84,7 @@ PJ *PROJECTION(putp5p) {
     return P;
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp5_selftest (void) {return 0;}
 #else
 
@@ -128,7 +128,7 @@ int pj_putp5_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp5p_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_putp6.c
+++ b/src/PJ_putp6.c
@@ -108,7 +108,7 @@ PJ *PROJECTION(putp6p) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp6_selftest (void) {return 0;}
 #else
 
@@ -152,7 +152,7 @@ int pj_putp6_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_putp6p_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_qsc.c
+++ b/src/PJ_qsc.c
@@ -411,7 +411,7 @@ PJ *PROJECTION(qsc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_qsc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_robin.c
+++ b/src/PJ_robin.c
@@ -151,7 +151,7 @@ PJ *PROJECTION(robin) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_robin_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_rpoly.c
+++ b/src/PJ_rpoly.c
@@ -68,7 +68,7 @@ PJ *PROJECTION(rpoly) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_rpoly_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_sconics.c
+++ b/src/PJ_sconics.c
@@ -223,7 +223,7 @@ PJ *PROJECTION(vitk1) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_euler_selftest (void) {return 0;}
 #else
 
@@ -287,7 +287,7 @@ int pj_euler_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_murd1_selftest (void) {return 0;}
 #else
 
@@ -359,7 +359,7 @@ int pj_murd1_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_murd2_selftest (void) {return 0;}
 #else
 
@@ -427,7 +427,7 @@ int pj_murd2_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_murd3_selftest (void) {return 0;}
 #else
 
@@ -496,7 +496,7 @@ int pj_murd3_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_pconic_selftest (void) {return 0;}
 #else
 
@@ -569,7 +569,7 @@ int pj_pconic_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tissot_selftest (void) {return 0;}
 #else
 
@@ -635,7 +635,7 @@ int pj_tissot_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_vitk1_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_somerc.c
+++ b/src/PJ_somerc.c
@@ -105,7 +105,7 @@ PJ *PROJECTION(somerc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_somerc_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_stere.c
+++ b/src/PJ_stere.c
@@ -301,7 +301,7 @@ PJ *PROJECTION(ups) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_stere_selftest (void) {return 0;}
 #else
 
@@ -364,7 +364,7 @@ int pj_stere_selftest (void) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_ups_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_sterea.c
+++ b/src/PJ_sterea.c
@@ -118,7 +118,7 @@ PJ *PROJECTION(sterea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_sterea_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_sts.c
+++ b/src/PJ_sts.c
@@ -87,7 +87,7 @@ PJ *PROJECTION(fouc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_fouc_selftest (void) {return 0;}
 #else
 int pj_fouc_selftest (void) {
@@ -158,7 +158,7 @@ PJ *PROJECTION(kav5) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_kav5_selftest (void) {return 0;}
 #else
 int pj_kav5_selftest (void) {
@@ -226,7 +226,7 @@ PJ *PROJECTION(qua_aut) {
     return setup(P, 2., 2., 0);
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_qua_aut_selftest (void) {return 0;}
 #else
 int pj_qua_aut_selftest (void) {
@@ -294,7 +294,7 @@ PJ *PROJECTION(mbt_s) {
     return setup(P, 1.48875, 1.36509, 0);
 }
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_mbt_s_selftest (void) {return 0;}
 #else
 int pj_mbt_s_selftest (void) {

--- a/src/PJ_tcc.c
+++ b/src/PJ_tcc.c
@@ -37,7 +37,7 @@ PJ *PROJECTION(tcc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tcc_selftest (void) {return 0;}
 #else
 int pj_tcc_selftest (void) {

--- a/src/PJ_tcea.c
+++ b/src/PJ_tcea.c
@@ -43,7 +43,7 @@ PJ *PROJECTION(tcea) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tcea_selftest (void) {return 0;}
 #else
 int pj_tcea_selftest (void) {

--- a/src/PJ_times.c
+++ b/src/PJ_times.c
@@ -90,7 +90,7 @@ PJ *PROJECTION(times) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_times_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_tmerc.c
+++ b/src/PJ_tmerc.c
@@ -195,7 +195,7 @@ PJ *PROJECTION(tmerc) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tmerc_selftest (void) {return 0;}
 #else
 int pj_tmerc_selftest (void) {

--- a/src/PJ_tpeqd.c
+++ b/src/PJ_tpeqd.c
@@ -117,7 +117,7 @@ PJ *PROJECTION(tpeqd) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_tpeqd_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_urm5.c
+++ b/src/PJ_urm5.c
@@ -53,7 +53,7 @@ PJ *PROJECTION(urm5) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_urm5_selftest (void) {return 0;}
 #else
 int pj_urm5_selftest (void) {

--- a/src/PJ_urmfps.c
+++ b/src/PJ_urmfps.c
@@ -81,7 +81,7 @@ PJ *PROJECTION(wag1) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_urmfps_selftest (void) {return 0;}
 #else
 int pj_urmfps_selftest (void) {
@@ -123,7 +123,7 @@ int pj_urmfps_selftest (void) {
 #endif
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag1_selftest (void) {return 0;}
 #else
 int pj_wag1_selftest (void) {

--- a/src/PJ_vandg.c
+++ b/src/PJ_vandg.c
@@ -111,7 +111,7 @@ PJ *PROJECTION(vandg) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_vandg_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_vandg2.c
+++ b/src/PJ_vandg2.c
@@ -87,7 +87,7 @@ PJ *PROJECTION(vandg3) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_vandg2_selftest (void) {return 0;}
 #else
 
@@ -117,7 +117,7 @@ int pj_vandg2_selftest (void) {
 
 #endif
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_vandg3_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_vandg4.c
+++ b/src/PJ_vandg4.c
@@ -66,7 +66,7 @@ PJ *PROJECTION(vandg4) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_vandg4_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_wag2.c
+++ b/src/PJ_wag2.c
@@ -43,7 +43,7 @@ PJ *PROJECTION(wag2) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag2_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_wag3.c
+++ b/src/PJ_wag3.c
@@ -56,7 +56,7 @@ PJ *PROJECTION(wag3) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag3_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_wag7.c
+++ b/src/PJ_wag7.c
@@ -38,7 +38,7 @@ PJ *PROJECTION(wag7) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wag7_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_wink1.c
+++ b/src/PJ_wink1.c
@@ -55,7 +55,7 @@ PJ *PROJECTION(wink1) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wink1_selftest (void) {return 0;}
 #else
 

--- a/src/PJ_wink2.c
+++ b/src/PJ_wink2.c
@@ -63,7 +63,7 @@ PJ *PROJECTION(wink2) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_wink2_selftest (void) {return 0;}
 #else
 

--- a/src/pj_geocent.c
+++ b/src/pj_geocent.c
@@ -72,7 +72,7 @@ PJ *PROJECTION(geocent) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_geocent_selftest (void) {return 0;}
 #else
 

--- a/src/pj_run_selftests.c
+++ b/src/pj_run_selftests.c
@@ -48,7 +48,7 @@ static void run_one_test (const char *mnemonic, int (testfunc)(void), int verbos
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_run_selftests (int verbosity) {
     printf ("This version of libproj is not configured for internal regression tests.\n");
     return 0;

--- a/src/proj_etmerc.c
+++ b/src/proj_etmerc.c
@@ -348,7 +348,7 @@ PJ *PROJECTION(etmerc) {
 
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_etmerc_selftest (void) {return 0;}
 #else
 
@@ -433,7 +433,7 @@ PJ *PROJECTION(utm) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_utm_selftest (void) {return 0;}
 #else
 

--- a/src/proj_rouss.c
+++ b/src/proj_rouss.c
@@ -153,7 +153,7 @@ PJ *PROJECTION(rouss) {
 }
 
 
-#ifdef PJ_OMIT_SELFTEST
+#ifndef PJ_SELFTEST
 int pj_rouss_selftest (void) {return 0;}
 #else
 

--- a/src/projects.h
+++ b/src/projects.h
@@ -36,6 +36,8 @@
 #  ifndef _CRT_NONSTDC_NO_DEPRECATE
 #    define _CRT_NONSTDC_NO_DEPRECATE
 #  endif
+/* enable predefined math constants M_* for MS Visual Studio workaround */
+#  define _USE_MATH_DEFINES
 #endif
 
 /* standard inclusions */
@@ -91,11 +93,6 @@ extern double hypot(double, double);
 #  define getenv wceex_getenv
 #  define strdup _strdup
 #  define hypot _hypot
-#endif
-
-/* enable predefined math constants M_* for MS Visual Studio workaround */
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
 #endif
 
 /* If we still haven't got M_PI*, we rely on our own defines.


### PR DESCRIPTION
This PR changes the self-test build process according to @rouault's suggestion on the [mailing list](http://lists.maptools.org/pipermail/proj/2016-May/007385.html). With these changes you now have to specifically ask for the self-test to be compiled, whereas it was compiled by default before. The idea behind the opt-in for the self-test is to keep the binary size as small as possible in "production" builds.

Since proj can be build in a few different ways here's some examples:

```
# cmake
cmake proj.4/ -DSELFTEST=ON && make

# autotools
CFLAGS="-DPJ_SELFTEST" ./configure && make

# nmake
nmake /f makefile.vc SELFTEST=1
```

I'm in no way an expert in any of the build systems so suggestions for better solutions are welcome.

The build flags should be documented properly at some point. For now they are documented in .travis.yml and appveyor.yml.
