### PR TITLE
Eliminated *_ERROR* macros.

### DIFF
--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -29,12 +29,13 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 
 struct pj_opaque {
-	double	cosphi1;
-	int		mode;
+    double  cosphi1;
+    int     mode;
 };
 
 
@@ -51,18 +52,18 @@ FORWARD(s_forward); /* spheroid */
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double c, d;
+    double c, d;
 
-	if((d = acos(cos(lp.phi) * cos(c = 0.5 * lp.lam))) != 0.0) {/* basic Aitoff */
-		xy.x = 2. * d * cos(lp.phi) * sin(c) * (xy.y = 1. / sin(d));
-		xy.y *= d * sin(lp.phi);
-	} else
-		xy.x = xy.y = 0.;
-	if (Q->mode) { /* Winkel Tripel */
-		xy.x = (xy.x + lp.lam * Q->cosphi1) * 0.5;
-		xy.y = (xy.y + lp.phi) * 0.5;
-	}
-	return (xy);
+    if((d = acos(cos(lp.phi) * cos(c = 0.5 * lp.lam))) != 0.0) {/* basic Aitoff */
+        xy.x = 2. * d * cos(lp.phi) * sin(c) * (xy.y = 1. / sin(d));
+        xy.y *= d * sin(lp.phi);
+    } else
+        xy.x = xy.y = 0.;
+    if (Q->mode) { /* Winkel Tripel */
+        xy.x = (xy.x + lp.lam * Q->cosphi1) * 0.5;
+        xy.y = (xy.y + lp.phi) * 0.5;
+    }
+    return (xy);
 }
 
 /***********************************************************************************
@@ -90,64 +91,64 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
     int iter, MAXITER = 10, round = 0, MAXROUND = 20;
-	double EPSILON = 1e-12, D, C, f1, f2, f1p, f1l, f2p, f2l, dp, dl, sl, sp, cp, cl, x, y;
+    double EPSILON = 1e-12, D, C, f1, f2, f1p, f1l, f2p, f2l, dp, dl, sl, sp, cp, cl, x, y;
 
-	if ((fabs(xy.x) < EPSILON) && (fabs(xy.y) < EPSILON )) { lp.phi = 0.; lp.lam = 0.; return lp; }
+    if ((fabs(xy.x) < EPSILON) && (fabs(xy.y) < EPSILON )) { lp.phi = 0.; lp.lam = 0.; return lp; }
 
-	/* initial values for Newton-Raphson method */
-	lp.phi = xy.y; lp.lam = xy.x;
-	do {
-		iter = 0;
-		do {
-			sl = sin(lp.lam * 0.5); cl = cos(lp.lam * 0.5);
-			sp = sin(lp.phi); cp = cos(lp.phi);
-			D = cp * cl;
- 		      	C = 1. - D * D;
-			D = acos(D) / pow(C, 1.5);
-	       		f1 = 2. * D * C * cp * sl;
-		       	f2 = D * C * sp;
-		       	f1p = 2.* (sl * cl * sp * cp / C - D * sp * sl);
-		       	f1l = cp * cp * sl * sl / C + D * cp * cl * sp * sp;
-		    	f2p = sp * sp * cl / C + D * sl * sl * cp;
-		      	f2l = 0.5 * (sp * cp * sl / C - D * sp * cp * cp * sl * cl);
-		      	if (Q->mode) { /* Winkel Tripel */
-				f1 = 0.5 * (f1 + lp.lam * Q->cosphi1);
-				f2 = 0.5 * (f2 + lp.phi);
-				f1p *= 0.5;
-				f1l = 0.5 * (f1l + Q->cosphi1);
-				f2p = 0.5 * (f2p + 1.);
-				f2l *= 0.5;
-			}
-			f1 -= xy.x; f2 -= xy.y;
-			dl = (f2 * f1p - f1 * f2p) / (dp = f1p * f2l - f2p * f1l);
-			dp = (f1 * f2l - f2 * f1l) / dp;
-			dl = fmod(dl, M_PI); /* set to interval [-M_PI, M_PI] */
-			lp.phi -= dp;	lp.lam -= dl;
-		} while ((fabs(dp) > EPSILON || fabs(dl) > EPSILON) && (iter++ < MAXITER));
-		if (lp.phi > M_PI_2) lp.phi -= 2.*(lp.phi-M_PI_2); /* correct if symmetrical solution for Aitoff */
-		if (lp.phi < -M_PI_2) lp.phi -= 2.*(lp.phi+M_PI_2); /* correct if symmetrical solution for Aitoff */
-		if ((fabs(fabs(lp.phi) - M_PI_2) < EPSILON) && (!Q->mode)) lp.lam = 0.; /* if pole in Aitoff, return longitude of 0 */
+    /* initial values for Newton-Raphson method */
+    lp.phi = xy.y; lp.lam = xy.x;
+    do {
+        iter = 0;
+        do {
+            sl = sin(lp.lam * 0.5); cl = cos(lp.lam * 0.5);
+            sp = sin(lp.phi); cp = cos(lp.phi);
+            D = cp * cl;
+                C = 1. - D * D;
+            D = acos(D) / pow(C, 1.5);
+                f1 = 2. * D * C * cp * sl;
+                f2 = D * C * sp;
+                f1p = 2.* (sl * cl * sp * cp / C - D * sp * sl);
+                f1l = cp * cp * sl * sl / C + D * cp * cl * sp * sp;
+                f2p = sp * sp * cl / C + D * sl * sl * cp;
+                f2l = 0.5 * (sp * cp * sl / C - D * sp * cp * cp * sl * cl);
+                if (Q->mode) { /* Winkel Tripel */
+                f1 = 0.5 * (f1 + lp.lam * Q->cosphi1);
+                f2 = 0.5 * (f2 + lp.phi);
+                f1p *= 0.5;
+                f1l = 0.5 * (f1l + Q->cosphi1);
+                f2p = 0.5 * (f2p + 1.);
+                f2l *= 0.5;
+            }
+            f1 -= xy.x; f2 -= xy.y;
+            dl = (f2 * f1p - f1 * f2p) / (dp = f1p * f2l - f2p * f1l);
+            dp = (f1 * f2l - f2 * f1l) / dp;
+            dl = fmod(dl, M_PI); /* set to interval [-M_PI, M_PI] */
+            lp.phi -= dp;   lp.lam -= dl;
+        } while ((fabs(dp) > EPSILON || fabs(dl) > EPSILON) && (iter++ < MAXITER));
+        if (lp.phi > M_PI_2) lp.phi -= 2.*(lp.phi-M_PI_2); /* correct if symmetrical solution for Aitoff */
+        if (lp.phi < -M_PI_2) lp.phi -= 2.*(lp.phi+M_PI_2); /* correct if symmetrical solution for Aitoff */
+        if ((fabs(fabs(lp.phi) - M_PI_2) < EPSILON) && (!Q->mode)) lp.lam = 0.; /* if pole in Aitoff, return longitude of 0 */
 
-		/* calculate x,y coordinates with solution obtained */
-		if((D = acos(cos(lp.phi) * cos(C = 0.5 * lp.lam))) != 0.0) {/* Aitoff */
-			x = 2. * D * cos(lp.phi) * sin(C) * (y = 1. / sin(D));
-			y *= D * sin(lp.phi);
-		} else
-			x = y = 0.;
-		if (Q->mode) { /* Winkel Tripel */
-			x = (x + lp.lam * Q->cosphi1) * 0.5;
-			y = (y + lp.phi) * 0.5;
-		}
-	/* if too far from given values of x,y, repeat with better approximation of phi,lam */
-	} while (((fabs(xy.x-x) > EPSILON) || (fabs(xy.y-y) > EPSILON)) && (round++ < MAXROUND));
+        /* calculate x,y coordinates with solution obtained */
+        if((D = acos(cos(lp.phi) * cos(C = 0.5 * lp.lam))) != 0.0) {/* Aitoff */
+            x = 2. * D * cos(lp.phi) * sin(C) * (y = 1. / sin(D));
+            y *= D * sin(lp.phi);
+        } else
+            x = y = 0.;
+        if (Q->mode) { /* Winkel Tripel */
+            x = (x + lp.lam * Q->cosphi1) * 0.5;
+            y = (y + lp.phi) * 0.5;
+        }
+    /* if too far from given values of x,y, repeat with better approximation of phi,lam */
+    } while (((fabs(xy.x-x) > EPSILON) || (fabs(xy.y-y) > EPSILON)) && (round++ < MAXROUND));
 
-	if (iter == MAXITER && round == MAXROUND)
+    if (iter == MAXITER && round == MAXROUND)
         {
             pj_ctx_set_errno( P->ctx, PJD_ERR_NON_CONVERGENT );
             /* fprintf(stderr, "Warning: Accuracy of 1e-12 not reached. Last increments: dlat=%e and dlon=%e\n", dp, dl); */
         }
 
-	return lp;
+    return lp;
 }
 
 
@@ -168,10 +169,10 @@ static void freeup (PJ *P) {
 }
 
 static PJ *setup(PJ *P) {
-	P->inv = s_inverse;
-	P->fwd = s_forward;
-	P->es = 0.;
-	return P;
+    P->inv = s_inverse;
+    P->fwd = s_forward;
+    P->es = 0.;
+    return P;
 }
 
 
@@ -181,7 +182,7 @@ PJ *PROJECTION(aitoff) {
         return freeup_new (P);
     P->opaque = Q;
 
-	Q->mode = 0;
+    Q->mode = 0;
     return setup(P);
 }
 
@@ -192,13 +193,15 @@ PJ *PROJECTION(wintri) {
         return freeup_new (P);
     P->opaque = Q;
 
-	Q->mode = 1;
-	if (pj_param(P->ctx, P->params, "tlat_1").i) {
-		if ((Q->cosphi1 = cos(pj_param(P->ctx, P->params, "rlat_1").f)) == 0.)
-			E_ERROR(-22)
+    Q->mode = 1;
+    if (pj_param(P->ctx, P->params, "tlat_1").i) {
+        if ((Q->cosphi1 = cos(pj_param(P->ctx, P->params, "rlat_1").f)) == 0.) {
+            proj_errno_set(P, PJD_ERR_LAT_LARGER_THAN_90);
+            return freeup_new(P);
+        }
     }
-	else /* 50d28' or acos(2/pi) */
-		Q->cosphi1 = 0.636619772367581343;
+    else /* 50d28' or acos(2/pi) */
+        Q->cosphi1 = 0.636619772367581343;
     return setup(P);
 }
 

--- a/src/PJ_bipc.c
+++ b/src/PJ_bipc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(bipc, "Bipolar conic of western hemisphere") "\n\tConic Sph.";
 
@@ -51,7 +52,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         sdlam = sin(sdlam);
         z = S20 * sphi + C20 * cphi * cdlam;
         if (fabs(z) > 1.) {
-            if (fabs(z) > ONEEPS) F_ERROR
+            if (fabs(z) > ONEEPS) {
+                proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+                return xy;
+            }
             else z = z < 0. ? -1. : 1.;
         } else
             z = acos(z);
@@ -62,19 +66,31 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     } else {
         z = S45 * (sphi + cphi * cdlam);
         if (fabs(z) > 1.) {
-            if (fabs(z) > ONEEPS) F_ERROR
+            if (fabs(z) > ONEEPS) {
+                proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+                return xy;
+            }
             else z = z < 0. ? -1. : 1.;
         } else
             z = acos(z);
         Av = Azba;
         xy.y = -rhoc;
     }
-    if (z < 0.) F_ERROR;
+    if (z < 0.) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     r = F * (t = pow(tan(.5 * z), n));
-    if ((al = .5 * (R104 - z)) < 0.) F_ERROR;
+    if ((al = .5 * (R104 - z)) < 0.) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     al = (t + pow(al, n)) / T;
     if (fabs(al) > 1.) {
-        if (fabs(al) > ONEEPS) F_ERROR
+        if (fabs(al) > ONEEPS) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return xy;
+        }
         else al = al < 0. ? -1. : 1.;
     } else
         al = acos(al);
@@ -125,7 +141,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
             break;
         rl = r;
     }
-    if (! i) I_ERROR;
+    if (! i) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    }
     Az = Av - Az / n;
     lp.phi = asin(s * cos(z) + c * sin(z) * cos(Az));
     lp.lam = atan2(sin(Az), c / tan(z) - s * cos(Az));

--- a/src/PJ_bonne.c
+++ b/src/PJ_bonne.c
@@ -1,78 +1,85 @@
 #define PJ_LIB__
-#include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(bonne, "Bonne (Werner lat_1=90)")
-	"\n\tConic Sph&Ell\n\tlat_1=";
-#define EPS10	1e-10
+    "\n\tConic Sph&Ell\n\tlat_1=";
+#define EPS10   1e-10
 
 struct pj_opaque {
-	double phi1;
-	double cphi1;
-	double am1;
-	double m1;
-	double *en;
+    double phi1;
+    double cphi1;
+    double am1;
+    double m1;
+    double *en;
 };
 
 
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double rh, E, c;
+    double rh, E, c;
 
-	rh = Q->am1 + Q->m1 - pj_mlfn(lp.phi, E = sin(lp.phi), c = cos(lp.phi), Q->en);
-	E = c * lp.lam / (rh * sqrt(1. - P->es * E * E));
-	xy.x = rh * sin(E);
-	xy.y = Q->am1 - rh * cos(E);
-	return xy;
+    rh = Q->am1 + Q->m1 - pj_mlfn(lp.phi, E = sin(lp.phi), c = cos(lp.phi), Q->en);
+    E = c * lp.lam / (rh * sqrt(1. - P->es * E * E));
+    xy.x = rh * sin(E);
+    xy.y = Q->am1 - rh * cos(E);
+    return xy;
 }
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double E, rh;
+    double E, rh;
 
-	rh = Q->cphi1 + Q->phi1 - lp.phi;
-	if (fabs(rh) > EPS10) {
-		xy.x = rh * sin(E = lp.lam * cos(lp.phi) / rh);
-		xy.y = Q->cphi1 - rh * cos(E);
-	} else
-		xy.x = xy.y = 0.;
-	return xy;
+    rh = Q->cphi1 + Q->phi1 - lp.phi;
+    if (fabs(rh) > EPS10) {
+        xy.x = rh * sin(E = lp.lam * cos(lp.phi) / rh);
+        xy.y = Q->cphi1 - rh * cos(E);
+    } else
+        xy.x = xy.y = 0.;
+    return xy;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double rh;
+    double rh;
 
-	rh = hypot(xy.x, xy.y = Q->cphi1 - xy.y);
-	lp.phi = Q->cphi1 + Q->phi1 - rh;
-	if (fabs(lp.phi) > M_HALFPI) I_ERROR;
-	if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10)
-		lp.lam = 0.;
-	else
-		lp.lam = rh * atan2(xy.x, xy.y) / cos(lp.phi);
-	return lp;
+    rh = hypot(xy.x, xy.y = Q->cphi1 - xy.y);
+    lp.phi = Q->cphi1 + Q->phi1 - rh;
+    if (fabs(lp.phi) > M_HALFPI) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    }
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10)
+        lp.lam = 0.;
+    else
+        lp.lam = rh * atan2(xy.x, xy.y) / cos(lp.phi);
+    return lp;
 }
 
 
 static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double s, rh;
+    double s, rh;
 
-	rh = hypot(xy.x, xy.y = Q->am1 - xy.y);
-	lp.phi = pj_inv_mlfn(P->ctx, Q->am1 + Q->m1 - rh, P->es, Q->en);
-	if ((s = fabs(lp.phi)) < M_HALFPI) {
-		s = sin(lp.phi);
-		lp.lam = rh * atan2(xy.x, xy.y) *
-		   sqrt(1. - P->es * s * s) / cos(lp.phi);
-	} else if (fabs(s - M_HALFPI) <= EPS10)
-		lp.lam = 0.;
-	else I_ERROR;
-	return lp;
+    rh = hypot(xy.x, xy.y = Q->am1 - xy.y);
+    lp.phi = pj_inv_mlfn(P->ctx, Q->am1 + Q->m1 - rh, P->es, Q->en);
+    if ((s = fabs(lp.phi)) < M_HALFPI) {
+        s = sin(lp.phi);
+        lp.lam = rh * atan2(xy.x, xy.y) *
+           sqrt(1. - P->es * s * s) / cos(lp.phi);
+    } else if (fabs(s - M_HALFPI) <= EPS10)
+        lp.lam = 0.;
+    else {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    }
+    return lp;
 }
 
 
@@ -94,29 +101,32 @@ static void freeup (PJ *P) {
 
 
 PJ *PROJECTION(bonne) {
-	double c;
+    double c;
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
     if (0==Q)
         return freeup_new (P);
     P->opaque = Q;
 
-	Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
-	if (fabs(Q->phi1) < EPS10) E_ERROR(-23);
-	if (P->es != 0.0) {
-		Q->en = pj_enfn(P->es);
-		Q->m1 = pj_mlfn(Q->phi1, Q->am1 = sin(Q->phi1),
-			c = cos(Q->phi1), Q->en);
-		Q->am1 = c / (sqrt(1. - P->es * Q->am1 * Q->am1) * Q->am1);
-		P->inv = e_inverse;
-		P->fwd = e_forward;
-	} else {
-		if (fabs(Q->phi1) + EPS10 >= M_HALFPI)
-			Q->cphi1 = 0.;
-		else
-			Q->cphi1 = 1. / tan(Q->phi1);
-		P->inv = s_inverse;
-		P->fwd = s_forward;
-	}
+    Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
+    if (fabs(Q->phi1) < EPS10) {
+        proj_errno_set(P, PJD_ERR_LAT1_IS_ZERO);
+        return freeup_new(P);
+    }
+    if (P->es != 0.0) {
+        Q->en = pj_enfn(P->es);
+        Q->m1 = pj_mlfn(Q->phi1, Q->am1 = sin(Q->phi1),
+            c = cos(Q->phi1), Q->en);
+        Q->am1 = c / (sqrt(1. - P->es * Q->am1 * Q->am1) * Q->am1);
+        P->inv = e_inverse;
+        P->fwd = e_forward;
+    } else {
+        if (fabs(Q->phi1) + EPS10 >= M_HALFPI)
+            Q->cphi1 = 0.;
+        else
+            Q->cphi1 = 1. / tan(Q->phi1);
+        P->inv = s_inverse;
+        P->fwd = s_forward;
+    }
     return P;
 }
 

--- a/src/PJ_calcofi.c
+++ b/src/PJ_calcofi.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(calcofi,
     "Cal Coop Ocean Fish Invest Lines/Stations") "\n\tCyl, Sph&Ell";
@@ -46,7 +47,10 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     /* if the user has specified +lon_0 or +k0 for some reason,
     we're going to ignore it so that xy is consistent with point O */
     lp.lam = lp.lam + P->lam0;
-    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     xy.x = lp.lam;
     xy.y = -log(pj_tsfn(lp.phi, sin(lp.phi), P->e)); /* Mercator transform xy*/
     oy = -log(pj_tsfn(PT_O_PHI, sin(PT_O_PHI), P->e));
@@ -74,7 +78,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     double l2;
     double ry;
     lp.lam = lp.lam + P->lam0;
-    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
+    if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     xy.x = lp.lam;
     xy.y = log(tan(M_FORTPI + .5 * lp.phi));
     oy = log(tan(M_FORTPI + .5 * PT_O_PHI));

--- a/src/PJ_cc.c
+++ b/src/PJ_cc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(cc, "Central Cylindrical") "\n\tCyl, Sph";
 #define EPS10 1.e-10
@@ -7,19 +8,22 @@ PROJ_HEAD(cc, "Central Cylindrical") "\n\tCyl, Sph";
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
-	if (fabs (fabs(lp.phi) - M_HALFPI) <= EPS10) F_ERROR;
-	xy.x = lp.lam;
-	xy.y = tan(lp.phi);
-	return xy;
+    if (fabs (fabs(lp.phi) - M_HALFPI) <= EPS10) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
+    xy.x = lp.lam;
+    xy.y = tan(lp.phi);
+    return xy;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
-	(void) P;
-	lp.phi = atan(xy.y);
-	lp.lam = xy.x;
-	return lp;
+    (void) P;
+    lp.phi = atan(xy.y);
+    lp.lam = xy.x;
+    return lp;
 }
 
 

--- a/src/PJ_chamb.c
+++ b/src/PJ_chamb.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 typedef struct { double r, Az; } VECT;
 struct pj_opaque {
@@ -130,7 +131,10 @@ PJ *PROJECTION(chamb) {
         j = i == 2 ? 0 : i + 1;
         Q->c[i].v = vect(P->ctx,Q->c[j].phi - Q->c[i].phi, Q->c[i].cosphi, Q->c[i].sinphi,
             Q->c[j].cosphi, Q->c[j].sinphi, Q->c[j].lam - Q->c[i].lam);
-        if (Q->c[i].v.r == 0.0) E_ERROR(-25);
+        if (Q->c[i].v.r == 0.0) {
+            proj_errno_set(P, PJD_ERR_CONTROL_POINT_NO_DIST);
+            return freeup_new(P);
+        }
         /* co-linearity problem ignored for now */
     }
     Q->beta_0 = lc(P->ctx,Q->c[0].v.r, Q->c[2].v.r, Q->c[1].v.r);

--- a/src/PJ_collg.c
+++ b/src/PJ_collg.c
@@ -1,37 +1,43 @@
 #define PJ_LIB__
-# include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(collg, "Collignon") "\n\tPCyl, Sph.";
-#define FXC	1.12837916709551257390
-#define FYC	1.77245385090551602729
-#define ONEEPS	1.0000001
+#define FXC 1.12837916709551257390
+#define FYC 1.77245385090551602729
+#define ONEEPS  1.0000001
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
-	(void) P;
-	if ((xy.y = 1. - sin(lp.phi)) <= 0.)
-		xy.y = 0.;
-	else
-		xy.y = sqrt(xy.y);
-	xy.x = FXC * lp.lam * xy.y;
-	xy.y = FYC * (1. - xy.y);
-	return (xy);
+    (void) P;
+    if ((xy.y = 1. - sin(lp.phi)) <= 0.)
+        xy.y = 0.;
+    else
+        xy.y = sqrt(xy.y);
+    xy.x = FXC * lp.lam * xy.y;
+    xy.y = FYC * (1. - xy.y);
+    return (xy);
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
-	lp.phi = xy.y / FYC - 1.;
-	if (fabs(lp.phi = 1. - lp.phi * lp.phi) < 1.)
-		lp.phi = asin(lp.phi);
-	else if (fabs(lp.phi) > ONEEPS) I_ERROR
-	else	lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
-	if ((lp.lam = 1. - sin(lp.phi)) <= 0.)
-		lp.lam = 0.;
-	else
-		lp.lam = xy.x / (FXC * sqrt(lp.lam));
-	return (lp);
+    lp.phi = xy.y / FYC - 1.;
+    if (fabs(lp.phi = 1. - lp.phi * lp.phi) < 1.)
+        lp.phi = asin(lp.phi);
+    else if (fabs(lp.phi) > ONEEPS) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    } else {
+        lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
+    }
+
+    if ((lp.lam = 1. - sin(lp.phi)) <= 0.)
+        lp.lam = 0.;
+    else
+        lp.lam = xy.x / (FXC * sqrt(lp.lam));
+    return (lp);
 }
 
 

--- a/src/PJ_eck2.c
+++ b/src/PJ_eck2.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-# include   <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(eck2, "Eckert II") "\n\tPCyl. Sph.";
 
@@ -28,9 +29,12 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     lp.lam = xy.x / (FXC * ( lp.phi = 2. - fabs(xy.y) / FYC) );
     lp.phi = (4. - lp.phi * lp.phi) * C13;
     if (fabs(lp.phi) >= 1.) {
-        if (fabs(lp.phi) > ONEEPS)  I_ERROR
-        else
+        if (fabs(lp.phi) > ONEEPS) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        } else {
             lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
+        }
     } else
         lp.phi = asin(lp.phi);
     if (xy.y < 0)

--- a/src/PJ_eqc.c
+++ b/src/PJ_eqc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 struct pj_opaque {
     double rc;
@@ -54,7 +55,10 @@ PJ *PROJECTION(eqc) {
         return freeup_new (P);
     P->opaque = Q;
 
-    if ((Q->rc = cos(pj_param(P->ctx, P->params, "rlat_ts").f)) <= 0.) E_ERROR(-24);
+    if ((Q->rc = cos(pj_param(P->ctx, P->params, "rlat_ts").f)) <= 0.) {
+        proj_errno_set(P, PJD_ERR_LAT_TS_LARGER_THAN_90);
+        return freeup_new(P);
+    }
     P->inv = s_inverse;
     P->fwd = s_forward;
     P->es = 0.;

--- a/src/PJ_eqdc.c
+++ b/src/PJ_eqdc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 struct pj_opaque {
     double phi1;
@@ -96,9 +97,16 @@ PJ *PROJECTION(eqdc) {
 
     Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
     Q->phi2 = pj_param(P->ctx, P->params, "rlat_2").f;
-    if (fabs(Q->phi1 + Q->phi2) < EPS10) E_ERROR(-21);
+
+    if (fabs(Q->phi1 + Q->phi2) < EPS10) {
+        proj_errno_set(P, PJD_ERR_CONIC_LAT_EQUAL);
+        freeup_new(P);
+        return 0;
+    }
+
     if (!(Q->en = pj_enfn(P->es)))
-        E_ERROR_0;
+        return freeup_new(P);
+
     Q->n = sinphi = sin(Q->phi1);
     cosphi = cos(Q->phi1);
     secant = fabs(Q->phi1 - Q->phi2) >= EPS10;
@@ -122,6 +130,7 @@ PJ *PROJECTION(eqdc) {
         Q->c = Q->phi1 + cos(Q->phi1) / Q->n;
         Q->rho0 = Q->c - P->phi0;
     }
+
     P->inv = e_inverse;
     P->fwd = e_forward;
     P->spc = special;

--- a/src/PJ_fouc_s.c
+++ b/src/PJ_fouc_s.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(fouc_s, "Foucaut Sinusoidal") "\n\tPCyl., Sph.";
 
@@ -71,8 +72,10 @@ PJ *PROJECTION(fouc_s) {
     P->opaque = Q;
 
     Q->n = pj_param(P->ctx, P->params, "dn").f;
-    if (Q->n < 0. || Q->n > 1.)
-        E_ERROR(-99)
+    if (Q->n < 0. || Q->n > 1.) {
+        proj_errno_set(P, PJD_ERR_N_OUT_OF_RANGE);
+        return freeup_new(P);
+    }
     Q->n1 = 1. - Q->n;
     P->es = 0;
     P->inv = s_inverse;

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(gn_sinu, "General Sinusoidal Series") "\n\tPCyl, Sph.\n\tm= n=";
 PROJ_HEAD(sinu, "Sinusoidal (Sanson-Flamsteed)") "\n\tPCyl, Sph&Ell";
@@ -36,7 +37,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     } else if ((s - EPS10) < M_HALFPI) {
         lp.lam = 0.;
     } else {
-        I_ERROR;
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
     }
 
     return lp;
@@ -60,8 +61,11 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
             if (fabs(V) < LOOP_TOL)
                 break;
         }
-        if (!i)
-            F_ERROR
+        if (!i) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return xy;
+        }
+
     }
     xy.x = Q->C_x * lp.lam * (Q->m + cos(lp.phi));
     xy.y = Q->C_y * lp.phi;

--- a/src/PJ_gnom.c
+++ b/src/PJ_gnom.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(gnom, "Gnomonic") "\n\tAzi, Sph.";
 
@@ -40,7 +41,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
             break;
     }
 
-    if (xy.y <= EPS10) F_ERROR;
+    if (xy.y <= EPS10) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
 
     xy.x = (xy.y = 1. / xy.y) * cosphi * sin(lp.lam);
     switch (Q->mode) {

--- a/src/PJ_goode.c
+++ b/src/PJ_goode.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(goode, "Goode Homolosine") "\n\tPCyl, Sph.";
 
@@ -71,12 +72,12 @@ PJ *PROJECTION(goode) {
 
     P->es = 0.;
     if (!(Q->sinu = pj_sinu(0)) || !(Q->moll = pj_moll(0)))
-        E_ERROR_0;
+        return freeup_new(P);
     Q->sinu->es = 0.;
         Q->sinu->ctx = P->ctx;
         Q->moll->ctx = P->ctx;
     if (!(Q->sinu = pj_sinu(Q->sinu)) || !(Q->moll = pj_moll(Q->moll)))
-        E_ERROR_0;
+        return freeup_new(P);
 
     P->fwd = s_forward;
     P->inv = s_inverse;

--- a/src/PJ_hammer.c
+++ b/src/PJ_hammer.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(hammer, "Hammer & Eckert-Greifendorff")
     "\n\tMisc Sph, \n\tW= M=";
@@ -33,7 +34,7 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     if (fabs(2.*z*z-1.) < EPS) {
         lp.lam = HUGE_VAL;
         lp.phi = HUGE_VAL;
-        pj_errno = -14;
+        proj_errno_set(P, PJD_ERR_LAT_OR_LON_EXCEED_LIMIT);
     } else {
         lp.lam = aatan2(Q->w * xy.x * z,2. * z * z - 1)/Q->w;
         lp.phi = aasin(P->ctx,z * xy.y);
@@ -65,11 +66,17 @@ PJ *PROJECTION(hammer) {
     P->opaque = Q;
 
     if (pj_param(P->ctx, P->params, "tW").i) {
-        if ((Q->w = fabs(pj_param(P->ctx, P->params, "dW").f)) <= 0.) E_ERROR(-27);
+        if ((Q->w = fabs(pj_param(P->ctx, P->params, "dW").f)) <= 0.) {
+            proj_errno_set(P, PJD_ERR_W_OR_M_ZERO_OR_LESS);
+            return freeup_new(P);
+        }
     } else
         Q->w = .5;
     if (pj_param(P->ctx, P->params, "tM").i) {
-        if ((Q->m = fabs(pj_param(P->ctx, P->params, "dM").f)) <= 0.) E_ERROR(-27);
+        if ((Q->m = fabs(pj_param(P->ctx, P->params, "dM").f)) <= 0.) {
+            proj_errno_set(P, PJD_ERR_W_OR_M_ZERO_OR_LESS);
+            return freeup_new(P);
+        }
     } else
         Q->m = 1.;
 

--- a/src/PJ_hatano.c
+++ b/src/PJ_hatano.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(hatano, "Hatano Asymmetrical Equal Area") "\n\tPCyl, Sph.";
 
@@ -43,7 +44,8 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     th = xy.y * ( xy.y < 0. ? RYCS : RYCN);
     if (fabs(th) > 1.) {
         if (fabs(th) > ONETOL) {
-            I_ERROR;
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
         } else {
             th = th > 0. ? M_HALFPI : - M_HALFPI;
         }
@@ -56,7 +58,8 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     lp.phi = (th + sin(th)) * (xy.y < 0. ? RCS : RCN);
     if (fabs(lp.phi) > 1.) {
         if (fabs(lp.phi) > ONETOL) {
-           I_ERROR;
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
         } else {
             lp.phi = lp.phi > 0. ? M_HALFPI : - M_HALFPI;
         }

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -29,7 +29,8 @@
  * SOFTWARE.
  *****************************************************************************/
 # define PJ_LIB__
-# include <projects.h>
+# include <proj.h>
+# include "projects.h"
 
 PROJ_HEAD(healpix, "HEALPix") "\n\tSph., Ellps.";
 PROJ_HEAD(rhealpix, "rHEALPix") "\n\tSph., Ellps.\n\tnorth_square= south_square=";
@@ -649,10 +650,12 @@ PJ *PROJECTION(rhealpix) {
 
     /* Check for valid north_square and south_square inputs. */
     if (Q->north_square < 0 || Q->north_square > 3) {
-        E_ERROR(-47);
+        proj_errno_set(P, PJD_ERR_AXIS);
+        return freeup_new(P);
     }
     if (Q->south_square < 0 || Q->south_square > 3) {
-        E_ERROR(-47);
+        proj_errno_set(P, PJD_ERR_AXIS);
+        return freeup_new(P);
     }
     if (P->es != 0.0) {
         Q->apa = pj_authset(P->es); /* For auth_lat(). */

--- a/src/PJ_igh.c
+++ b/src/PJ_igh.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(igh, "Interrupted Goode Homolosine") "\n\tPCyl, Sph.";
 
@@ -175,8 +175,8 @@ static void freeup (PJ *P) {
 */
 
 #define SETUP(n, proj, x_0, y_0, lon_0) \
-    if (!(Q->pj[n-1] = pj_##proj(0))) E_ERROR_0; \
-    if (!(Q->pj[n-1] = pj_##proj(Q->pj[n-1]))) E_ERROR_0; \
+    if (!(Q->pj[n-1] = pj_##proj(0))) return freeup_new(P); \
+    if (!(Q->pj[n-1] = pj_##proj(Q->pj[n-1]))) return freeup_new(P); \
     Q->pj[n-1]->ctx = P->ctx; \
     Q->pj[n-1]->x0 = x_0; \
     Q->pj[n-1]->y0 = y_0; \

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -1034,7 +1034,8 @@ isea_forward(struct isea_dgg *g, struct isea_geo *in)
  */
 
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(isea, "Icosahedral Snyder Equal Area") "\n\tSph";
 
@@ -1099,7 +1100,8 @@ PJ *PROJECTION(isea) {
         } else if (!strcmp(opt, "pole")) {
             isea_orient_pole(&Q->dgg);
         } else {
-            E_ERROR(-34);
+            proj_errno_set(P, PJD_ERR_ELLIPSOID_USE_REQUIRED);
+            return freeup_new(P);
         }
     }
 
@@ -1138,7 +1140,8 @@ PJ *PROJECTION(isea) {
         }
         else {
             /* TODO verify error code.  Possibly eliminate magic */
-            E_ERROR(-34);
+            proj_errno_set(P, PJD_ERR_ELLIPSOID_USE_REQUIRED);
+            return freeup_new(P);
         }
     }
 

--- a/src/PJ_loxim.c
+++ b/src/PJ_loxim.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(loxim, "Loximuthal") "\n\tPCyl Sph";
 
@@ -72,8 +73,10 @@ PJ *PROJECTION(loxim) {
 
     Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
     Q->cosphi1 = cos(Q->phi1);
-    if (Q->cosphi1 < EPS)
-        E_ERROR(-22);
+    if (Q->cosphi1 < EPS) {
+        proj_errno_set(P, PJD_ERR_LAT_LARGER_THAN_90);
+        return freeup_new(P);
+    }
 
     Q->tanphi1 = tan(M_FORTPI + 0.5 * Q->phi1);
 

--- a/src/PJ_lsat.c
+++ b/src/PJ_lsat.c
@@ -1,6 +1,7 @@
 /* based upon Snyder and Linck, USGS-NMD */
 #define PJ_LIB__
-#include    <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(lsat, "Space oblique for LANDSAT")
     "\n\tCyl, Sph&Ell\n\tlsat= path=";
@@ -172,9 +173,15 @@ PJ *PROJECTION(lsat) {
     P->opaque = Q;
 
     land = pj_param(P->ctx, P->params, "ilsat").i;
-    if (land <= 0 || land > 5) E_ERROR(-28);
+    if (land <= 0 || land > 5) {
+        proj_errno_set(P, PJD_ERR_LSAT_NOT_IN_RANGE);
+        return freeup_new(P);
+    }
     path = pj_param(P->ctx, P->params, "ipath").i;
-    if (path <= 0 || path > (land <= 3 ? 251 : 233)) E_ERROR(-29);
+    if (path <= 0 || path > (land <= 3 ? 251 : 233)) {
+        proj_errno_set(P, PJD_ERR_PATH_NOT_IN_RANGE);
+        return freeup_new(P);
+    }
     if (land <= 3) {
         P->lam0 = DEG_TO_RAD * 128.87 - M_TWOPI / 251. * path;
         Q->p22 = 103.2669323;

--- a/src/PJ_mbtfpp.c
+++ b/src/PJ_mbtfpp.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(mbtfpp, "McBride-Thomas Flat-Polar Parabolic") "\n\tCyl., Sph.";
 
@@ -27,19 +28,23 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 
     lp.phi = xy.y / FYC;
     if (fabs(lp.phi) >= 1.) {
-        if (fabs(lp.phi) > ONEEPS)
-            I_ERROR
-        else
+        if (fabs(lp.phi) > ONEEPS) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        } else {
             lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
+        }
     } else
         lp.phi = asin(lp.phi);
 
     lp.lam = xy.x / ( FXC * (2. * cos(C23 * (lp.phi *= 3.)) - 1.) );
     if (fabs(lp.phi = sin(lp.phi) / CS) >= 1.) {
-        if (fabs(lp.phi) > ONEEPS)
-            I_ERROR
-        else
+        if (fabs(lp.phi) > ONEEPS) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        } else {
             lp.phi = (lp.phi < 0.) ? -M_HALFPI : M_HALFPI;
+        }
     } else
         lp.phi = asin(lp.phi);
 

--- a/src/PJ_mbtfpq.c
+++ b/src/PJ_mbtfpq.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(mbtfpq, "McBryde-Thomas Flat-Polar Quartic") "\n\tCyl., Sph.";
 
@@ -38,7 +39,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
 
     lp.phi = RYC * xy.y;
     if (fabs(lp.phi) > 1.) {
-        if (fabs(lp.phi) > ONETOL)  I_ERROR
+        if (fabs(lp.phi) > ONETOL) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        }
         else if (lp.phi < 0.) { t = -1.; lp.phi = -M_PI; }
         else { t = 1.; lp.phi = M_PI; }
     } else
@@ -46,7 +50,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     lp.lam = RXC * xy.x / (1. + 2. * cos(lp.phi)/cos(0.5 * lp.phi));
     lp.phi = RC * (t + sin(lp.phi));
     if (fabs(lp.phi) > 1.)
-        if (fabs(lp.phi) > ONETOL)  I_ERROR
+        if (fabs(lp.phi) > ONETOL) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        }
         else            lp.phi = lp.phi < 0. ? -M_HALFPI : M_HALFPI;
     else
         lp.phi = asin(lp.phi);

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -21,7 +21,8 @@
  *****************************************************************************/
 /* based upon Snyder and Linck, USGS-NMD */
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(misrsom, "Space oblique for MISR")
         "\n\tCyl, Sph&Ell\n\tpath=";
@@ -189,7 +190,10 @@ PJ *PROJECTION(misrsom) {
     P->opaque = Q;
 
     path = pj_param(P->ctx, P->params, "ipath").i;
-    if (path <= 0 || path > 233) E_ERROR(-29);
+    if (path <= 0 || path > 233) {
+        proj_errno_set(P, PJD_ERR_PATH_NOT_IN_RANGE);
+        return freeup_new(P);
+    }
     P->lam0 = DEG_TO_RAD * 129.3056 - M_TWOPI / 233. * path;
     alf = 98.30382 * DEG_TO_RAD;
     Q->p22 = 98.88 / 1440.0;

--- a/src/PJ_oea.c
+++ b/src/PJ_oea.c
@@ -1,53 +1,54 @@
 #define PJ_LIB__
-#include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(oea, "Oblated Equal Area") "\n\tMisc Sph\n\tn= m= theta=";
 
 struct pj_opaque {
-	double	theta;
-	double	m, n;
-	double	two_r_m, two_r_n, rm, rn, hm, hn;
-	double	cp0, sp0;
+    double  theta;
+    double  m, n;
+    double  two_r_m, two_r_n, rm, rn, hm, hn;
+    double  cp0, sp0;
 };
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double Az, M, N, cp, sp, cl, shz;
+    double Az, M, N, cp, sp, cl, shz;
 
-	cp = cos(lp.phi);
-	sp = sin(lp.phi);
-	cl = cos(lp.lam);
-	Az = aatan2(cp * sin(lp.lam), Q->cp0 * sp - Q->sp0 * cp * cl) + Q->theta;
-	shz = sin(0.5 * aacos(P->ctx, Q->sp0 * sp + Q->cp0 * cp * cl));
-	M = aasin(P->ctx, shz * sin(Az));
-	N = aasin(P->ctx, shz * cos(Az) * cos(M) / cos(M * Q->two_r_m));
-	xy.y = Q->n * sin(N * Q->two_r_n);
-	xy.x = Q->m * sin(M * Q->two_r_m) * cos(N) / cos(N * Q->two_r_n);
+    cp = cos(lp.phi);
+    sp = sin(lp.phi);
+    cl = cos(lp.lam);
+    Az = aatan2(cp * sin(lp.lam), Q->cp0 * sp - Q->sp0 * cp * cl) + Q->theta;
+    shz = sin(0.5 * aacos(P->ctx, Q->sp0 * sp + Q->cp0 * cp * cl));
+    M = aasin(P->ctx, shz * sin(Az));
+    N = aasin(P->ctx, shz * cos(Az) * cos(M) / cos(M * Q->two_r_m));
+    xy.y = Q->n * sin(N * Q->two_r_n);
+    xy.x = Q->m * sin(M * Q->two_r_m) * cos(N) / cos(N * Q->two_r_n);
 
-	return xy;
+    return xy;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double N, M, xp, yp, z, Az, cz, sz, cAz;
+    double N, M, xp, yp, z, Az, cz, sz, cAz;
 
-	N = Q->hn * aasin(P->ctx,xy.y * Q->rn);
-	M = Q->hm * aasin(P->ctx,xy.x * Q->rm * cos(N * Q->two_r_n) / cos(N));
-	xp = 2. * sin(M);
-	yp = 2. * sin(N) * cos(M * Q->two_r_m) / cos(M);
-	cAz = cos(Az = aatan2(xp, yp) - Q->theta);
-	z = 2. * aasin(P->ctx, 0.5 * hypot(xp, yp));
-	sz = sin(z);
-	cz = cos(z);
-	lp.phi = aasin(P->ctx, Q->sp0 * cz + Q->cp0 * sz * cAz);
-	lp.lam = aatan2(sz * sin(Az),
-		Q->cp0 * cz - Q->sp0 * sz * cAz);
+    N = Q->hn * aasin(P->ctx,xy.y * Q->rn);
+    M = Q->hm * aasin(P->ctx,xy.x * Q->rm * cos(N * Q->two_r_n) / cos(N));
+    xp = 2. * sin(M);
+    yp = 2. * sin(N) * cos(M * Q->two_r_m) / cos(M);
+    cAz = cos(Az = aatan2(xp, yp) - Q->theta);
+    z = 2. * aasin(P->ctx, 0.5 * hypot(xp, yp));
+    sz = sin(z);
+    cz = cos(z);
+    lp.phi = aasin(P->ctx, Q->sp0 * cz + Q->cp0 * sz * cAz);
+    lp.lam = aatan2(sz * sin(Az),
+        Q->cp0 * cz - Q->sp0 * sz * cAz);
 
-	return lp;
+    return lp;
 }
 
 
@@ -73,25 +74,24 @@ PJ *PROJECTION(oea) {
         return freeup_new (P);
     P->opaque = Q;
 
-	if (((Q->n = pj_param(P->ctx, P->params, "dn").f) <= 0.) ||
-		((Q->m = pj_param(P->ctx, P->params, "dm").f) <= 0.))
-        {
-		E_ERROR(-39)
-        }
-	else {
-		Q->theta = pj_param(P->ctx, P->params, "rtheta").f;
-		Q->sp0 = sin(P->phi0);
-		Q->cp0 = cos(P->phi0);
-		Q->rn = 1./ Q->n;
-		Q->rm = 1./ Q->m;
-		Q->two_r_n = 2. * Q->rn;
-		Q->two_r_m = 2. * Q->rm;
-		Q->hm = 0.5 * Q->m;
-		Q->hn = 0.5 * Q->n;
-		P->fwd = s_forward;
-		P->inv = s_inverse;
-		P->es = 0.;
-	}
+    if (((Q->n = pj_param(P->ctx, P->params, "dn").f) <= 0.) ||
+        ((Q->m = pj_param(P->ctx, P->params, "dm").f) <= 0.)) {
+            proj_errno_set(P, PJD_ERR_INVALID_M_OR_N);
+            return freeup_new(P);
+    } else {
+        Q->theta = pj_param(P->ctx, P->params, "rtheta").f;
+        Q->sp0 = sin(P->phi0);
+        Q->cp0 = cos(P->phi0);
+        Q->rn = 1./ Q->n;
+        Q->rm = 1./ Q->m;
+        Q->two_r_n = 2. * Q->rn;
+        Q->two_r_m = 2. * Q->rm;
+        Q->hm = 0.5 * Q->m;
+        Q->hn = 0.5 * Q->n;
+        P->fwd = s_forward;
+        P->inv = s_inverse;
+        P->es = 0.;
+    }
 
     return P;
 }

--- a/src/PJ_poly.c
+++ b/src/PJ_poly.c
@@ -1,17 +1,18 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(poly, "Polyconic (American)")
-	"\n\tConic, Sph&Ell";
+    "\n\tConic, Sph&Ell";
 
 struct pj_opaque {
-	double ml0; \
-	double *en;
+    double ml0; \
+    double *en;
 };
 
-#define TOL	1e-10
-#define CONV	1e-10
-#define N_ITER	10
+#define TOL 1e-10
+#define CONV    1e-10
+#define N_ITER  10
 #define I_ITER 20
 #define ITOL 1.e-12
 
@@ -19,37 +20,37 @@ struct pj_opaque {
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double  ms, sp, cp;
+    double  ms, sp, cp;
 
-	if (fabs(lp.phi) <= TOL) {
+    if (fabs(lp.phi) <= TOL) {
         xy.x = lp.lam;
         xy.y = -Q->ml0;
     } else {
-		sp = sin(lp.phi);
-		ms = fabs(cp = cos(lp.phi)) > TOL ? pj_msfn(sp, cp, P->es) / sp : 0.;
-		xy.x = ms * sin(lp.lam *= sp);
-		xy.y = (pj_mlfn(lp.phi, sp, cp, Q->en) - Q->ml0) + ms * (1. - cos(lp.lam));
-	}
+        sp = sin(lp.phi);
+        ms = fabs(cp = cos(lp.phi)) > TOL ? pj_msfn(sp, cp, P->es) / sp : 0.;
+        xy.x = ms * sin(lp.lam *= sp);
+        xy.y = (pj_mlfn(lp.phi, sp, cp, Q->en) - Q->ml0) + ms * (1. - cos(lp.lam));
+    }
 
-	return xy;
+    return xy;
 }
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double  cot, E;
+    double  cot, E;
 
-	if (fabs(lp.phi) <= TOL) {
+    if (fabs(lp.phi) <= TOL) {
         xy.x = lp.lam;
         xy.y = Q->ml0;
     } else {
-		cot = 1. / tan(lp.phi);
-		xy.x = sin(E = lp.lam * sin(lp.phi)) * cot;
-		xy.y = lp.phi - P->phi0 + cot * (1. - cos(E));
-	}
+        cot = 1. / tan(lp.phi);
+        xy.x = sin(E = lp.lam * sin(lp.phi)) * cot;
+        xy.y = lp.phi - P->phi0 + cot * (1. - cos(E));
+    }
 
-	return xy;
+    return xy;
 }
 
 
@@ -57,64 +58,71 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
 
-	xy.y += Q->ml0;
-	if (fabs(xy.y) <= TOL) {
+    xy.y += Q->ml0;
+    if (fabs(xy.y) <= TOL) {
         lp.lam = xy.x;
         lp.phi = 0.;
     } else {
-		double r, c, sp, cp, s2ph, ml, mlb, mlp, dPhi;
-		int i;
+        double r, c, sp, cp, s2ph, ml, mlb, mlp, dPhi;
+        int i;
 
-		r = xy.y * xy.y + xy.x * xy.x;
-		for (lp.phi = xy.y, i = I_ITER; i ; --i) {
-			sp = sin(lp.phi);
-			s2ph = sp * ( cp = cos(lp.phi));
-			if (fabs(cp) < ITOL)
-				I_ERROR;
-			c = sp * (mlp = sqrt(1. - P->es * sp * sp)) / cp;
-			ml = pj_mlfn(lp.phi, sp, cp, Q->en);
-			mlb = ml * ml + r;
-			mlp = P->one_es / (mlp * mlp * mlp);
-			lp.phi += ( dPhi =
-				( ml + ml + c * mlb - 2. * xy.y * (c * ml + 1.) ) / (
-				P->es * s2ph * (mlb - 2. * xy.y * ml) / c +
-				2.* (xy.y - ml) * (c * mlp - 1. / s2ph) - mlp - mlp ));
-			if (fabs(dPhi) <= ITOL)
-				break;
-		}
-		if (!i)
-			I_ERROR;
-		c = sin(lp.phi);
-		lp.lam = asin(xy.x * tan(lp.phi) * sqrt(1. - P->es * c * c)) / sin(lp.phi);
-	}
+        r = xy.y * xy.y + xy.x * xy.x;
+        for (lp.phi = xy.y, i = I_ITER; i ; --i) {
+            sp = sin(lp.phi);
+            s2ph = sp * ( cp = cos(lp.phi));
+            if (fabs(cp) < ITOL) {
+                proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+                return lp;
+            }
+            c = sp * (mlp = sqrt(1. - P->es * sp * sp)) / cp;
+            ml = pj_mlfn(lp.phi, sp, cp, Q->en);
+            mlb = ml * ml + r;
+            mlp = P->one_es / (mlp * mlp * mlp);
+            lp.phi += ( dPhi =
+                ( ml + ml + c * mlb - 2. * xy.y * (c * ml + 1.) ) / (
+                P->es * s2ph * (mlb - 2. * xy.y * ml) / c +
+                2.* (xy.y - ml) * (c * mlp - 1. / s2ph) - mlp - mlp ));
+            if (fabs(dPhi) <= ITOL)
+                break;
+        }
+        if (!i) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        }
+        c = sin(lp.phi);
+        lp.lam = asin(xy.x * tan(lp.phi) * sqrt(1. - P->es * c * c)) / sin(lp.phi);
+    }
 
-	return lp;
+    return lp;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
-	double B, dphi, tp;
-	int i;
+    double B, dphi, tp;
+    int i;
 
-	if (fabs(xy.y = P->phi0 + xy.y) <= TOL) {
+    if (fabs(xy.y = P->phi0 + xy.y) <= TOL) {
         lp.lam = xy.x;
         lp.phi = 0.;
     } else {
-		lp.phi = xy.y;
-		B = xy.x * xy.x + xy.y * xy.y;
-		i = N_ITER;
-		do {
-			tp = tan(lp.phi);
-			lp.phi -= (dphi = (xy.y * (lp.phi * tp + 1.) - lp.phi -
-				.5 * ( lp.phi * lp.phi + B) * tp) /
-				((lp.phi - xy.y) / tp - 1.));
-		} while (fabs(dphi) > CONV && --i);
-		if (! i) I_ERROR;
-		lp.lam = asin(xy.x * tan(lp.phi)) / sin(lp.phi);
-	}
+        lp.phi = xy.y;
+        B = xy.x * xy.x + xy.y * xy.y;
+        i = N_ITER;
+        do {
+            tp = tan(lp.phi);
+            lp.phi -= (dphi = (xy.y * (lp.phi * tp + 1.) - lp.phi -
+                .5 * ( lp.phi * lp.phi + B) * tp) /
+                ((lp.phi - xy.y) / tp - 1.));
+        } while (fabs(dphi) > CONV && --i);
+        if (! i) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return lp;
+        }
+        lp.lam = asin(xy.x * tan(lp.phi)) / sin(lp.phi);
+    }
 
-	return lp;
+    return lp;
 }
 
 
@@ -142,16 +150,16 @@ PJ *PROJECTION(poly) {
         return freeup_new (P);
     P->opaque = Q;
 
-	if (P->es != 0.0) {
-		if (!(Q->en = pj_enfn(P->es))) E_ERROR_0;
-		Q->ml0 = pj_mlfn(P->phi0, sin(P->phi0), cos(P->phi0), Q->en);
-		P->inv = e_inverse;
-		P->fwd = e_forward;
-	} else {
-		Q->ml0 = -P->phi0;
-		P->inv = s_inverse;
-		P->fwd = s_forward;
-	}
+    if (P->es != 0.0) {
+        if (!(Q->en = pj_enfn(P->es))) return freeup_new(P);
+        Q->ml0 = pj_mlfn(P->phi0, sin(P->phi0), cos(P->phi0), Q->en);
+        P->inv = e_inverse;
+        P->fwd = e_forward;
+    } else {
+        Q->ml0 = -P->phi0;
+        P->inv = s_inverse;
+        P->fwd = s_forward;
+    }
 
     return P;
 }

--- a/src/PJ_somerc.c
+++ b/src/PJ_somerc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(somerc, "Swiss. Obl. Mercator") "\n\tCyl, Ell\n\tFor CH1903";
 
@@ -54,8 +55,10 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     if (i) {
         lp.phi = phip;
         lp.lam = lamp / Q->c;
-    } else
-        I_ERROR
+    } else {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    }
     return (lp);
 }
 

--- a/src/PJ_tcc.c
+++ b/src/PJ_tcc.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(tcc, "Transverse Central Cylindrical") "\n\tCyl, Sph, no inv.";
 
@@ -11,7 +12,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     double b, bt;
 
     b = cos (lp.phi) * sin (lp.lam);
-    if ((bt = 1. - b * b) < EPS10) F_ERROR;
+    if ((bt = 1. - b * b) < EPS10) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     xy.x = b / sqrt(bt);
     xy.y = atan2 (tan (lp.phi) , cos (lp.lam));
     return xy;

--- a/src/PJ_tpeqd.c
+++ b/src/PJ_tpeqd.c
@@ -1,56 +1,57 @@
 #define PJ_LIB__
-#include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 
 PROJ_HEAD(tpeqd, "Two Point Equidistant")
-	"\n\tMisc Sph\n\tlat_1= lon_1= lat_2= lon_2=";
+    "\n\tMisc Sph\n\tlat_1= lon_1= lat_2= lon_2=";
 
 struct pj_opaque {
-	double cp1, sp1, cp2, sp2, ccs, cs, sc, r2z0, z02, dlam2; \
-	double hz0, thz0, rhshz0, ca, sa, lp, lamc;
+    double cp1, sp1, cp2, sp2, ccs, cs, sc, r2z0, z02, dlam2; \
+    double hz0, thz0, rhshz0, ca, sa, lp, lamc;
 };
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0, 0.0};
     struct pj_opaque *Q = P->opaque;
-	double t, z1, z2, dl1, dl2, sp, cp;
+    double t, z1, z2, dl1, dl2, sp, cp;
 
-	sp = sin(lp.phi);
-	cp = cos(lp.phi);
-	z1 = aacos(P->ctx, Q->sp1 * sp + Q->cp1 * cp * cos (dl1 = lp.lam + Q->dlam2));
-	z2 = aacos(P->ctx, Q->sp2 * sp + Q->cp2 * cp * cos (dl2 = lp.lam - Q->dlam2));
-	z1 *= z1;
-	z2 *= z2;
+    sp = sin(lp.phi);
+    cp = cos(lp.phi);
+    z1 = aacos(P->ctx, Q->sp1 * sp + Q->cp1 * cp * cos (dl1 = lp.lam + Q->dlam2));
+    z2 = aacos(P->ctx, Q->sp2 * sp + Q->cp2 * cp * cos (dl2 = lp.lam - Q->dlam2));
+    z1 *= z1;
+    z2 *= z2;
 
-	xy.x = Q->r2z0 * (t = z1 - z2);
-	t = Q->z02 - t;
-	xy.y = Q->r2z0 * asqrt (4. * Q->z02 * z2 - t * t);
-	if ((Q->ccs * sp - cp * (Q->cs * sin(dl1) - Q->sc * sin(dl2))) < 0.)
-		xy.y = -xy.y;
-	return xy;
+    xy.x = Q->r2z0 * (t = z1 - z2);
+    t = Q->z02 - t;
+    xy.y = Q->r2z0 * asqrt (4. * Q->z02 * z2 - t * t);
+    if ((Q->ccs * sp - cp * (Q->cs * sin(dl1) - Q->sc * sin(dl2))) < 0.)
+        xy.y = -xy.y;
+    return xy;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0,0.0};
     struct pj_opaque *Q = P->opaque;
-	double cz1, cz2, s, d, cp, sp;
+    double cz1, cz2, s, d, cp, sp;
 
-	cz1 = cos (hypot(xy.y, xy.x + Q->hz0));
-	cz2 = cos (hypot(xy.y, xy.x - Q->hz0));
-	s = cz1 + cz2;
-	d = cz1 - cz2;
-	lp.lam = - atan2(d, (s * Q->thz0));
-	lp.phi = aacos(P->ctx, hypot (Q->thz0 * s, d) * Q->rhshz0);
-	if ( xy.y < 0. )
-		lp.phi = - lp.phi;
-	/* lam--phi now in system relative to P1--P2 base equator */
-	sp = sin (lp.phi);
-	cp = cos (lp.phi);
-	lp.phi = aasin (P->ctx, Q->sa * sp + Q->ca * cp * (s = cos(lp.lam -= Q->lp)));
-	lp.lam = atan2 (cp * sin(lp.lam), Q->sa * cp * s - Q->ca * sp) + Q->lamc;
-	return lp;
+    cz1 = cos (hypot(xy.y, xy.x + Q->hz0));
+    cz2 = cos (hypot(xy.y, xy.x - Q->hz0));
+    s = cz1 + cz2;
+    d = cz1 - cz2;
+    lp.lam = - atan2(d, (s * Q->thz0));
+    lp.phi = aacos(P->ctx, hypot (Q->thz0 * s, d) * Q->rhshz0);
+    if ( xy.y < 0. )
+        lp.phi = - lp.phi;
+    /* lam--phi now in system relative to P1--P2 base equator */
+    sp = sin (lp.phi);
+    cp = cos (lp.phi);
+    lp.phi = aasin (P->ctx, Q->sa * sp + Q->ca * cp * (s = cos(lp.lam -= Q->lp)));
+    lp.lam = atan2 (cp * sin(lp.lam), Q->sa * cp * s - Q->ca * sp) + Q->lamc;
+    return lp;
 }
 
 
@@ -70,48 +71,50 @@ static void freeup (PJ *P) {
 
 
 PJ *PROJECTION(tpeqd) {
-	double lam_1, lam_2, phi_1, phi_2, A12, pp;
+    double lam_1, lam_2, phi_1, phi_2, A12, pp;
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
     if (0==Q)
         return freeup_new (P);
     P->opaque = Q;
 
 
-	/* get control point locations */
-	phi_1 = pj_param(P->ctx, P->params, "rlat_1").f;
-	lam_1 = pj_param(P->ctx, P->params, "rlon_1").f;
-	phi_2 = pj_param(P->ctx, P->params, "rlat_2").f;
-	lam_2 = pj_param(P->ctx, P->params, "rlon_2").f;
+    /* get control point locations */
+    phi_1 = pj_param(P->ctx, P->params, "rlat_1").f;
+    lam_1 = pj_param(P->ctx, P->params, "rlon_1").f;
+    phi_2 = pj_param(P->ctx, P->params, "rlat_2").f;
+    lam_2 = pj_param(P->ctx, P->params, "rlon_2").f;
 
-	if (phi_1 == phi_2 && lam_1 == lam_2)
-        E_ERROR(-25);
-	P->lam0  = adjlon (0.5 * (lam_1 + lam_2));
-	Q->dlam2 = adjlon (lam_2 - lam_1);
+    if (phi_1 == phi_2 && lam_1 == lam_2) {
+        proj_errno_set(P, PJD_ERR_CONTROL_POINT_NO_DIST);
+        return freeup_new(P);
+    }
+    P->lam0  = adjlon (0.5 * (lam_1 + lam_2));
+    Q->dlam2 = adjlon (lam_2 - lam_1);
 
-	Q->cp1 = cos (phi_1);
-	Q->cp2 = cos (phi_2);
-	Q->sp1 = sin (phi_1);
-	Q->sp2 = sin (phi_2);
-	Q->cs = Q->cp1 * Q->sp2;
-	Q->sc = Q->sp1 * Q->cp2;
-	Q->ccs = Q->cp1 * Q->cp2 * sin(Q->dlam2);
-	Q->z02 = aacos(P->ctx, Q->sp1 * Q->sp2 + Q->cp1 * Q->cp2 * cos (Q->dlam2));
-	Q->hz0 = .5 * Q->z02;
-	A12 = atan2(Q->cp2 * sin (Q->dlam2),
-		Q->cp1 * Q->sp2 - Q->sp1 * Q->cp2 * cos (Q->dlam2));
-	Q->ca = cos(pp = aasin(P->ctx, Q->cp1 * sin(A12)));
-	Q->sa = sin(pp);
-	Q->lp = adjlon ( atan2 (Q->cp1 * cos(A12), Q->sp1) - Q->hz0);
-	Q->dlam2 *= .5;
-	Q->lamc = M_HALFPI - atan2(sin(A12) * Q->sp1, cos(A12)) - Q->dlam2;
-	Q->thz0 = tan (Q->hz0);
-	Q->rhshz0 = .5 / sin (Q->hz0);
-	Q->r2z0 = 0.5 / Q->z02;
-	Q->z02 *= Q->z02;
+    Q->cp1 = cos (phi_1);
+    Q->cp2 = cos (phi_2);
+    Q->sp1 = sin (phi_1);
+    Q->sp2 = sin (phi_2);
+    Q->cs = Q->cp1 * Q->sp2;
+    Q->sc = Q->sp1 * Q->cp2;
+    Q->ccs = Q->cp1 * Q->cp2 * sin(Q->dlam2);
+    Q->z02 = aacos(P->ctx, Q->sp1 * Q->sp2 + Q->cp1 * Q->cp2 * cos (Q->dlam2));
+    Q->hz0 = .5 * Q->z02;
+    A12 = atan2(Q->cp2 * sin (Q->dlam2),
+        Q->cp1 * Q->sp2 - Q->sp1 * Q->cp2 * cos (Q->dlam2));
+    Q->ca = cos(pp = aasin(P->ctx, Q->cp1 * sin(A12)));
+    Q->sa = sin(pp);
+    Q->lp = adjlon ( atan2 (Q->cp1 * cos(A12), Q->sp1) - Q->hz0);
+    Q->dlam2 *= .5;
+    Q->lamc = M_HALFPI - atan2(sin(A12) * Q->sp1, cos(A12)) - Q->dlam2;
+    Q->thz0 = tan (Q->hz0);
+    Q->rhshz0 = .5 / sin (Q->hz0);
+    Q->r2z0 = 0.5 / Q->z02;
+    Q->z02 *= Q->z02;
 
     P->inv = s_inverse;
     P->fwd = s_forward;
-	P->es = 0.;
+    P->es = 0.;
 
     return P;
 }

--- a/src/PJ_urm5.c
+++ b/src/PJ_urm5.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(urm5, "Urmaev V") "\n\tPCyl., Sph., no inv.\n\tn= q= alpha=";
 
@@ -44,10 +45,14 @@ PJ *PROJECTION(urm5) {
     
     if (pj_param(P->ctx, P->params, "tn").i) {
         Q->n = pj_param(P->ctx, P->params, "dn").f;
-        if (Q->n <= 0. || Q->n > 1.)
-            E_ERROR(-40)
-    } else
-        E_ERROR(-40)
+        if (Q->n <= 0. || Q->n > 1.) {
+            proj_errno_set(P, PJD_ERR_N_OUT_OF_RANGE);
+            return freeup_new(0);
+        }
+    } else {
+            proj_errno_set(P, PJD_ERR_N_OUT_OF_RANGE);
+            return freeup_new(0);
+    }
     Q->q3 = pj_param(P->ctx, P->params, "dq").f / 3.;
     alpha = pj_param(P->ctx, P->params, "ralpha").f;
     t = Q->n * sin (alpha);

--- a/src/PJ_urmfps.c
+++ b/src/PJ_urmfps.c
@@ -1,11 +1,12 @@
 #define PJ_LIB__
-#include	<projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(urmfps, "Urmaev Flat-Polar Sinusoidal") "\n\tPCyl, Sph.\n\tn=";
 PROJ_HEAD(wag1, "Wagner I (Kavraisky VI)") "\n\tPCyl, Sph.";
 
 struct pj_opaque {
-	double	n, C_y;
+    double  n, C_y;
 };
 
 #define C_x 0.8773826753
@@ -14,19 +15,19 @@ struct pj_opaque {
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     XY xy = {0.0, 0.0};
-	lp.phi = aasin (P->ctx,P->opaque->n * sin (lp.phi));
-	xy.x = C_x * lp.lam * cos (lp.phi);
-	xy.y = P->opaque->C_y * lp.phi;
-	return xy;
+    lp.phi = aasin (P->ctx,P->opaque->n * sin (lp.phi));
+    xy.x = C_x * lp.lam * cos (lp.phi);
+    xy.y = P->opaque->C_y * lp.phi;
+    return xy;
 }
 
 
 static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
     LP lp = {0.0, 0.0};
-	xy.y /= P->opaque->C_y;
-	lp.phi = aasin(P->ctx, sin (xy.y) / P->opaque->n);
-	lp.lam = xy.x / (C_x * cos (xy.y));
-	return lp;
+    xy.y /= P->opaque->C_y;
+    lp.phi = aasin(P->ctx, sin (xy.y) / P->opaque->n);
+    lp.lam = xy.x / (C_x * cos (xy.y));
+    return lp;
 }
 
 
@@ -45,11 +46,11 @@ static void freeup (PJ *P) {
 }
 
 static PJ *setup(PJ *P) {
-	P->opaque->C_y = Cy / P->opaque->n;
-	P->es = 0.;
-	P->inv = s_inverse;
-	P->fwd = s_forward;
-	return P;
+    P->opaque->C_y = Cy / P->opaque->n;
+    P->es = 0.;
+    P->inv = s_inverse;
+    P->fwd = s_forward;
+    return P;
 }
 
 
@@ -59,12 +60,16 @@ PJ *PROJECTION(urmfps) {
         return freeup_new (P);
     P->opaque = Q;
 
-	if (pj_param(P->ctx, P->params, "tn").i) {
-		P->opaque->n = pj_param(P->ctx, P->params, "dn").f;
-		if (P->opaque->n <= 0. || P->opaque->n > 1.)
-			E_ERROR(-40)
-	} else
-		E_ERROR(-40)
+    if (pj_param(P->ctx, P->params, "tn").i) {
+        P->opaque->n = pj_param(P->ctx, P->params, "dn").f;
+        if (P->opaque->n <= 0. || P->opaque->n > 1.) {
+            proj_errno_set(P, PJD_ERR_N_OUT_OF_RANGE);
+            return freeup_new(P);
+        }
+    } else {
+        proj_errno_set(P, PJD_ERR_N_OUT_OF_RANGE);
+        return freeup_new(P);
+    }
 
     return setup(P);
 }
@@ -76,7 +81,7 @@ PJ *PROJECTION(wag1) {
         return freeup_new (P);
     P->opaque = Q;
 
-	P->opaque->n = 0.8660254037844386467637231707;
+    P->opaque->n = 0.8660254037844386467637231707;
     return setup(P);
 }
 

--- a/src/PJ_vandg.c
+++ b/src/PJ_vandg.c
@@ -1,5 +1,6 @@
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 PROJ_HEAD(vandg, "van der Grinten (I)") "\n\tMisc Sph";
 
@@ -18,7 +19,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     double  al, al2, g, g2, p2;
 
     p2 = fabs(lp.phi / M_HALFPI);
-    if ((p2 - TOL) > 1.) F_ERROR;
+    if ((p2 - TOL) > 1.) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
     if (p2 > 1.)
         p2 = 1.;
     if (fabs(lp.phi) <= TOL) {
@@ -41,7 +45,10 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         if (lp.lam < 0.) xy.x = -xy.x;
         xy.y = fabs(xy.x / M_PI);
         xy.y = 1. - xy.y * (xy.y + 2. * al);
-        if (xy.y < -TOL) F_ERROR;
+        if (xy.y < -TOL) {
+            proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+            return xy;
+        }
         if (xy.y < 0.)
             xy.y = 0.;
         else
@@ -81,8 +88,10 @@ static LP s_inverse (XY xy, PJ *P) {           /* Spheroidal, inverse */
         t = r2 + TPISQ * (x2 - y2 + HPISQ);
         lp.lam = fabs(xy.x) <= TOL ? 0. :
            .5 * (r - PISQ + (t <= 0. ? 0. : sqrt(t))) / xy.x;
-    } else
-        I_ERROR;
+    } else {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return lp;
+    }
 
     return lp;
 }

--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -60,6 +60,7 @@ pj_err_list[] = {
     "invalid scale",                                                   /* -52 */
     "non-convergent computation",                                      /* -53 */
     "missing required arguments",                                      /* -54 */
+    "lat_0 = 0",                                                       /* -55 */
 };
 
 char *pj_strerrno(int err) {

--- a/src/proj_rouss.c
+++ b/src/proj_rouss.c
@@ -24,7 +24,8 @@
 ** SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #define PJ_LIB__
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 struct pj_opaque {
     double s0;
@@ -105,7 +106,7 @@ PJ *PROJECTION(rouss) {
     P->opaque = Q;
 
     if (!((Q->en = proj_mdist_ini(P->es))))
-        E_ERROR_0;
+        return freeup_new(P);
     es2 = sin(P->phi0);
     Q->s0 = proj_mdist(P->phi0, es2, cos(P->phi0), Q->en);
     t = 1. - (es2 = P->es * es2 * es2);

--- a/src/projects.h
+++ b/src/projects.h
@@ -523,15 +523,37 @@ struct FACTORS {
 #define PJD_WGS84     4   /* WGS84 (or anything considered equivalent) */
 
 /* library errors */
-#define PJD_ERR_NO_ARGS              -1
-#define PJD_ERR_INVALID_M_OR_N      -39
-#define PJD_ERR_GEOCENTRIC          -45
-#define PJD_ERR_AXIS                -47
-#define PJD_ERR_GRID_AREA           -48
-#define PJD_ERR_CATALOG             -49
-#define PJD_ERR_INVALID_SCALE       -52
-#define PJD_ERR_NON_CONVERGENT      -53
-#define PJD_ERR_MISSING_ARGS        -54
+#define PJD_ERR_NO_ARGS                  -1
+#define PJD_ERR_LAT_OR_LON_EXCEED_LIMIT -14
+#define PJD_ERR_TOLERANCE_CONDITION     -20
+#define PJD_ERR_CONIC_LAT_EQUAL         -21
+#define PJD_ERR_LAT_LARGER_THAN_90      -22
+#define PJD_ERR_LAT1_IS_ZERO            -23
+#define PJD_ERR_LAT_TS_LARGER_THAN_90   -24
+#define PJD_ERR_CONTROL_POINT_NO_DIST   -25
+#define PJD_ERR_NO_ROTATION_PROJ        -26
+#define PJD_ERR_W_OR_M_ZERO_OR_LESS     -27
+#define PJD_ERR_LSAT_NOT_IN_RANGE       -28
+#define PJD_ERR_PATH_NOT_IN_RANGE       -29
+#define PJD_ERR_H_LESS_THAN_ZERO        -30
+#define PJD_ERR_LAT_1_OR_2_ZERO_OR_90   -32
+#define PJD_ERR_LAT_0_OR_ALPHA_EQ_90    -33
+#define PJD_ERR_ELLIPSOID_USE_REQUIRED  -34
+#define PJD_ERR_INVALID_UTM_ZONE        -35
+#define PJD_ERR_FAILED_TO_FIND_PROJ     -37
+#define PJD_ERR_INVALID_M_OR_N          -39
+#define PJD_ERR_N_OUT_OF_RANGE          -40
+#define PJD_ERR_ABS_LAT1_EQ_ABS_LAT2    -42
+#define PJD_ERR_LAT_0_HALF_PI_FROM_MEAN -43
+#define PJD_ERR_GEOCENTRIC              -45
+#define PJD_ERR_UNKNOWN_PRIME_MERIDIAN  -46
+#define PJD_ERR_AXIS                    -47
+#define PJD_ERR_GRID_AREA               -48
+#define PJD_ERR_INVALID_SWEEP_AXIS      -49
+#define PJD_ERR_INVALID_SCALE           -52
+#define PJD_ERR_NON_CONVERGENT          -53
+#define PJD_ERR_MISSING_ARGS            -54
+#define PJD_ERR_LAT_0_IS_ZERO           -55
 
 struct projFileAPI_t;
 
@@ -582,12 +604,6 @@ extern struct PJ_PRIME_MERIDIANS pj_prime_meridians[];
 #ifdef PJ_LIB__
 #define PROJ_HEAD(id, name) static const char des_##id [] = name
 
-#define E_ERROR(err) { pj_ctx_set_errno( P->ctx, err); freeup(P); return(0); }
-#define E_ERROR_0 { freeup(P); return(0); }
-#define F_ERROR { pj_ctx_set_errno( P->ctx, -20); return(xy); }
-#define F3_ERROR { pj_ctx_set_errno( P->ctx, -20); return(xyz); }
-#define I_ERROR { pj_ctx_set_errno( P->ctx, -20); return(lp); }
-#define I3_ERROR { pj_ctx_set_errno( P->ctx, -20); return(lpz); }
 
 #define PROJECTION(name)                                     \
 pj_projection_specific_setup_##name (PJ *P);                 \


### PR DESCRIPTION
Expanded `*_ERROR*` macros with calls to `proj_errno_set()` and proper
returns when necessary. Defined a bunch of new `PJD_ERR_*` constants in
projects.h that corresponds to the error numbers in `pj_strerrno.c`. A few
unknown error numbers were replaced by existing ones in `pj_strerrno.c`.

Fixes #432.