### PR TITLE
Fix the Solaris 11.3 compilation error

### DIFF
--- a/src/pj_mutex.c
+++ b/src/pj_mutex.c
@@ -28,7 +28,7 @@
 
 /* projects.h and windows.h conflict - avoid this! */
 
-#if defined(MUTEX_pthread) && !defined(_XOPEN_SOURCE)
+#if defined(MUTEX_pthread) && !defined(_XOPEN_SOURCE) && !defined(__sun)
 /* For pthread_mutexattr_settype */
 #define _XOPEN_SOURCE 500
 #endif


### PR DESCRIPTION
When _XOPEN_SOURCE 500 is defined on Solaris 11 the following error message is displayed : "Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications"

As pthread_mutexattr_settype is available without _XOPEN_SOURCE defined, the easier way to fix the error is to disable it.