### PR TITLE
Repairing tests that fails on OS X

### DIFF
--- a/src/PJ_aea.c
+++ b/src/PJ_aea.c
@@ -220,7 +220,7 @@ int pj_aea_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=aea   +ellps=GRS80  +lat_1=0 +lat_2=2"};
-    char s_args[] = {"+proj=aea   +a=6400000    +lat_1=0 +lat_2=2"};
+    char s_args[] = {"+proj=aea   +R=6400000    +lat_1=0 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},
@@ -280,7 +280,7 @@ int pj_leac_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=leac   +ellps=GRS80  +lat_1=0 +lat_2=2"};
-    char s_args[] = {"+proj=leac   +a=6400000    +lat_1=0 +lat_2=2"};
+    char s_args[] = {"+proj=leac   +R=6400000    +lat_1=0 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_aeqd.c
+++ b/src/PJ_aeqd.c
@@ -319,7 +319,7 @@ int pj_aeqd_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=aeqd   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=aeqd   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=aeqd   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -207,7 +207,7 @@ int pj_aitoff_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    char s_args[] = {"+proj=aitoff   +a=6400000    +lat_1=0 +lat_2=2"};
+    char s_args[] = {"+proj=aitoff   +R=6400000    +lat_1=0 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_bonne.c
+++ b/src/PJ_bonne.c
@@ -129,7 +129,7 @@ int pj_bonne_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=bonne   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=bonne   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=bonne   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_cass.c
+++ b/src/PJ_cass.c
@@ -129,7 +129,7 @@ int pj_cass_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=cass   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=cass   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=cass   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_cea.c
+++ b/src/PJ_cea.c
@@ -105,7 +105,7 @@ int pj_cea_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=cea   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=cea   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=cea   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_eqdc.c
+++ b/src/PJ_eqdc.c
@@ -139,7 +139,7 @@ int pj_eqdc_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=eqdc   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=eqdc   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=eqdc   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_geos.c
+++ b/src/PJ_geos.c
@@ -248,7 +248,7 @@ int pj_geos_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=geos   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +h=35785831"};
-    char s_args[] = {"+proj=geos   +a=6400000    +lat_1=0.5 +lat_2=2 +h=35785831"};
+    char s_args[] = {"+proj=geos   +R=6400000    +lat_1=0.5 +lat_2=2 +h=35785831"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -189,7 +189,7 @@ int pj_sinu_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=sinu   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=sinu   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=sinu   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_gstmerc.c
+++ b/src/PJ_gstmerc.c
@@ -93,7 +93,7 @@ int pj_gstmerc_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    char s_args[] = {"+proj=gstmerc   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=gstmerc   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -671,7 +671,7 @@ int pj_healpix_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=healpix   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=healpix   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=healpix   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},
@@ -730,7 +730,7 @@ int pj_rhealpix_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=rhealpix   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=rhealpix   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=rhealpix   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_laea.c
+++ b/src/PJ_laea.c
@@ -287,7 +287,7 @@ int pj_laea_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=laea   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=laea   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=laea   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -83,7 +83,7 @@ int pj_merc_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=merc   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=merc   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=merc   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -230,7 +230,7 @@ int pj_misrsom_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=misrsom   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +path=1"};
-    char s_args[] = {"+proj=misrsom   +a=6400000    +lat_1=0.5 +lat_2=2 +path=1"};
+    char s_args[] = {"+proj=misrsom   +R=6400000    +lat_1=0.5 +lat_2=2 +path=1"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_mod_ster.c
+++ b/src/PJ_mod_ster.c
@@ -299,7 +299,7 @@ int pj_mil_os_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    char s_args[] = {"+proj=mil_os   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=mil_os   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},
@@ -343,7 +343,7 @@ int pj_lee_os_selftest (void) {
     double tolerance_lp = 1e-10;
     double tolerance_xy = 1e-7;
 
-    char s_args[] = {"+proj=lee_os   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=lee_os   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},
@@ -387,7 +387,7 @@ int pj_gs48_selftest (void) {
     double tolerance_lp = 1e-12;
     double tolerance_xy = 1e-8;
 
-    char s_args[] = {"+proj=gs48 +a=6370997"};
+    char s_args[] = {"+proj=gs48 +R=6370997"};
 
     /* All latitudes and longitudes within the continental US */
     LP fwd_in[] = {
@@ -435,7 +435,7 @@ int pj_alsk_selftest (void) {
     double tolerance_xy = 1e-8;
 
     char e_args[] = {"+proj=alsk +ellps=clrk66"};
-    char s_args[] = {"+proj=alsk +a=6370997"};
+    char s_args[] = {"+proj=alsk +R=6370997"};
 
     LP fwd_in[] = {
         {-160.0, 55.0},
@@ -494,7 +494,7 @@ int pj_gs50_selftest (void) {
     double tolerance_xy = 1e-8;
 
     char e_args[] = {"+proj=gs50 +ellps=clrk66"};
-    char s_args[] = {"+proj=gs50 +a=6370997"};
+    char s_args[] = {"+proj=gs50 +R=6370997"};
 
     LP fwd_in[] = {
         {-160.0, 65.0},

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -525,7 +525,7 @@ int pj_pipeline_selftest (void) {
     double dist;
 
     /* forward-reverse geo->utm->geo */
-    P = pj_create ("+proj=pipeline +ellps=GRS80 +zone=32 +step +proj=utm +step +proj=utm +inv");
+    P = pj_create ("+proj=pipeline +zone=32 +step +proj=utm +ellps=GRS80 +step +proj=utm +ellps=GRS80 +inv");
     if (0==P)
         return 1000;
     /* zero initialize everything, then set (longitude, latitude, height) to (12, 55, 0) */
@@ -547,7 +547,7 @@ int pj_pipeline_selftest (void) {
     pj_free (P);
 
     /* And now the back-to-back situation utm->geo->utm */
-    P = pj_create ("+proj=pipeline +ellps=GRS80 +zone=32 +step +proj=utm +inv +step +proj=utm");
+    P = pj_create ("+proj=pipeline +zone=32 +step +proj=utm +ellps=GRS80 +inv +step +proj=utm +ellps=GRS80");
     if (0==P)
         return 2000;
 
@@ -571,9 +571,10 @@ int pj_pipeline_selftest (void) {
 
 
     /* Finally testing a corner case: A rather pointless one-step pipeline geo->utm */
-    P = pj_create ("+proj=pipeline +ellps=GRS80 +zone=32 +step +proj=utm");
+    P = pj_create ("+proj=pipeline +zone=32 +step +proj=utm +ellps=GRS80 ");
     if (0==P)
         return 3000;
+
 
     a = b = pj_obs_null;
     a.coo.lpz.lam = TORAD(12);

--- a/src/PJ_poly.c
+++ b/src/PJ_poly.c
@@ -166,7 +166,7 @@ int pj_poly_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=poly   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=poly   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=poly   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_qsc.c
+++ b/src/PJ_qsc.c
@@ -420,7 +420,7 @@ int pj_qsc_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=qsc   +ellps=GRS80  +lat_1=0.5 +lat_2=2"};
-    char s_args[] = {"+proj=qsc   +a=6400000    +lat_1=0.5 +lat_2=2"};
+    char s_args[] = {"+proj=qsc   +R=6400000    +lat_1=0.5 +lat_2=2"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_somerc.c
+++ b/src/PJ_somerc.c
@@ -114,7 +114,7 @@ int pj_somerc_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=somerc   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +n=0.5"};
-    char s_args[] = {"+proj=somerc   +a=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
+    char s_args[] = {"+proj=somerc   +R=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_stere.c
+++ b/src/PJ_stere.c
@@ -310,7 +310,7 @@ int pj_stere_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=stere   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +n=0.5"};
-    char s_args[] = {"+proj=stere   +a=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
+    char s_args[] = {"+proj=stere   +R=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_sterea.c
+++ b/src/PJ_sterea.c
@@ -127,7 +127,7 @@ int pj_sterea_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=sterea   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +n=0.5"};
-    char s_args[] = {"+proj=sterea   +a=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
+    char s_args[] = {"+proj=sterea   +R=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
 
     LP fwd_in[] = {
         { 2, 1},

--- a/src/PJ_tmerc.c
+++ b/src/PJ_tmerc.c
@@ -206,7 +206,7 @@ int pj_tmerc_selftest (void) {
     double tolerance_xy = 1e-7;
 
     char e_args[] = {"+proj=tmerc   +ellps=GRS80  +lat_1=0.5 +lat_2=2 +n=0.5"};
-    char s_args[] = {"+proj=tmerc   +a=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
+    char s_args[] = {"+proj=tmerc   +R=6400000    +lat_1=0.5 +lat_2=2 +n=0.5"};
 
     LP fwd_in[] = {
         { 2, 1},


### PR DESCRIPTION
As described in #468 and #469 

All tests but the one for ```pipeline``` can be fixed by using ```+R``` instead of ```+a```. I suspect this was caused by refactoring the ellipsoid-code in 44c611c. Is that correct, @busstoptaktik?

The ```pipeline``` test fails because the expected tolerance of 1e-4 is not met. Instead it comes out as 0.000124169332, which is close but not quite there. I don't know why that happens. The problem is easily solved by changing the tolerance, but before we go down that path we should try to find an explanation as to why the results differ across system. 