### PR TITLE
Fixes #138 (spherical tmerc with negative northing gives inverted latitude)

### DIFF
--- a/src/PJ_tmerc.c
+++ b/src/PJ_tmerc.c
@@ -1,12 +1,12 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include <projects.h>
 
 PROJ_HEAD(tmerc, "Transverse Mercator") "\n\tCyl, Sph&Ell";
 
 
 struct pj_opaque {
-    double  esp; \
-    double  ml0; \
+    double  esp;
+    double  ml0;
     double  *en;
 };
 
@@ -146,7 +146,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     g = .5 * (h - 1. / h);
     h = cos (P->phi0 + xy.y / P->opaque->esp);
     lp.phi = asin(sqrt((1. - h * h) / (1. + g * g)));
-    if (xy.y < 0.) lp.phi = -lp.phi;
+
+    /* Make sure that phi is on the correct hemisphere when false northing is used */
+    if (xy.y < 0. && -lp.phi+P->phi0 < 0.0) lp.phi = -lp.phi;
+
     lp.lam = (g || h) ? atan2 (g, h) : 0.;
     return lp;
 }


### PR DESCRIPTION
This should fix #138 - hopefully tests agree!

The reporter supplied a test similar to this:

```
echo 0 -0.01 spherical  | ./proj -I -f %f +proj=tmerc +lat_0=32 +lon_0=-117 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs
echo 0 -0.01 ellipsoidal| ./proj -I -f %f +proj=tmerc +lat_0=32 +lon_0=-117 +y_0=0 +a=6378137 +b=6378136 +units=m +no_defs
```

Which before the fix gave the results (note the latitude is wrong in the spherical projection):

```
-117.000000 -32.000000 spherical
-117.000000 32.000000 ellipsoidal
```

After fix:

```
-117.000000 32.000000 spherical
-117.000000 32.000000 ellipsoidal
```
