### PR TITLE
Add ITRF init files

### DIFF
--- a/nad/CMakeLists.txt
+++ b/nad/CMakeLists.txt
@@ -13,7 +13,10 @@ set(PROJ_DICTIONARY  epsg
                      nad83
                      nad.lst
                      proj_def.dat
-                     CH )
+                     CH
+                     ITRF2000
+                     ITRF2008
+                     ITRF2014 )
 
 #
 # gridshift file

--- a/nad/ITRF2000
+++ b/nad/ITRF2000
@@ -1,0 +1,24 @@
+# ITRF2000 params are in cm/year, PJ_helmert uses m/year
+<metadata> +version=1.0.0 +origin=ftp://itrf.ensg.ign.fr/pub/itrf/ITRF.TP +lastupdate=2017-07-25
+
+# ITRF2000 -> ITRF2005 is only defined the opposite way, so we flip the sign on all
+# parameters to get the opposite transformation. Parameters from http://itrf.ign.fr/ITRF_solutions/2005/tp_05-00.php
+<ITRF2005> +proj=helmert +x=-0.0001 +y=0.0008 +z=0.0058 +s=-0.0004 +dx=0.0002 +dy=-0.0001 +dz=0.0018 +ds=-0.000008 +epoch=2000.0 +transpose
+
+<ITRF97> +proj=helmert +x=0.0067 +y=0.0061 +z=-0.0185 +s=0.00155 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1997.0 +transpose
+
+<ITRF96> +proj=helmert +x=0.0067 +y=0.0061 +z=-0.0185 +s=0.00155 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1997.0 +transpose
+
+<ITRF94> +proj=helmert +x=0.0067 +y=0.0061 +z=-0.0185 +s=0.00155 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1997.0 +transpose
+
+<ITRF93> +proj=helmert +x=0.0127 +y=0.0065 +z=-0.0209 +s=0.00195 +rx=-0.00039 +ry=0.00080 +rz=-0.00114 +dx=-0.0029 +dy=-0.0002 +dz=-0.0006 +ds=0.00001 +drx=-0.00011 +dry=-0.00019 +drz=0.00007 +epoch=1988.0 +transpose
+
+<ITRF92> +proj=helmert +x=0.0147 +y=0.0135 +z=-0.0139 +s=0.00075 +rz=-0.00018 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1988.0 +transpose
+
+<ITRF91> +proj=helmert +x=0.0267 +y=0.0275 +z=-0.0199 +s=0.00215 +rz=-0.00018 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1988.0 +transpose
+
+<ITRF90> +proj=helmert +x=0.0247 +y=0.0235 +z=-0.0359 +s=0.00245 +rz=-0.00018 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1988.0 +transpose
+
+<ITRF89> +proj=helmert +x=0.0297 +y=0.0475 +z=-0.0739 +s=0.00585 +rz=-0.00018 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1988.0 +transpose
+
+<ITRF88> +proj=helmert +x=0.0247 +y=0.0115 +z=-0.0979 +s=0.00895 +rx=0.0001 +rz=-0.00018 +dy=-0.0006 +dz=-0.0014 +ds=0.00001 +drz=0.00002 +epoch=1988.0 +transpose

--- a/nad/ITRF2008
+++ b/nad/ITRF2008
@@ -1,0 +1,24 @@
+# ITRF2008 params are in mm/year, PJ_helmert uses m/year
+<metadata> +version=1.0.0 +origin=http://itrf.ign.fr/doc_ITRF/Transfo-ITRF2008_ITRFs.txt +lastupdate=2017-07-26
+
+<ITRF2005> +proj=helmert +x=-0.002 +y=-0.0009 +z=-0.0047 +s=0.00094 +dx=0.0003 +epoch=2000.0 +transpose
+
+<ITRF2000> +proj=helmert +x=-0.0019 +y=-0.0017 +z=-0.0105 +s=0.00134  +dx=0.0001 +dy=0.0001 +dz=-0.0018 +ds=0.00008  +epoch=2000.0 +transpose
+
+<ITRF97> +proj=helmert +x=0.0048 +y=0.0026 +z=-0.0332 +s=0.00292 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF96> +proj=helmert +x=0.0048 +y=0.0026 +z=-0.0332 +s=0.00292 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF94> +proj=helmert +x=0.0048 +y=0.0026 +z=-0.0332 +s=0.00292 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF93> +proj=helmert +x=-0.024 +y=0.0024 +z=-0.00386 +s=0.00341 +rx=-0.00171 +ry=-0.00148 +rz=-0.0003 +dx=-0.0028 +dy=-0.0001 +dz=-0.0024 +ds=0.00009 +drx=-0.00011 +dry=-0.00019 +drz=0.00007 +epoch=2000.0 +transpose
+
+<ITRF92> +proj=helmert +x=0.0128 +y=0.0046 +z=-0.0412 +s=0.00221 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF91> +proj=helmert +x=0.0248 +y=0.0186 +z=-0.0472 +s=0.00361 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF90> +proj=helmert +x=0.0228 +y=0.0146 +z=-0.0632 +s=0.00391 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF89> +proj=helmert +x=0.0278 +y=0.0386 +z=-0.1012 +s=0.00731 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose
+
+<ITRF88> +proj=helmert +x=0.0228 +y=0.0026 +z=-0.1252 +s=0.01041 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +epoch=2000.0 +transpose

--- a/nad/ITRF2014
+++ b/nad/ITRF2014
@@ -1,0 +1,26 @@
+# ITRF2014 params are in mm/year, PJ_helmert uses m/year
+<metadata> +version=1.0.0 +origin=http://itrf.ign.fr/doc_ITRF/Transfo-ITRF2014_ITRFs.txt +lastupdate=2017-07-26
+
+<ITRF2008> +proj=helmert +x=0.0016 +y=0.0019 +z=0.0024 +s=-0.00002 +dz=-0.0001 +ds=0.00003 +epoch=2010.0 +transpose
+
+<ITRF2005> +proj=helmert +x=0.0026 +y=0.001 +z=-0.0023 +s=0.00092 +dx=0.0003 +dz=-0.0001 +ds=0.00003 +epoch=2010.0 +transpose
+
+<ITRF2000> +proj=helmert +x=0.0007 +y=0.0012 +z=-0.0261 +s=0.00212 +dx=0.0001 +dy=0.0001 +dz=-0.0019 +ds=0.00011 +epoch=2010.0 +transpose
+
+<ITRF97> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +d=0.0038 +rz=0.00026 +dx0.0001	+dy=-0.0005 +dz=-0.0033	+ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose
+
+<ITRF96> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +epoch=2010.0 +transpose
+
+<ITRF94> +proj=helmert +x=0.0074 +y=-0.0005 +z=-0.0628 +s=0.0038 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +epoch=2010.0 +transpose
+
+<ITRF93> +proj=helmert +x=-0.0504 +y=0.0033 +z=-0.0602 +s=0.00429 +rx=-0.00281 +ry=-0.00338 +rz=0.0004 +dx=-0.0028 +dy=-0.0001 +dz=-0.0025 +ds=0.00012 +drx=-0.00011 +dry=-0.00019 +drz=0.00007 +epoch=2010.0 +transpose
+
+<ITRF92> +proj=helmert +x=0.0154 +y=0.0015 +z=-0.0708 +s=0.00309 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose
+
+<ITRF91> +proj=helmert +x=0.0274 +y=0.0155 +z=-0.0768 +s=0.00449 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose
+
+<ITRF90> +proj=helmert +x=0.0254 +y=0.0115 +z=-0.0928 +s=0.00479 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose
+
+<ITRF89> +proj=helmert +x=0.0304 +y=0.0355 +z=-0.1308 +s=0.00819 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose
+
+<ITRF88> +proj=helmert +x=0.0254 +y=-0.0005 +z=-0.1548 +s=0.01129 +rx=0.0001 +rz= +dx=0.00026 +dy=0.0001 +dx=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +epoch=2010.0 +transpose

--- a/nad/Makefile.am
+++ b/nad/Makefile.am
@@ -15,13 +15,15 @@ TESTIGN = $(NADPATH)/testIGNF
 
 pkgdata_DATA = GL27 nad.lst proj_def.dat nad27 nad83 world epsg esri \
 		esri.extra other.extra \
-		CH IGNF
+		CH IGNF \
+		ITRF2000 ITRF2008 ITRF2014
 
 EXTRA_DIST = GL27 nad.lst proj_def.dat nad27 nad83 pj_out27.dist pj_out83.dist td_out.dist \
 		test27 test83 world epsg esri tv_out.dist tf_out.dist \
 		testflaky testvarious testdatumfile testntv2 ntv2_out.dist \
 		esri.extra other.extra \
 		CH IGNF testIGNF proj_outIGNF.dist \
+		ITRF2000 ITRF2008 ITRF2014
 		makefile.vc CMakeLists.txt
 
 process-nad2bin:

--- a/nad/makefile.vc
+++ b/nad/makefile.vc
@@ -7,7 +7,7 @@
 OLD_GRIDS = conus MD TN WI WO alaska hawaii prvi stgeorge stlrnc stpaul null
 
 OTHER_FILES = FL GL27 nad.lst nad27 nad83 proj_def.dat world epsg esri \
-	esri.extra other.extra IGNF
+	esri.extra other.extra IGNF ITRF2000 ITRF2008 ITRF20014
 
 
 


### PR DESCRIPTION
With the three new init files it is now possible to do transformation from one ITRF to another by using the `+init` parameter instead of having to write out all the parameters in the proj-string. It is a lot easier to read a given proj-string and there are less room for mistakes. 

For example:

    +init=ITRF2014:ITRF2008

which expand to:

     +proj=helmert +x=0.0016 +y=0.0019 +z=0.0024 +s=-0.00002 +dz=-0.0001 +ds=0.00003 +epoch=2010.0 +transpose

If all observations have the same epoch it is of course possible to add it to the proj-string:  

     +init=ITRF2014:ITRF2008 +tobs=2015.13

Fixes #154, although in a slighlty different way than suggested in the issue. 