### PR TITLE
fix memory leak in PJ_ob_tran.c (in freeup_new)

### DIFF
--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -86,7 +86,7 @@ static void *freeup_new (PJ *P) {                       /* Destructor */
         return pj_dealloc (P);
 
     if (P->opaque->link)
-        return pj_dealloc (P->opaque->link);
+        pj_dealloc (P->opaque->link);
 
     pj_dealloc (P->opaque);
     return pj_dealloc(P);


### PR DESCRIPTION
freeup_new must not return before both P->opaque and P are deallocated.