### PR TITLE
Pro forma PR to force a check of ob_tran memleak. DO NOT MERGE!!!

### DIFF
--- a/travis/linux_clang/install.sh
+++ b/travis/linux_clang/install.sh
@@ -4,4 +4,4 @@ set -e
 
 export CCACHE_CPP2=yes
 
-CC="ccache clang" CFLAGS="-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -O2" ./travis/install.sh
+CC="ccache clang" CFLAGS="-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -fsanitize=address -O2" ./travis/install.sh


### PR DESCRIPTION
Basically, this is a case of checkout master, then add address sanitizer to linux_clang build.

There appears to be a hard to trace memleak in PR #583, and I need to see whether it was present even before that work, but have no accessible way of running a -fsanitize=address enabled build, other than through travis.