### PR TITLE
Adding info functions to proj.h API.

### DIFF
--- a/nad/CH
+++ b/nad/CH
@@ -16,6 +16,7 @@
 #
 # This init file uses the official one
 #
+<metadata> +origin=Swisstopo +lastupdate=2012-02-27
 # CH1903/LV03
 <1903_LV03>  +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +nadgrids=chenyx06etrs.gsb +no_defs
 # CH1903

--- a/nad/GL27
+++ b/nad/GL27
@@ -1,5 +1,6 @@
 # SCCSID @(#)GL27	1.1 93/08/25 GIE REL
 # Great Lakes Grids
+<metadata> +lastupdate=1993-08-25
 <erie-etal> # Lake Erie, Ontario and St. Lawrence River.
 	proj=omerc ellps=clrk66 k_0=0.9999
 	lonc=78d00'W lat_0=44d00'N alpha=55d40'

--- a/nad/IGNF
+++ b/nad/IGNF
@@ -1,3 +1,4 @@
+<metadata> +version=1.0.0 +origin=IGNF +lastupdate=2011-11-27
 # W [AMANU49]
 # W [AMANU63]
 <AMST63> +title=Ile d'Amsterdam 1963 +proj=geocent +towgs84=109.7530,-528.1330,-362.2440 +a=6378388.0000 +rf=297.0000000000000 +units=m +no_defs <>

--- a/nad/epsg
+++ b/nad/epsg
@@ -1,3 +1,4 @@
+<metadata> +version=9.0.0 +origin=EPSG +lastupdate=2017-01-10
 # HD1909
 <3819> +proj=longlat +ellps=bessel +towgs84=595.48,121.69,515.35,4.115,-2.9383,0.853,-3.408 +no_defs  <>
 # TWD67

--- a/nad/esri
+++ b/nad/esri
@@ -1,3 +1,4 @@
+<metadata> +origin=Esri +lastupdate=2017-02-26
 # Anguilla 1957 / British West Indies Grid
 <2000> +proj=tmerc +lat_0=0 +lon_0=-62 +k=0.999500 +x_0=400000 +y_0=0 +ellps=clrk80 +units=m +no_defs <>
 # Antigua 1943 / British West Indies Grid

--- a/nad/nad27
+++ b/nad/nad27
@@ -4,6 +4,7 @@
 #     State Plane Coordinate Systems,
 #     North American Datum 1927
 
+<metadata> +lastupdate=1992-12-20
 # 101: alabama east: nad27
 <101> proj=tmerc  datum=NAD27
 lon_0=-85d50 lat_0=30d30 k=.99996

--- a/nad/nad83
+++ b/nad/nad83
@@ -4,6 +4,7 @@
 #     State Plane Coordinate Systems,
 #     North American Datum 1983
 
+<metadata> +lastupdate=1992-12-20
 # 101: alabama east: nad83
 <101> proj=tmerc  datum=NAD83
 lon_0=-85d50 lat_0=30d30 k=.99996

--- a/nad/world
+++ b/nad/world
@@ -1,6 +1,8 @@
 # SCCSID @(#)world	1.2 95/08/05 GIE REL
 # proj +init files for various non-U.S. coordinate systems.
 #
+<metadata> +lastupdate=2016-12-12
+
 <CH1903> # Swiss Coordinate System
 	+proj=somerc +lat_0=46d57'8.660"N +lon_0=7d26'22.500"E
 	+ellps=bessel +x_0=600000 +y_0=200000

--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -237,6 +237,9 @@ int pj_cart_selftest (void) {
     PJ_OBS a, b, obs[2];
     PJ_COORD coord[2];
     PJ_INFO info;
+    PJ_PROJ_INFO pj_info;
+    PJ_GRID_INFO grid_info;
+    PJ_INIT_INFO init_info;
     int err;
     size_t n, sz;
     double dist, h, t;
@@ -492,21 +495,26 @@ int pj_cart_selftest (void) {
     proj_destroy(P);
 
     P = proj_create(0, arg);
-    if ( !proj_pj_info(P).has_inverse )            {  proj_destroy(P); return 61; }
-    if ( strcmp(proj_pj_info(P).definition, arg) ) {  proj_destroy(P); return 62; }
-    if ( strcmp(proj_pj_info(P).id, "utm") )       {  proj_destroy(P); return 63; }
+    pj_info = proj_pj_info(P);
+    if ( !pj_info.has_inverse )            {  proj_destroy(P); return 61; }
+    if ( strcmp(pj_info.definition, arg) ) {  proj_destroy(P); return 62; }
+    if ( strcmp(pj_info.id, "utm") )       {  proj_destroy(P); return 63; }
     proj_destroy(P);
 
     /* proj_grid_info() */
-    if ( proj_grid_info("nonexistinggrid").filename[0] != '\0' )           return 64;
-    if ( proj_grid_info("egm96_15.gtx").filename[0] == '\0' )              return 65;
-    if ( strcmp(proj_grid_info("egm96_15.gtx").gridname, "egm96_15.gtx") ) return 66;
+    grid_info = proj_grid_info("egm96_15.gtx");
+    if ( strlen(grid_info.filename) == 0 )            return 64;
+    if ( strcmp(grid_info.gridname, "egm96_15.gtx") ) return 65;
+    grid_info = proj_grid_info("nonexistinggrid");
+    if ( strlen(grid_info.filename) > 0 )             return 66;
 
     /* proj_init_info() */
-    if ( strcmp(proj_init_info("epsg").origin, "EPSG") )  return 69;
-    if ( strcmp(proj_init_info("epsg").name, "epsg") )    return 68;
-    if ( proj_init_info("unknown").filename[0] != '\0' )  return 67;
+    init_info = proj_init_info("unknowninit");
+    if ( strlen(init_info.filename) != 0 )  return 67;
 
+    init_info = proj_init_info("epsg");
+    if ( strcmp(init_info.origin, "EPSG") )    return 69;
+    if ( strcmp(init_info.name, "epsg") )      return 68;
 
 
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -243,8 +243,9 @@ get_opt(projCtx ctx, paralist **start, PAFile fid, char *name, paralist *next,
         else
         {
             /* skip past word */
-            while( *next_char && !isspace(*next_char) )
+            while( *next_char && !isspace(*next_char) ) {
                 next_char++;
+            }
 
         }
     }
@@ -253,7 +254,6 @@ get_opt(projCtx ctx, paralist **start, PAFile fid, char *name, paralist *next,
         errno = 0;
 
     free(state);
-
     return next;
 }
 
@@ -280,8 +280,7 @@ get_defaults(projCtx ctx, paralist **start, paralist *next, char *name) {
 /************************************************************************/
 /*                              get_init()                              */
 /************************************************************************/
-static paralist *
-get_init(projCtx ctx, paralist **start, paralist *next, char *name, int *found_def) {
+static paralist *get_init(projCtx ctx, paralist **start, paralist *next, char *name, int *found_def) {
     char fname[MAX_PATH_FILENAME+ID_TAG_MAX+3], *opt;
     PAFile fid;
     paralist *init_items = NULL;
@@ -328,6 +327,10 @@ get_init(projCtx ctx, paralist **start, paralist *next, char *name, int *found_d
         pj_insert_initcache( name, orig_next->next );
 
     return next;
+}
+
+paralist * pj_get_init(projCtx ctx, paralist **start, paralist *next, char *name, int *found_def) {
+    return get_init(ctx, start, next, name, found_def);
 }
 
 /************************************************************************/
@@ -466,7 +469,7 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
         }
     }
 
-    /* in cae the parameter list only consist of a +init parameter
+    /* in case the parameter list only consist of a +init parameter
        it is expanded here (will not be handled in the above loop). */
     if (pj_param(ctx, start, "tinit").i && argc == 1) {
         found_def = 0;

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -167,6 +167,53 @@ void proj_context_inherit (PJ *parent, PJ *child) {
 
 
 
+size_t pj_strlcpy(char *dst, const char *src, size_t siz) {
+/*******************************************************************
+   Copy src to string dst of size siz.  At most siz-1 characters
+   will be copied.  Always NUL terminates (unless siz == 0).
+   Returns strlen(src); if retval >= siz, truncation occurred.
+
+
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+  Source: http://www.i-pi.com/Training/EthicalHacking/Solutions/strlcpy.c
+
+********************************************************************/
+    register char *d = dst;
+    register const char *s = src;
+    register size_t n = siz;
+
+    /* Copy as many bytes as will fit */
+    if (n != 0 && --n != 0) {
+        do {
+            if ((*d++ = *s++) == 0)
+                break;
+        } while (--n != 0);
+    }
+
+    /* Not enough room in dst, add NUL and traverse rest of src */
+    if (n == 0) {
+        if (siz != 0)
+            *d = '\0';      /* NUL-terminate dst */
+        while (*s++)
+            ;
+    }
+
+    return(s - src - 1);    /* count does not include NUL */
+}
+
 
 
 /* stuff below is *not* considered API, and will be moved to an "internal plumbing toolset" */

--- a/src/pj_obs_api.c
+++ b/src/pj_obs_api.c
@@ -510,25 +510,198 @@ void proj_context_destroy (PJ_CONTEXT *ctx) {
 }
 
 
-/* Build a fully expanded proj_create() compatible representation of P */
-char *proj_definition_retrieve (PJ *P) {
-    if (0==P)
-        return 0;
-    return pj_get_def(P, 0);
+/*****************************************************************************/
+PJ_INFO proj_info(void) {
+/******************************************************************************
+    Basic info about the current instance of the PROJ.4 library.
+
+    Returns PJ_INFO struct. Searchpath member of the struct is truncated to 512
+    characters.
+
+******************************************************************************/
+    PJ_INFO info;
+    const char **paths;
+    char *tmpstr;
+    int i, n;
+
+    info.major = PROJ_VERSION_MAJOR;
+    info.minor = PROJ_VERSION_MINOR;
+    info.patch = PROJ_VERSION_PATCH;
+    sprintf(info.version, "%d.%d.%d", info.major, info.minor, info.patch);
+    strcpy(info.release, pj_get_release());
+
+    paths = proj_get_searchpath();
+    n = proj_get_path_count();
+    /* build search path string */
+    tmpstr = getenv("HOME");
+    if (tmpstr != NULL) {
+        sprintf(info.searchpath, "%s", tmpstr);
+    }
+
+    tmpstr = getenv("PROJ_LIB");
+    if (info.searchpath != NULL) {
+        /* $HOME already in path */
+        if (tmpstr != NULL)
+            sprintf(info.searchpath, "%s;%s", info.searchpath, tmpstr);
+    } else {
+        /* path is empty */
+        if (tmpstr != NULL)
+            sprintf(info.searchpath, "%s", getenv("HOME"));
+    }
+
+    for (i=0; i<n; i++) {
+        if (strlen(info.searchpath)+strlen(paths[i]) >= 512)
+            continue;
+
+        if (info.searchpath != NULL)
+            sprintf(info.searchpath, "%s;%s", info.searchpath, paths[i]);
+        else
+            sprintf(info.searchpath, "%s", paths[i]);
+    }
+
+    return info;
 }
 
-/* ...and get rid of it safely */
-void *proj_release (void *buffer) {
-    return pj_dealloc (buffer);
+/*****************************************************************************/
+PJ_PROJ_INFO proj_pj_info(const PJ *P) {
+/******************************************************************************
+    Basic info about a particular instance of a projection object.
+
+    Returns PJ_PROJ_INFO struct.
+
+******************************************************************************/
+    PJ_PROJ_INFO info;
+    char *def;
+
+    /* projection id */
+    if (pj_param(P->ctx, P->params, "tproj").i)
+        strncpy(info.id, pj_param(P->ctx, P->params, "sproj").s, sizeof(info.id));
+
+    /* projection description */
+    strncpy(info.description, P->descr, sizeof(info.description));
+
+    /* projection definition */
+    def = pj_get_def((PJ *)P, 0); /* pj_get_def takes a non-const PJ pointer */
+    strncpy(info.definition, &def[1], sizeof(info.definition)); /* def includes a leading space */
+    pj_dealloc(def);
+
+    /* this does not take into account that a pipeline potentially does not */
+    /* have an inverse.                                                     */
+    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->invobs != 0);
+
+    return info;
+}
+
+
+/*****************************************************************************/
+PJ_GRID_INFO proj_grid_info(const char *gridname) {
+/******************************************************************************
+    Information about a named datum grid.
+
+    Returns PJ_GRID_INFO struct.
+
+******************************************************************************/
+    PJ_GRID_INFO info;
+
+    /*PJ_CONTEXT *ctx = proj_context_create(); */
+    PJ_CONTEXT *ctx = pj_get_default_ctx();
+    PJ_GRIDINFO *gridinfo = pj_gridinfo_init(ctx, gridname);
+    memset(&info, 0, sizeof(PJ_GRID_INFO));
+
+    /* in case the grid wasn't found */
+    if (gridinfo->filename == NULL) {
+        pj_gridinfo_free(ctx, gridinfo);
+        strcpy(info.format, "missing");
+        return info;
+    }
+
+    /* name of grid */
+    strncpy(info.gridname, gridname, sizeof(info.gridname));
+
+    /* full path of grid */
+    pj_find_file(ctx, gridname, info.filename, sizeof(info.filename));
+
+    /* grid format */
+    strncpy(info.format, gridinfo->format, sizeof(info.format));
+
+    /* grid size */
+    info.n_lon = gridinfo->ct->lim.lam;
+    info.n_lat = gridinfo->ct->lim.phi;
+
+    /* cell size */
+    info.cs_lon = gridinfo->ct->del.lam;
+    info.cs_lat = gridinfo->ct->del.phi;
+
+    /* bounds of grid */
+    info.lowerleft  = gridinfo->ct->ll;
+    info.upperright.lam = info.lowerleft.lam + info.n_lon*info.cs_lon;
+    info.upperright.phi = info.lowerleft.phi + info.n_lat*info.cs_lat;
+
+    pj_gridinfo_free(ctx, gridinfo);
+
+    return info;
+}
+
+/*****************************************************************************/
+PJ_INIT_INFO proj_init_info(const char *initname){
+/******************************************************************************
+    Information about a named init file.
+
+    Returns PJ_INIT_INFO struct.
+
+    If the init file is not found all members of
+    the return struct are set to 0. If the init file is found, but it the
+    metadata is missing, the value is set to "Unknown".
+
+******************************************************************************/
+    int file_found, def_found=0;
+    char param[64], key[64];
+    paralist *start, *next;
+    PJ_INIT_INFO info;
+    PJ_CONTEXT *ctx = pj_get_default_ctx();
+
+    memset(&info, 0, sizeof(PJ_INIT_INFO));
+
+    file_found = pj_find_file(ctx, initname, info.filename, sizeof(info.filename));
+    if (!file_found) {
+        return info;
+    }
+
+    strncpy(info.name, initname, sizeof(info.name));
+    strcpy(info.origin, "Unknown");
+    strcpy(info.version, "Unknown");
+    strcpy(info.lastupdate, "Unknown");
+
+    sprintf(key, "%s:metadata", initname);
+    sprintf(param, "+init=%s", key);
+    start = pj_mkparam(param);
+
+    next = pj_get_init(ctx, &start, start, key, &def_found);
+
+    if (pj_param(ctx, start, "tversion").i) {
+        strncpy(info.version, pj_param(ctx, start, "sversion").s, sizeof(info.version));
+    }
+
+    if (pj_param(ctx, start, "torigin").i) {
+        strncpy(info.origin, pj_param(ctx, start, "sorigin").s, sizeof(info.origin));
+    }
+
+    if (pj_param(ctx, start, "tlastupdate").i) {
+        strncpy(info.lastupdate, pj_param(ctx, start, "slastupdate").s, sizeof(info.lastupdate));
+    }
+
+    for ( ; start; start = next) {
+        next = start->next;
+        pj_dalloc(start);
+    }
+
+   return info;
 }
 
 
 double proj_torad (double angle_in_degrees) { return PJ_TORAD (angle_in_degrees);}
 double proj_todeg (double angle_in_radians) { return PJ_TODEG (angle_in_radians);}
 
-int proj_has_inverse(PJ *P) {
-    return (P->inv != 0 || P->inv3d != 0 || P->invobs != 0);
-}
 
 double proj_dmstor(const char *is, char **rs) {
     return dmstor(is, rs);

--- a/src/pj_obs_api.c
+++ b/src/pj_obs_api.c
@@ -592,6 +592,12 @@ PJ_PROJ_INFO proj_pj_info(const PJ *P) {
     PJ_PROJ_INFO info;
     char *def;
 
+    memset(&info, 0, sizeof(PJ_PROJ_INFO));
+
+    if (!P) {
+        return info;
+    }
+
     /* projection id */
     if (pj_param(P->ctx, P->params, "tproj").i)
         pj_strlcpy(info.id, pj_param(P->ctx, P->params, "sproj").s, sizeof(info.id));

--- a/src/pj_open_lib.c
+++ b/src/pj_open_lib.c
@@ -29,6 +29,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
+#include "proj_internal.h"
 #include <projects.h>
 #include <stdio.h>
 #include <string.h>
@@ -86,10 +87,19 @@ void pj_set_searchpath ( int count, const char **path )
             strcpy(search_path[i], path[i]);
         }
     }
-        
+
     path_count = count;
 }
 
+/* just a couple of helper functions that lets other functions
+   access the otherwise private search path */
+const char **proj_get_searchpath(void) {
+    return (const char **)search_path;
+}
+
+int proj_get_path_count(void) {
+    return path_count;
+}
 /************************************************************************/
 /*                          pj_open_lib_ex()                            */
 /************************************************************************/

--- a/src/proj.def
+++ b/src/proj.def
@@ -90,50 +90,53 @@ EXPORTS
     geod_polygon_clear              @88
     pj_run_selftests                @89
 
-    proj_create                     @90
-    proj_create_argv                @91
-    proj_create_crs_to_crs          @92
-    proj_destroy                    @93
+    pj_find_file                    @90
 
-    proj_trans_obs                  @94
-    proj_trans_coord                @95
-    proj_transform                  @96
-    proj_transform_obs              @97
-    proj_transform_coord            @98
-    proj_roundtrip                  @99
+    proj_create                     @91
+    proj_create_argv                @92
+    proj_create_crs_to_crs          @93
+    proj_destroy                    @94
 
-    proj_coord                     @100
-    proj_obs                       @101
-    proj_coord_error               @102
-    proj_obs_error                 @103
+    proj_trans_obs                  @95
+    proj_trans_coord                @96
+    proj_transform                  @97
+    proj_transform_obs              @98
+    proj_transform_coord            @99
+    proj_roundtrip                 @100
 
-    proj_errno                     @104
-    proj_errno_set                 @105
-    proj_errno_reset               @106
-    proj_errno_restore             @107
-    proj_context_errno_set         @108
+    proj_coord                     @101
+    proj_obs                       @102
+    proj_coord_error               @103
+    proj_obs_error                 @104
 
-    proj_context_create            @109
-    proj_context_set               @110
-    proj_context_inherit           @111
-    proj_context_destroy           @112
+    proj_errno                     @105
+    proj_errno_set                 @106
+    proj_errno_reset               @107
+    proj_errno_restore             @108
+    proj_context_errno_set         @109
 
-    proj_lp_dist                   @113
-    proj_xy_dist                   @114
-    proj_xyz_dist                  @115
+    proj_context_create            @110
+    proj_context_set               @111
+    proj_context_inherit           @112
+    proj_context_destroy           @113
 
-    proj_log_level                 @116
-    proj_log_func                  @117
-    proj_log_error                 @118
-    proj_log_debug                 @119
-    proj_log_trace                 @120
+    proj_lp_dist                   @114
+    proj_xy_dist                   @115
+    proj_xyz_dist                  @116
 
-    proj_definition_retrieve       @121
-    proj_release                   @122
-    proj_torad                     @123
-    proj_todeg                     @124
-    proj_has_inverse               @125
-    proj_rtodms                    @126
-    proj_dmstor                    @127
+    proj_log_level                 @117
+    proj_log_func                  @118
+    proj_log_error                 @119
+    proj_log_debug                 @120
+    proj_log_trace                 @121
 
-    pj_find_file                   @128
+    proj_info                      @122
+    proj_pj_info                   @123
+    proj_grid_info                 @124
+    proj_init_info                 @125
+
+    proj_torad                     @126
+    proj_todeg                     @127
+    proj_rtodms                    @128
+    proj_dmstor                    @129
+

--- a/src/proj.h
+++ b/src/proj.h
@@ -302,7 +302,7 @@ struct PJ_PROJ_INFO {
 
 struct PJ_GRID_INFO {
     char        gridname[32];       /* name of grid                         */
-    char        filename[128];      /* full path to grid                    */
+    char        filename[260];      /* full path to grid                    */
     char        format[8];          /* file format of grid                  */
     LP          lowerleft;          /* Coordinates of lower left corner     */
     LP          upperright;         /* Coordinates of upper right corner    */
@@ -312,7 +312,7 @@ struct PJ_GRID_INFO {
 
 struct PJ_INIT_INFO {
     char        name[32];           /* name of init file                        */
-    char        filename[128];      /* full path to the init file               */
+    char        filename[260];      /* full path to the init file.              */
     char        version[32];        /* version of the init file                 */
     char        origin[32];         /* origin of the file, e.g. EPSG            */
     char        lastupdate[16];     /* Date of last update in YYYY-MM-DD format */

--- a/src/proj.h
+++ b/src/proj.h
@@ -156,7 +156,7 @@ extern "C" {
 ************************************************************************/
 #define PROJ_VERSION_MAJOR 10
 #define PROJ_VERSION_MINOR 0
-#define PROJ_VERSION_MICRO 0
+#define PROJ_VERSION_PATCH 0
 
 #ifndef PJ_VERSION
 #define PJ_VERSION 10##000##00
@@ -185,6 +185,19 @@ typedef union PJ_COORD PJ_COORD;
 /* Data type for projection/transformation information */
 struct PJconsts;
 typedef struct PJconsts PJ;         /* the PJ object herself */
+
+/* Data type for library level information */
+struct PJ_INFO;
+typedef struct PJ_INFO PJ_INFO;
+
+struct PJ_PROJ_INFO;
+typedef struct PJ_PROJ_INFO PJ_PROJ_INFO;
+
+struct PJ_GRID_INFO;
+typedef struct PJ_GRID_INFO PJ_GRID_INFO;
+
+struct PJ_INIT_INFO;
+typedef struct PJ_INIT_INFO PJ_INIT_INFO;
 
 /* Omega, Phi, Kappa: Rotations */
 typedef struct {double o, p, k;}  PJ_OPK;
@@ -269,6 +282,42 @@ struct PJ_OBS {
     unsigned int flags;  /* additional data, intended for flags */
 };
 
+struct PJ_INFO {
+    char        release[64];        /* Release info. Version + date         */
+    char        version[64];        /* Full version number                  */
+    int         major;              /* Major release number                 */
+    int         minor;              /* Minor release number                 */
+    int         patch;              /* Patch level                          */
+    char        searchpath[512];    /* Paths where init and grid files are  */
+                                    /* looked for. Paths are separated by   */
+                                    /* semi-colons.                         */
+};
+
+struct PJ_PROJ_INFO {
+    char        id[16];             /* Name of the projection in question           */
+    char        description[128];   /* Description of the projection                */
+    char        definition[512];    /* Projection definition                        */
+    int         has_inverse;        /* 1 if an inverse mapping exists, 0 otherwise  */
+};
+
+struct PJ_GRID_INFO {
+    char        gridname[32];       /* name of grid                         */
+    char        filename[128];      /* full path to grid                    */
+    char        format[8];          /* file format of grid                  */
+    LP          lowerleft;          /* Coordinates of lower left corner     */
+    LP          upperright;         /* Coordinates of upper right corner    */
+    int         n_lon, n_lat;       /* Grid size                            */
+    double      cs_lon, cs_lat;     /* Cell size of grid                    */
+};
+
+struct PJ_INIT_INFO {
+    char        name[32];           /* name of init file                        */
+    char        filename[128];      /* full path to the init file               */
+    char        version[32];        /* version of the init file                 */
+    char        origin[32];         /* origin of the file, e.g. EPSG            */
+    char        lastupdate[16];     /* Date of last update in YYYY-MM-DD format */
+};
+
 /* The context type - properly namespaced synonym for projCtx */
 struct projCtx_t;
 typedef struct projCtx_t PJ_CONTEXT;
@@ -337,11 +386,11 @@ void proj_errno_set (PJ *P, int err);
 int  proj_errno_reset (PJ *P);
 void proj_errno_restore (PJ *P, int err);
 
-
-/* Build a fully expanded proj_create() compatible representation of P */
-char *proj_definition_retrieve (PJ *P);
-/* ...and get rid of it safely */
-void *proj_release (void *buffer);
+/* Info functions - get information about various PROJ.4 entities */
+PJ_INFO      proj_info(void);
+PJ_PROJ_INFO proj_pj_info(const PJ *P);
+PJ_GRID_INFO proj_grid_info(const char *gridname);
+PJ_INIT_INFO proj_init_info(const char *initname);
 
 
 /* These are trivial, and while occasionaly useful in real code, primarily here to       */
@@ -349,9 +398,6 @@ void *proj_release (void *buffer);
 /* angular units expected by classical proj, and by Charles Karney's geodesics subsystem */
 double proj_torad (double angle_in_degrees);
 double proj_todeg (double angle_in_radians);
-
-/* Check if a projection has an inverse mapping */
-int proj_has_inverse(PJ *P);
 
 double proj_dmstor(const char *is, char **rs);
 char*  proj_rtodms(char *s, double r, int pos, int neg);

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -107,6 +107,8 @@ void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION log);
 /* Lowest level: Minimum support for fileapi */
 void proj_fileapi_set (PJ *P, void *fileapi);
 
+const char **proj_get_searchpath(void);
+int    proj_get_path_count(void);
 
 #ifdef __cplusplus
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -110,6 +110,8 @@ void proj_fileapi_set (PJ *P, void *fileapi);
 const char **proj_get_searchpath(void);
 int    proj_get_path_count(void);
 
+size_t pj_strlcpy(char *dst, const char *src, size_t siz);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/projects.h
+++ b/src/projects.h
@@ -696,6 +696,7 @@ void pj_prepare (PJ *P, const char *description, void (*freeup)(struct PJconsts 
 paralist *pj_clone_paralist( const paralist* );
 paralist *pj_search_initcache( const char *filekey );
 void      pj_insert_initcache( const char *filekey, const paralist *list);
+paralist *pj_get_init(projCtx ctx, paralist **start, paralist *next, char *name, int *found_def);
 
 double *pj_enfn(double);
 double  pj_mlfn(double, double, double, double *);


### PR DESCRIPTION
Four new functions are added with this commit: `proj_info()`, `proj_pj_info()`,
`proj_grid_info()` and `proj_init_info()`. Additionally four new data types are
added: `PJ_INFO`, `PJ_PROJ_INFO`, `PJ_GRID_INFO` and `PJ_INIT_INFO`. The functions
return the corresponding data types.

These functions allows users of the PROJ.4 library to get information about
various PROJ.4 entities and the library itself. The new data types are structs
that contain specific information about either the library instance, a `PJ`
instance, a grid or an init file. Together the four new functions cover a big
part of the functionality in the semi-public `projects.h` API and should hopefully
make it easier for user to migrate their code to the `proj.h` API in the future.

Besides covering already existing functionality in the old API, this commit
introduces the ability to add metadata to init-files. This is primarily added
to give users a way of knowing which version of the EPSG database they are
using, but it also comes in handy for other init-files. The init-file metadata
is added directly to the init-file as a special "projection" called "metadata".
The info projection of the epsg init-file is thus described as:

    <metadata> +version=9.0.0 +origin=EPSG +lastupdate=2017-01-10

The `proj_init_info()` function uses the internal `pj_param()` to read the
metadata. As a consequence, "metadata" will not be available as a the name of
a projection in the future. This is a reasonable price to pay considering the
ease of the implementation of adding metadata to init-files this way, and of
course that "metadata" is a very unlikely name for a projection in any case.
A metadata tag has been added to all init-files in the nad-directory. For most
only a subset of the possible parameters has been added.

This PR removes a few functions that was recently introduced to the `proj.h` API. Namely `proj_has_inverse()`, `proj_definition_retrieve()` and `proj_release()` since they provide the
same functionality as `proj_pj_info()`. Except for `proj_release()`, but with `proj_definition_retrieve()` gone, it no longer has a purpose.

I think this way of providing information for the users of PROJ.4 is a better than having
a function for each specific piece of info a users might want. By using structs with fixed
length strings memory handling issues should be at a minimum, although at the cost of
a slightly larger memory consumption.

This PR resolves #471, #300 and #538 (which was already fixed, but now handled differently).

------------------------------------------------------------------------------

To demonstrate the info functions I have written a simple program:

```
#include <stdio.h>
#include <proj.h>

int main(void) {
    /*PJ *P = proj_create(0, "+proj=pipeline +step +init=epsg:25833"); */
    PJ *P = proj_create(0, "+proj=merc +lat_0=24 +lon_0=53");
    PJ_GRID_INFO grid_info = proj_grid_info("BETA2007.gsb");

    printf("\n");
    printf("                            proj_info()\n");
    printf("--------------------------------------------------------------------\n");
    printf("Major:       %d\n", proj_info().major);
    printf("Minor:       %d\n", proj_info().minor);
    printf("Patch:       %d\n", proj_info().patch);
    printf("             %s\n", proj_info().release);
    printf("version:     %s\n", proj_info().version);
    printf("Search path: %s\n", proj_info().searchpath);
    printf("\n");
    printf("                            proj_pj_info()\n");
    printf("--------------------------------------------------------------------\n");
    printf("Projection id: %s\n", proj_pj_info(P).id);
    printf("Description:   %s\n", proj_pj_info(P).description);
    printf("Definition:    %s\n", proj_pj_info(P).definition);
    printf("Has inverse:   %d\n", proj_pj_info(P).has_inverse);
    printf("\n");
    printf("                            proj_grid_info()\n");
    printf("--------------------------------------------------------------------\n");
    printf("Grid name:    %s\n", grid_info.gridname);
    printf("File name:    %s\n", grid_info.filename);
    printf("Format:       %s\n", grid_info.format);
    printf("Lower left:   (%f, %f)\n", proj_todeg(grid_info.lowerleft.lam),
                                       proj_todeg(grid_info.lowerleft.phi));
    printf("Upper right:  (%f, %f)\n", proj_todeg(grid_info.upperright.lam),
                                       proj_todeg(grid_info.upperright.phi));
    printf("Grid size:    (%d, %d)\n", grid_info.n_lon, grid_info.n_lat);
    printf("\n");
    printf("                            proj_init_info()\n");
    printf("--------------------------------------------------------------------\n");
    printf("Init name:   %s\n", proj_init_info("epsg").name);
    printf("File name:   %s\n", proj_init_info("epsg").filename);
    printf("Version:     %s\n", proj_init_info("epsg").version);
    printf("Origin:      %s\n", proj_init_info("epsg").origin);
    printf("\n");

    proj_destroy(P);
    return 0;
}
```

Which on my computer generates the following output:

```
                            proj_info()
--------------------------------------------------------------------
Major:       10
Minor:       0
Patch:       0
             Rel. 4.9.3, 15 August 2016
version:     10.0.0
Search path: C:\Users\b012349;C:\OSGeo4W64\\share\proj

                            proj_pj_info()
--------------------------------------------------------------------
Projection id: merc
Description:   Mercator
        Cyl, Sph&Ell
        lat_ts=
Definition:    +proj=merc +lat_0=24 +lon_0=53 +ellps=WGS84
Has inverse:   1

                            proj_grid_info()
--------------------------------------------------------------------
Grid name:    BETA2007.gsb
File name:    C:\OSGeo4W64\\share\proj\BETA2007.gsb
Format:       ntv2
Lower left:   (5.500000, 47.000000)
Upper right:  (15.833333, 55.400000)
Grid size:    (62, 84)

                            proj_init_info()
--------------------------------------------------------------------
Init name:   epsg
File name:   C:\OSGeo4W64\\share\proj\epsg
Version:     9.0.0
Origin:      EPSG
```