### PR TITLE
Disallow usage of m<0 and n<0 in gn_sinu.

### DIFF
--- a/src/projects.h
+++ b/src/projects.h
@@ -453,6 +453,7 @@ struct FACTORS {
 #define PJD_WGS84     4   /* WGS84 (or anything considered equivalent) */
 
 /* library errors */
+#define PJD_ERR_INVALID_M_OR_N      -39
 #define PJD_ERR_GEOCENTRIC          -45
 #define PJD_ERR_AXIS                -47
 #define PJD_ERR_GRID_AREA           -48


### PR DESCRIPTION
Negative values of m and n are not valid. Can for certain values of m
and n result in zero division. An error is raised at projection setup if
m or n is negative.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1836

Credit to OSS-Fuzz.