### PR TITLE
Add unbuffered output option to proj

### DIFF
--- a/src/proj.c
+++ b/src/proj.c
@@ -33,6 +33,7 @@ reversein = 0,	/* != 0 reverse input arguments */
 reverseout = 0,	/* != 0 reverse output arguments */
 bin_in = 0,	/* != 0 then binary input */
 bin_out = 0,	/* != 0 then binary output */
+unbuf_out = 0,	/* != 0 then unbuffered output */
 echoin = 0,	/* echo input data to output line */
 tag = '#',	/* beginning of line tag character */
 inverse = 0,	/* != 0 then inverse projection */
@@ -46,7 +47,7 @@ postscale = 0;
 *oform = (char *)0,	/* output format for x-y or decimal degrees */
 *oterr = "*\t*",	/* output line for unprojectable input */
 *usage =
-"%s\nusage: %s [ -bCeEfiIlormsStTvVwW [args] ] [ +opts[=arg] ] [ files ]\n";
+"%s\nusage: %s [ -bCeEfiIlormsStTuvVwW [args] ] [ +opts[=arg] ] [ files ]\n";
 	static struct FACTORS
 facs;
 	static double
@@ -297,6 +298,9 @@ int main(int argc, char **argv) {
               case 'o': /* output binary */
                 bin_out = 1;
                 continue;
+              case 'u': /* output unbuffered */
+                unbuf_out = 1;
+                continue;
               case 'I': /* alt. method to spec inverse */
                 inverse = 1;
                 continue;
@@ -490,6 +494,10 @@ int main(int argc, char **argv) {
     if (bin_out)
     {
         SET_BINARY_MODE(stdout);
+    }
+
+    if (unbuf_out) {
+        setbuf(stdout, NULL);
     }
 
     /* process input file list */


### PR DESCRIPTION
With this option, we are no longer limited to one single path per `proj` process when creating the plots. There are between 13 and 1462 paths, so cutting it down to 1 process per plot greatly improves plot runtime. Creating all plots takes 6 minutes on `master` and 1m25s with this branch.