### PR TITLE
Make sure to use custom hypot() when building as ANSI C

### DIFF
--- a/src/projects.h
+++ b/src/projects.h
@@ -84,7 +84,7 @@ extern "C" {
 #endif
 
 /* prototype hypot for systems where absent */
-#ifndef _WIN32
+#if !defined(_WIN32) || !defined(__ANSI__)
 extern double hypot(double, double);
 #endif
 


### PR DESCRIPTION
`hypot()` is not defined in C versions earlier than C99. So when trying to build PROJ.4 as ANSI C warnings are issued. 

Below I build with `CFLAGS=-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2 -ansi` which results in a failed build because `hypot()` is unknown. This PR fixes the problem.

```
λ ninja binproj
[2/176] Building C object src/CMakeFiles/proj.dir/PJ_aeqd.c.obj
FAILED: src/CMakeFiles/proj.dir/PJ_aeqd.c.obj
C:\TDM-GCC-64\bin\gcc.exe -DHAVE_PTHREAD_MUTEX_RECURSIVE=1 -DMUTEX_pthread -DMUTEX_win32 -DPJ_SELFTEST -DPROJ_LIB=\"c:/OSGeo4W/share\" -IC:/dev/proj4/src -Isrc -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2 -ansi -O3 -DNDEBUG -MD -MT src/CMakeFiles/proj.dir/PJ_aeqd.c.obj -MF src\CMakeFiles\proj.dir\PJ_aeqd.c.obj.d -o src/CMakeFiles/proj.dir/PJ_aeqd.c.obj   -c C:/dev/proj4/src/PJ_aeqd.c
C:/dev/proj4/src/PJ_aeqd.c: In function 'e_inverse':
C:/dev/proj4/src/PJ_aeqd.c:177:14: error: implicit declaration of function 'hypot' [-Werror=implicit-function-declaration]
     if ((c = hypot(xy.x, xy.y)) < EPS10) {
              ^
cc1.exe: all warnings being treated as errors
[3/176] Building C object src/CMakeFiles/proj.dir/PJ_aea.c.obj
FAILED: src/CMakeFiles/proj.dir/PJ_aea.c.obj
C:\TDM-GCC-64\bin\gcc.exe -DHAVE_PTHREAD_MUTEX_RECURSIVE=1 -DMUTEX_pthread -DMUTEX_win32 -DPJ_SELFTEST -DPROJ_LIB=\"c:/OSGeo4W/share\" -IC:/dev/proj4/src -Isrc -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2 -ansi -O3 -DNDEBUG -MD -MT src/CMakeFiles/proj.dir/PJ_aea.c.obj -MF src\CMakeFiles\proj.dir\PJ_aea.c.obj.d -o src/CMakeFiles/proj.dir/PJ_aea.c.obj   -c C:/dev/proj4/src/PJ_aea.c
C:/dev/proj4/src/PJ_aea.c: In function 'e_inverse':
C:/dev/proj4/src/PJ_aea.c:97:19: error: implicit declaration of function 'hypot' [-Werror=implicit-function-declaration]
     if( (Q->rho = hypot(xy.x, xy.y = Q->rho0 - xy.y)) != 0.0 ) {
                   ^
cc1.exe: all warnings being treated as errors
[7/176] Building C object src/CMakeFiles/proj.dir/PJ_aitoff.c.obj
ninja: build stopped: subcommand failed.
```