### PR TITLE
Put the cmake exported targets in a namespace

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -26,4 +26,5 @@ install (FILES
 # available.
 install (EXPORT targets
   FILE ${PROJECT_NAME_LOWER}-targets.cmake
-  DESTINATION "${INSTALL_CMAKE_DIR}")
+  DESTINATION "${INSTALL_CMAKE_DIR}"
+  NAMESPACE ${PROJECT_NAME}::)


### PR DESCRIPTION
It is good practice to have imported targets be in the project namespace (https://cmake.org/cmake/help/v3.8/manual/cmake-developer.7.html?highlight=namespace). Even more when the target names are so simple and confusing as `proj`