### PR TITLE
Fix aea projection return value in case of invalid parameters

### DIFF
--- a/src/PJ_aea.c
+++ b/src/PJ_aea.c
@@ -193,8 +193,7 @@ PJ *PROJECTION(aea) {
 
 	Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
 	Q->phi2 = pj_param(P->ctx, P->params, "rlat_2").f;
-    setup(P);
-    return P;
+    return setup(P);
 }
 
 
@@ -206,8 +205,7 @@ PJ *PROJECTION(leac) {
 
 	Q->phi2 = pj_param(P->ctx, P->params, "rlat_1").f;
 	Q->phi1 = pj_param(P->ctx, P->params, "bsouth").i ? - M_HALFPI: M_HALFPI;
-    setup (P);
-    return P;
+    return setup(P);
 }
 
 


### PR DESCRIPTION
In aea projection setup(P) will free P pointer and return 0 (inside E_ERROR macro) if any of projection parameters are invalid. Right now return value of setup(P) is ignored that could lead to attempt to free P pointer once more and segmentation fault. 
This commit fixes described issue.