### PR TITLE
EQC projection doc

### DIFF
--- a/docs/source/projections/eqc.rst
+++ b/docs/source/projections/eqc.rst
@@ -8,3 +8,23 @@ Equidistant Cylindrical (Plate Caree)
    :scale: 50%
    :alt:   Equidistant Cylindrical (Plate Caree)  
 
+The simplist of all projections. Standard parallels (0° when omitted) may be specified that determine latitude of true scale (k=h=1).
+
+.. math::
+
+   x = \lambda cos \phi_{ts}
+
+.. math::
+
+   y = \phi
+
+Reverse operation :
+
+.. math::
+
+   \lambda = x / cos \phi_{ts}
+
+.. math::
+
+   \phi = y
+

--- a/docs/source/projections/eqc.rst
+++ b/docs/source/projections/eqc.rst
@@ -12,11 +12,11 @@ The simplist of all projections. Standard parallels (0° when omitted) may be sp
 
 .. math::
 
-   x = \lambda cos \phi_{ts}
+   x = \lambda \cos \phi_{ts}
 
 .. math::
 
-   y = \phi
+   y = \phi - \phi_0
 
 Reverse operation :
 
@@ -26,5 +26,5 @@ Reverse operation :
 
 .. math::
 
-   \phi = y
+   \phi = y + \phi_0
 

--- a/docs/source/projections/merc.rst
+++ b/docs/source/projections/merc.rst
@@ -8,3 +8,87 @@ Mercator
    :scale: 50%
    :alt:   Mercator  
 
+Scaling may be specified by either the latitude of true scale (:math:`\phi_{ts}`) or setting :math:`k_0` with :math:`+k=` or :math:`+k_0=`.
+
+The spherical form :
+
+.. math::
+
+   x = k_0 \lambda
+
+.. math::
+
+   y = k_0 * \ln( \tan(\pi/4 + \phi/2))
+
+.. math::
+
+   k_0 = \cos(\phi_{ts})
+
+The spherical form's reverse operation :
+
+.. math::
+
+   \lambda = x/k_0
+
+.. math::
+
+   \phi = \pi/2 - 2 \arctan(e^{-y/k_0})
+
+.. math::
+
+   k_0 = \cos(\phi_{ts})
+
+
+The elliptical form :
+
+.. math::
+
+   x = k_0 \lambda
+
+.. math::
+
+   y = k_0 \ln(t(\phi))
+
+.. math::
+
+   k_0 = m(\phi_{ts})
+
+The elliptical form's reverse operation :
+
+.. math::
+
+  \lambda = x / k_0
+
+.. math::
+
+  \phi = t^{-1} (e^{-y/k_0})
+
+where :math:`t()` is the isometric latitude kernel function :
+
+.. math::
+
+   t = \tan(\pi/4 + \phi/2) ( \frac{1 - e \sin \phi}{1 + e \sin \phi})^{e/2}
+
+and the inverse of isometric latitude need to be iteratively solve for \phi_+ until a sufficiently small difference between evaluations occurs :
+
+.. math::
+
+   \phi_+ = \pi/2 - 2 \arctan(t(\frac{1 - e \sin \phi}{1+e \sin \phi})^{e/2})
+
+.. math::
+
+   t = e^{-\tau}
+
+with an initial value of :
+
+.. math::
+
+   \phi = \pi / 2 - 2 \arctan(t)
+
+and :math:`m(\phi)` is the parallel radius at latitude :math:`\phi` :
+
+.. math::
+
+   m = N \cos \phi = \frac{a cos \phi}{\sqrt{1-e^2\sin^2 \phi}}
+
+where N is the radius of curvature of the ellipse perpendicular to the plane of the meridian. A unit major axis(a) is used.


### PR DESCRIPTION
Here is my second test, I think it will be accepted.
The references I used for are :
https://github.com/OSGeo/proj.4/blob/master/docs/old/libproj.pdf
ftp://ftp.ams.org/pub/tex/doc/amsmath/amsldoc.pdf
make html ;)

Tell me if it's ok, then I will make more.

I have a first question : in proj4 source code, there an optionnal \phi_0 that do not appear in the old documentation formula, but only in the parameters.
May I fix it in the new docs ?

It leads me to a second question about the png generated in that page.
There is "+eqc", but it does not show the parameters [+lat 0= | +lat ts=] as in the old documentation.
How can I improve it ?
