### PR TITLE
Disallow +s=0 when in 4-param. mode.

### DIFF
--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -520,12 +520,15 @@ PJ *PROJECTION(helmert) {
     if (pj_param (P->ctx, P->params, "ttheta").i) {
         Q->theta_0 = pj_param (P->ctx, P->params, "dtheta").f * ARCSEC_TO_RAD;
         Q->fourparam = 1;
+        Q->scale_0 = 1.0; /* default scale for the 4-param shift */
     }
 
     /* Scale */
-    if (pj_param (P->ctx, P->params, "ts").i)
+    if (pj_param (P->ctx, P->params, "ts").i) {
         Q->scale_0 = pj_param (P->ctx, P->params, "ds").f;
-
+        if (pj_param (P->ctx, P->params, "ttheta").i && Q->scale_0 == 0.0)
+            return freeup_msg(P, -PJD_ERR_INVALID_SCALE);
+    }
 
     /* Translation rates */
     if (pj_param(P->ctx, P->params, "tdx").i)

--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -57,6 +57,7 @@ pj_err_list[] = {
     "invalid sweep axis, choose x or y",                               /* -49 */
     "malformed pipeline",                                              /* -50 */
     "unit conversion factor must be > 0",                              /* -51 */
+    "invalid scale",                                                   /* -52 */
 };
 
 char *pj_strerrno(int err) {

--- a/src/projects.h
+++ b/src/projects.h
@@ -457,6 +457,7 @@ struct FACTORS {
 #define PJD_ERR_AXIS                -47
 #define PJD_ERR_GRID_AREA           -48
 #define PJD_ERR_CATALOG             -49
+#define PJD_ERR_INVALID_SCALE       -52
 
 struct projFileAPI_t;
 


### PR DESCRIPTION
Avoids zero-division in PJ_helmert.c

Fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1956

Credit to OSS-Fuzz.