### PR TITLE
Correcting convergence formula for LCC. Fixes #16.

### DIFF
--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -77,7 +77,7 @@ static void special(LP lp, PJ *P, struct FACTORS *fac) {
     fac->code |= IS_ANAL_HK + IS_ANAL_CONV;
     fac->k = fac->h = P->k0 * Q->n * rho /
         pj_msfn(sin(lp.phi), cos(lp.phi), P->es);
-    fac->conv = - Q->n * lp.lam;
+    fac->conv = Q->n * lp.lam;
 }
 
 


### PR DESCRIPTION
Thanks to @dtutic the meridian convergence sign error in LCC is now fixed.