### PR TITLE
Fix possible zero division [OSS-Fuzz issue 1801]

### DIFF
--- a/src/pj_tsfn.c
+++ b/src/pj_tsfn.c
@@ -2,9 +2,15 @@
 #include <math.h>
 #include <projects.h>
 
-	double
-pj_tsfn(double phi, double sinphi, double e) {
-	sinphi *= e;
-	return (tan (.5 * (M_HALFPI - phi)) /
-	   pow((1. - sinphi) / (1. + sinphi), .5 * e));
+double pj_tsfn(double phi, double sinphi, double e) {
+    double denominator;
+    sinphi *= e;
+
+    /* avoid zero division, fail gracefully */
+    denominator = 1.0 + sinphi;
+    if (denominator == 0.0)
+        return HUGE_VAL;
+
+    return (tan (.5 * (M_HALFPI - phi)) /
+            pow((1. - sinphi) / (denominator), .5 * e));
 }


### PR DESCRIPTION
For some extreme values of eccentricity a zero divison can occur. In
those rare cases we return HUGE_VAL to indicate something went wrong
while still returning a defined value.

Credit to OSS Fuzz.

I still need to confirm this against OSS-Fuzz, just checking that the usual test-suite is happy.