### PR TITLE
Use more consistent description for sch projection.

### DIFF
--- a/src/PJ_sch.c
+++ b/src/PJ_sch.c
@@ -48,7 +48,7 @@ struct pj_opaque {
     GeocentricInfo elp_0;
 };
 
-PROJ_HEAD(sch, "Spherical Cross-track Height") "\n\tMisc\n\tplat_0 = ,plon_0 = , phdg_0 = ,[h_0 = ]";
+PROJ_HEAD(sch, "Spherical Cross-track Height") "\n\tMisc\n\tplat_0= plon_0= phdg_0= [h_0=]";
 
 static LPZ inverse3d(XYZ xyz, PJ *P) {
     LPZ lpz = {0.0, 0.0, 0.0};


### PR DESCRIPTION
The `sch` projection uses a different format for its parameters description which caused an issue with the [PDL::Transform::Proj4](http://pdl.perl.org/?docs=Transform/Proj4&title=PDL::Transform::Proj4) documentation generator as reported in [PDL Bug #429](https://sourceforge.net/p/pdl/bugs/429/).

Most other projections don't use spaces around the equals sign and separate parameters with spaces instead of commas, the format used in `PJ_sch.c` is not supported by the parser in PDL. I've worked around the issue in the PDL documentation generator to skip empty parameters, but I think the format of the description in Proj4 should also be made consistent with the changes in this PR.
