### PR TITLE
PJ_vgridshift.c: fix memleak in initialization if grid loading fail

### DIFF
--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -29,8 +29,8 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
         /* Only try the gridshift if at least one grid is loaded,
          * otherwise just pass the coordinate through unchanged. */
         pj_apply_vgridshift( P, "sgrids",
-                             &(P->vgridlist_geoid),
-                             &(P->vgridlist_geoid_count),
+                             &(P->gridlist),
+                             &(P->gridlist_count),
                              1, 1, 0,
                              &point.xyz.x, &point.xyz.y, &point.xyz.z );
     }
@@ -47,8 +47,8 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
         /* Only try the gridshift if at least one grid is loaded,
          * otherwise just pass the coordinate through unchanged. */
         pj_apply_vgridshift( P, "sgrids",
-                             &(P->vgridlist_geoid),
-                             &(P->vgridlist_geoid_count),
+                             &(P->gridlist),
+                             &(P->gridlist_count),
                              0, 1, 0,
                              &point.xyz.x, &point.xyz.y, &point.xyz.z );
     }
@@ -84,6 +84,8 @@ PJ *PROJECTION(vgridshift) {
     /* Was gridlist compiled properly? */
     if ( pj_ctx_get_errno(P->ctx) ) {
         pj_log_error(P, "vgridshift: could not find required grid(s).");
+        pj_dalloc(P->gridlist);
+        P->gridlist = NULL;
         return freeup_msg(P, -38);
     }
 

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -193,6 +193,7 @@ PJ_GRIDINFO **pj_gridlist_from_nadgrids( projCtx ctx, const char *nadgrids,
 
         if( end_char >= sizeof(name) )
         {
+            pj_dalloc( gridlist );
             pj_ctx_set_errno( ctx, -38 );
             pj_release_lock();
             return NULL;


### PR DESCRIPTION
When gridloading fail for one grid, but return a gridlist, we leak the grid list array.
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2230. Credit to OSS Fuzz

Also use the P->vgridlist_geoid member consistently to try reducing confusion between
P->gridlist and P->vgridlist_geoid