### PR TITLE
Add pj_find_file() function to retrieve the full filename of a proj resource file.

### DIFF
--- a/src/proj.def
+++ b/src/proj.def
@@ -106,3 +106,4 @@ EXPORTS
     pj_lp_dist                     @106
     pj_xy_dist                     @107
     pj_xyz_dist                    @108
+    pj_find_file                   @109

--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -202,7 +202,8 @@ void   pj_ctx_fclose(projCtx ctx, PAFile file);
 char  *pj_ctx_fgets(projCtx ctx, char *line, int size, PAFile file);
 
 PAFile pj_open_lib(projCtx, const char *, const char *);
-
+int pj_find_file(projCtx ctx, const char *short_filename,
+                 char* out_full_filename, size_t out_full_filename_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Will help GDAL finding where +nadgrids=... or +geoidgrids=... resouces are located
to be able to directly open them.

Cf https://github.com/OSGeo/proj.4/commit/25066cfb3b90dc447b26cf4f796e7ed8f1377585#commitcomment-21347676