### PR TITLE
Completing the Helmert transformation with the 4-parameter shift

### DIFF
--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -1,13 +1,14 @@
 /***********************************************************************
 
-           Helmert transformations, 3-, 4-, 7- and 14-parameter
+             3-, 4-and 7-parameter shifts, and their 6-, 8-
+                and 14-parameter kinematic counterparts.
 
                     Thomas Knudsen, 2016-05-24
 
 ************************************************************************
 
-  Implements 3-, 4-, 7- and 14-parameter Helmert transformations for 3D
-  data.
+  Implements 3(6)-, 4(8) and 7(14)-parameter Helmert transformations for
+  3D data.
 
   Primarily useful for implementation of datum shifts in transformation
   pipelines.
@@ -16,7 +17,7 @@
 
 Thomas Knudsen, thokn@sdfe.dk, 2016-05-24/06-05
 Kristian Evers, kreve@sdfe.dk, 2017-05-01
-Last update: 2017-05-08
+Last update: 2017-05-15
 
 ************************************************************************
 * Copyright (c) 2016, Thomas Knudsen / SDFE
@@ -48,7 +49,7 @@ Last update: 2017-05-08
 #include <assert.h>
 #include <stddef.h>
 #include <errno.h>
-PROJ_HEAD(helmert, "3-, 4-, 7- and 14-parameter Helmert shift");
+PROJ_HEAD(helmert, "3(6)-, 4(8)- and 7(14)-parameter Helmert shift");
 
 static XYZ helmert_forward_3d (LPZ lpz, PJ *P);
 static LPZ helmert_reverse_3d (XYZ xyz, PJ *P);


### PR DESCRIPTION
Completing the Helmert driver with the 4-parameter shift that handles
the 2D transformation. The implementation is written in such a way that
not only 2D-points but also 3D- and 4D-points can be transformed with
the 4-parameter Helmert. The four parameters that can be set in this
mode are +x, +y (translations), +s (scale) and +theta (rotation). The
presence of the +theta parameter activates the 2D-helmert code,
irregardless of the input data's dimensions.

The units are meters for the translations as in all the other versions
of the Helmert transform. The rotation unit is arcseconds.
The units of the scale differ from the 3-, 7- and 14-parameter shift
where the unit is ppm. Here it is instead given directly and is as such
unitless.

The 4-parameter case can also be extended to an 8-parameter shift in the
same way as the 7-parameter shift extens to the 14-parameter shift. This
might be a bit silly and will probably never be used, but nonetheless, I
have included it for the sake of completeness. The rates of change are
givens as +dx, +dy, +ds and +dtheta.