### PR TITLE
Ignore Visual Studio cruft and build directories and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
+build.local.bat
+build.local.sh
 Makefile
 Makefile.in
 CMakeFiles
@@ -8,8 +10,10 @@ cmake_install.cmake
 install_manifest.txt
 cmake/project-config*.cmake
 
+/.vs*
 /*.manifest
 /*.swp
+/*build*
 /aclocal.m4
 /autom4te.cache
 /config.cache


### PR DESCRIPTION
build.local.sh and build.local.bat as as user-specific scripts
Build directories: build, _build.{platform} or _build.{compiler}
