### PR TITLE
Fix broken very verbose usage of proj (-V) fails on Windows

### DIFF
--- a/src/proj.c
+++ b/src/proj.c
@@ -209,8 +209,10 @@ vprocess(FILE *fid) {
 			dat_xy = pj_fwd(dat_ll, Proj);
 			if (postscale) { dat_xy.u *= fscale; dat_xy.v *= fscale; }
 		}
-		if (pj_errno) {
-			emess(-1, pj_strerrno(pj_errno));
+		/* For some reason pj_errno does not work as expected in some   */
+		/* versions of Visual Studio, so using pj_get_errno_ref instead */
+		if (*pj_get_errno_ref()) {
+			emess(-1, pj_strerrno(*pj_get_errno_ref()));
 			continue;
 		}
 		if (!*s && (s > line)) --s; /* assumed we gobbled \n */


### PR DESCRIPTION
On Windows in some combinations of nmake and Visual Studio the -V option in proj.exe is broken. It is due to checking the `pj_errno` variable before printing the verbose output. For some reason `pj_errno` is not initialized to zero and the check thinks an error happened in `pj_fwd()`. I haven't determined what the root cause is, but the problem can be circumvented by getting the error value from `*pj_get_errno_ref()`.

Fixes #484.