### PR TITLE
Add tests for C99 math functions, hypot, atanh, cbrt, etc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,28 @@ if (HAVE_PTHREAD_MUTEX_RECURSIVE_DEFN)
     add_definitions(-DHAVE_PTHREAD_MUTEX_RECURSIVE=1)
 endif()
 
+include (CheckCSourceCompiles)
+if (MSVC)
+  set (CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX")
+else
+  set (CMAKE_REQUIRED_LIBRARIES m)
+  set (CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif ()
+# Check whether the C99 math function: hypot, atanh, etc. are available.
+check_c_source_compiles (
+  "#include <math.h>
+int main() {
+  int q;
+  return (int)(hypot(3.0, 4.0) + atanh(0.8) + cbrt(8.0) +
+               remquo(100.0, 90.0, &q) +
+               remainder(100.0, 90.0) + copysigna(1.0, -0.0));
+}\n" C99_MATH)
+if (C99_MATH)
+  add_definitions (-DHAVE_C99_MATH=1)
+else ()
+  add_definitions (-DHAVE_C99_MATH=0)
+endif ()
+
 boost_report_value(PROJ_PLATFORM_NAME)
 boost_report_value(PROJ_COMPILER_NAME)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 include (CheckCSourceCompiles)
 if (MSVC)
   set (CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX")
-else
+else ()
   set (CMAKE_REQUIRED_LIBRARIES m)
   set (CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror")
 endif ()

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,20 @@ CFLAGS="$save_CFLAGS"
 dnl We check for headers
 AC_HEADER_STDC
 
+dnl Check for C99 math functions
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Wall -Werror"
+AC_MSG_CHECKING([for C99 math functions])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [#include <math.h>],
+        [int q;
+         return (int)(hypot(3.0, 4.0) + atanh(0.8) + cbrt(8.0) +
+                      remquo(100.0, 90.0, &q) +
+                      remainder(100.0, 90.0) + copysign(1.0, -0.0));])],
+        [AC_MSG_RESULT([yes]);C99_MATH="-DHAVE_C99_MATH=1"],
+        [AC_MSG_RESULT([no]);C99_MATH="-DHAVE_C99_MATH=0"])
+CFLAGS="$save_CFLAGS $C99_MATH"
+
 AC_CHECK_FUNC(localeconv, [AC_DEFINE(HAVE_LOCALECONV,1,[Define to 1 if you have localeconv])])
 
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
This tests whether the functions are declared in <math.h>.  If they are,
then -DHAVE_C99_MATH=1 is added to the C flags.  The intention is that
this flag is only seen when building proj.4 and shouldn't be referenced
in any of the installed include files.  The next update to geodesic.c
will use this flag.

Left unaddressed is what to do if HAVE_C99_MATH is 0.  The strategy in
geodesic.c is to assume that the missing functions will need to be
defined explicitly.  A less safe alternative is to assume that the
functions are in fact available in libm and that all that needs to be
done is to declare the functions.