### PR TITLE
Memleak fixes

### DIFF
--- a/src/PJ_wag3.c
+++ b/src/PJ_wag3.c
@@ -28,13 +28,8 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 	return lp;
 }
 
-
-static void *freeup_new (PJ *P) {                       /* Destructor */
-    return pj_dealloc(P);
-}
-
 static void freeup (PJ *P) {
-    freeup_new (P);
+    pj_freeup_plain (P);
     return;
 }
 
@@ -43,7 +38,10 @@ PJ *PROJECTION(wag3) {
 	double ts;
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
     if (0==Q)
-        return freeup_new (P);
+    {
+        freeup(P);
+        return 0;
+    }
     P->opaque = Q;
 
 	ts = pj_param (P->ctx, P->params, "rlat_ts").f;

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -668,11 +668,6 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
     else
         PIN->from_greenwich = 0.0;
 
-    /* Private object for the geodesic functions */
-    PIN->geod = pj_calloc (1, sizeof (struct geod_geodesic));
-    if (0!=PIN->geod)
-        geod_init(PIN->geod, PIN->a,  (1 - sqrt (1 - PIN->es)));
-
     /* projection specific initialization */
     if (!(PIN = (*proj)(PIN)) || ctx->last_errno) {
       bum_call: /* cleanup error return */
@@ -684,6 +679,12 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
                 pj_dalloc(start);
             }
         PIN = 0;
+    }
+    else {
+        /* Private object for the geodesic functions */
+        PIN->geod = pj_calloc (1, sizeof (struct geod_geodesic));
+        if (0!=PIN->geod)
+            geod_init(PIN->geod, PIN->a,  (1 - sqrt (1 - PIN->es)));
     }
 
     return PIN;


### PR DESCRIPTION
@busstoptaktik I'm not completely sure about the change in pj_init(). It could be a problem if a (*proj)(PIN) function needed the ->geod member, but it doesn't look like this is the case. Annther issue, which existed before, is that in the unlikely case PIN->geod = pj_calloc(...) would fail, we would return a valid PIN pointer. So code later that would need geod could crash