### PR TITLE
Export CMake targets to PROJ4:: namespace

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -23,7 +23,12 @@ install (FILES
   DESTINATION "${INSTALL_CMAKE_DIR}"
   RENAME "${PROJECT_NAME_LOWER}-config-version.cmake")
 # Make information about the cmake targets (the library and the tools)
-# available.
+# available. Targets without namespace are provided for compatibility
+# with other and older projects but will be removed in a future release.
 install (EXPORT targets
+  NAMESPACE ${PROJECT_NAME}::
   FILE ${PROJECT_NAME_LOWER}-targets.cmake
+  DESTINATION "${INSTALL_CMAKE_DIR}")
+install (EXPORT targets
+  FILE ${PROJECT_NAME_LOWER}-deprecated-targets.cmake
   DESTINATION "${INSTALL_CMAKE_DIR}")

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -23,6 +23,7 @@ set (@PROJECT_NAME@_BINARY_DIRS "${_ROOT}/@BINDIR@")
 set (@PROJECT_NAME@_LIBRARIES proj)
 # Read in the exported definition of the library
 include ("${_DIR}/@PROJECT_NAME_LOWER@-targets.cmake")
+include ("${_DIR}/@PROJECT_NAME_LOWER@-deprecated-targets.cmake")
 
 unset (_ROOT)
 unset (_DIR)

--- a/docs/source/development/cmake.rst
+++ b/docs/source/development/cmake.rst
@@ -1,0 +1,38 @@
+.. _cmake:
+
+********************************************************************************
+Using Proj.4 in CMake projects
+********************************************************************************
+
+Getting Started
+---------------
+
+The recommended way to use the Proj.4 library in a CMake project is to link to
+the imported library target ``PROJ4::proj`` provided by the CMake configuration
+which comes with the library. Typical usage is:
+
+.. code::
+
+    find_package(PROJ4)
+
+    target_link_libraries(MyApp PROJ4::proj)
+
+
+By adding the imported library target ``PROJ4::proj`` to the target link
+libraries, CMake will also pass all usage requirements (definitions, include
+directories etc.) to the given target.
+
+The CMake command ``find_package`` will look for the configuration in a number
+of places. The lookup can be adjusted for all packages by setting the cache
+variable or environment variable ``CMAKE_PREFIX_PATH``. In particular, CMake
+will consult (and set) the cache variable ``PROJ4_DIR``.
+
+
+Deprecated Targets
+------------------
+
+The CMake configuration will also create an imported library target ``proj``.
+Except for the name, this target is identical with ``PROJ4::proj``. However,
+it should not be used in new projects. It is provided for compatibility with
+older projects and will be removed in a future release.
+

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -14,4 +14,5 @@ proj.4 project or using the library in their own software.
    api
    threads
    bindings
+   cmake
 


### PR DESCRIPTION
It is (poorly) documented CMake convention that imported targets have "::"
in their name, unlike targets from the current build system.
Setting the namespace according to the config module (i.e. project) name.