### PR TITLE
Handle allocation failure when loading grid files

### DIFF
--- a/src/nad_init.c
+++ b/src/nad_init.c
@@ -224,7 +224,7 @@ struct CTABLE *nad_ctable2_init( projCtx ctx, PAFile fid )
     ct = (struct CTABLE *) pj_malloc(sizeof(struct CTABLE));
     if( ct == NULL )
     {
-        pj_ctx_set_errno( ctx, -38 );
+        pj_ctx_set_errno( ctx, ENOMEM );
         return NULL;
     }
 
@@ -241,6 +241,7 @@ struct CTABLE *nad_ctable2_init( projCtx ctx, PAFile fid )
         || ct->lim.phi < 1 || ct->lim.phi > 100000 )
     {
         pj_ctx_set_errno( ctx, -38 );
+        pj_dalloc( ct );
         return NULL;
     }
     

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -212,7 +212,9 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
         ct_tmp.cvs = (FLP *) pj_malloc(gi->ct->lim.lam*gi->ct->lim.phi*sizeof(FLP));
         if( row_buf == NULL || ct_tmp.cvs == NULL )
         {
-            pj_ctx_set_errno( ctx, -38 );
+            pj_dalloc( row_buf );
+            pj_dalloc( ct_tmp.cvs );
+            pj_ctx_set_errno( ctx, ENOMEM );
             pj_release_lock();
             return 0;
         }
@@ -230,6 +232,7 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
                 pj_dalloc( row_buf );
                 pj_dalloc( ct_tmp.cvs );
                 pj_ctx_set_errno( ctx, -38 );
+                pj_release_lock();
                 return 0;
             }
 
@@ -290,7 +293,9 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
         ct_tmp.cvs = (FLP *) pj_malloc(gi->ct->lim.lam*gi->ct->lim.phi*sizeof(FLP));
         if( row_buf == NULL || ct_tmp.cvs == NULL )
         {
-            pj_ctx_set_errno( ctx, -38 );
+            pj_dalloc( row_buf );
+            pj_dalloc( ct_tmp.cvs );
+            pj_ctx_set_errno( ctx, ENOMEM );
             pj_release_lock();
             return 0;
         }
@@ -362,7 +367,7 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
         ct_tmp.cvs = (FLP *) pj_malloc(words*sizeof(float));
         if( ct_tmp.cvs == NULL )
         {
-            pj_ctx_set_errno( ctx, -38 );
+            pj_ctx_set_errno( ctx, ENOMEM );
             pj_release_lock();
             return 0;
         }
@@ -371,6 +376,7 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
             != (size_t)words )
         {
             pj_dalloc( ct_tmp.cvs );
+            pj_ctx_set_errno( ctx, PJD_ERR_FAILED_TO_LOAD_GRID );
             pj_release_lock();
             return 0;
         }
@@ -519,6 +525,10 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
 /*      Initialize a corresponding "ct" structure.                      */
 /* -------------------------------------------------------------------- */
         ct = (struct CTABLE *) pj_malloc(sizeof(struct CTABLE));
+        if (!ct) {
+            pj_ctx_set_errno(ctx, ENOMEM);
+            return 0;
+        }
         strncpy( ct->id, (const char *) header + 8, 8 );
         ct->id[8] = '\0';
 
@@ -553,6 +563,7 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
                     "GS_COUNT(%d) does not match expected cells (%dx%d=%d)\n",
                     gs_count, ct->lim.lam, ct->lim.phi,
                     ct->lim.lam * ct->lim.phi );
+            pj_dalloc(ct);
             pj_ctx_set_errno( ctx, -38 );
             return 0;
         }
@@ -568,10 +579,23 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
         else
         {
             gi = (PJ_GRIDINFO *) pj_malloc(sizeof(PJ_GRIDINFO));
+            if (!gi) {
+                pj_dalloc(ct);
+                pj_gridinfo_free(ctx, gilist);
+                pj_ctx_set_errno(ctx, ENOMEM);
+                return 0;
+            }
             memset( gi, 0, sizeof(PJ_GRIDINFO) );
 
             gi->gridname = pj_strdup( gilist->gridname );
             gi->filename = pj_strdup( gilist->filename );
+            if (!gi->gridname || gi->filename) {
+                pj_gridinfo_free(ctx, gi);
+                pj_dalloc(ct);
+                pj_gridinfo_free(ctx, gilist);
+                pj_ctx_set_errno(ctx, ENOMEM);
+                return 0;
+            }
             gi->next = NULL;
         }
 
@@ -699,6 +723,10 @@ static int pj_gridinfo_init_ntv1( projCtx ctx, PAFile fid, PJ_GRIDINFO *gi )
 /*      Fill in CTABLE structure.                                       */
 /* -------------------------------------------------------------------- */
     ct = (struct CTABLE *) pj_malloc(sizeof(struct CTABLE));
+    if (!ct) {
+        pj_ctx_set_errno(ctx, ENOMEM);
+        return 0;
+    }
     strcpy( ct->id, "NTv1 Grid Shift File" );
 
     ct->ll.lam = - *((double *) (header+72));
@@ -799,6 +827,10 @@ static int pj_gridinfo_init_gtx( projCtx ctx, PAFile fid, PJ_GRIDINFO *gi )
 /*      Fill in CTABLE structure.                                       */
 /* -------------------------------------------------------------------- */
     ct = (struct CTABLE *) pj_malloc(sizeof(struct CTABLE));
+    if (!ct) {
+        pj_ctx_set_errno(ctx, ENOMEM);
+        return 0;
+    }
     strcpy( ct->id, "GTX Vertical Grid Shift File" );
 
     ct->ll.lam = xorigin;
@@ -864,9 +896,18 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
 /*      cannot be loaded.                                               */
 /* -------------------------------------------------------------------- */
     gilist = (PJ_GRIDINFO *) pj_malloc(sizeof(PJ_GRIDINFO));
+    if (!gilist) {
+        pj_ctx_set_errno(ctx, ENOMEM);
+        return NULL;
+    }
     memset( gilist, 0, sizeof(PJ_GRIDINFO) );
 
     gilist->gridname = pj_strdup( gridname );
+    if (!gilist->gridname) {
+        pj_dalloc(gilist);
+        pj_ctx_set_errno(ctx, ENOMEM);
+        return NULL;
+    }
     gilist->filename = NULL;
     gilist->format = "missing";
     gilist->grid_offset = 0;
@@ -883,6 +924,12 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
     }
 
     gilist->filename = pj_strdup(fname);
+    if (!gilist->filename) {
+        pj_dalloc(gilist->gridname);
+        pj_dalloc(gilist);
+        pj_ctx_set_errno(ctx, ENOMEM);
+        return NULL;
+    }
 
 /* -------------------------------------------------------------------- */
 /*      Load a header, to determine the file type.                      */

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -578,14 +578,13 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
             gi = gilist;
         else
         {
-            gi = (PJ_GRIDINFO *) pj_malloc(sizeof(PJ_GRIDINFO));
+            gi = (PJ_GRIDINFO *) pj_calloc(1, sizeof(PJ_GRIDINFO));
             if (!gi) {
                 pj_dalloc(ct);
                 pj_gridinfo_free(ctx, gilist);
                 pj_ctx_set_errno(ctx, ENOMEM);
                 return 0;
             }
-            memset( gi, 0, sizeof(PJ_GRIDINFO) );
 
             gi->gridname = pj_strdup( gilist->gridname );
             gi->filename = pj_strdup( gilist->filename );
@@ -895,12 +894,11 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
 /*      Initialize a GRIDINFO with stub info we would use if it         */
 /*      cannot be loaded.                                               */
 /* -------------------------------------------------------------------- */
-    gilist = (PJ_GRIDINFO *) pj_malloc(sizeof(PJ_GRIDINFO));
+    gilist = (PJ_GRIDINFO *) pj_calloc(1, sizeof(PJ_GRIDINFO));
     if (!gilist) {
         pj_ctx_set_errno(ctx, ENOMEM);
         return NULL;
     }
-    memset( gilist, 0, sizeof(PJ_GRIDINFO) );
 
     gilist->gridname = pj_strdup( gridname );
     if (!gilist->gridname) {

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -28,6 +28,7 @@
 
 #define PJ_LIB__
 
+#include <errno.h>
 #include <projects.h>
 #include <string.h>
 #include <math.h>
@@ -103,6 +104,10 @@ static int pj_gridlist_merge_gridfile( projCtx ctx,
                 int new_max = *p_gridmax + 20;
 
                 new_list = (PJ_GRIDINFO **) pj_calloc(new_max, sizeof(void *));
+                if (!new_list) {
+                    pj_ctx_set_errno( ctx, ENOMEM );
+                    return 0;
+                }
                 if( *p_gridlist != NULL )
                 {
                     memcpy( new_list, *p_gridlist,
@@ -132,8 +137,6 @@ static int pj_gridlist_merge_gridfile( projCtx ctx,
 
     if( this_grid == NULL )
     {
-        /* we should get at least a stub grid with a missing "ct" member */
-        assert( FALSE );
         return 0;
     }
     

--- a/src/pj_strtod.c
+++ b/src/pj_strtod.c
@@ -101,8 +101,11 @@ static char* pj_replace_point_by_locale_point(const char* pszNumber, char point,
                 strcpy(pszWorkBuffer, pszNumber);
                 pszNew = pszWorkBuffer;
             }
-            else
+            else {
                 pszNew = pj_strdup(pszNumber);
+                if (!pszNew)
+                    return NULL;
+            }
             pszNew[pszPoint - pszNumber] = byPoint;
             return pszNew;
         }
@@ -127,8 +130,11 @@ static char* pj_replace_point_by_locale_point(const char* pszNumber, char point,
                     strcpy(pszWorkBuffer, pszNumber);
                     pszNew = pszWorkBuffer;
                 }
-                else
+                else {
                     pszNew = pj_strdup(pszNumber);
+                    if (!pszNew)
+                        return NULL;
+                }
                 if( pszLocalePoint )
                     pszNew[pszLocalePoint - pszNumber] = ' ';
                 if( pszPoint )


### PR DESCRIPTION
Continuing #606, we tackle the same issues in the loading and processing of grid files. This should fix potential crashes and memory leaks, and makes sure the global lock is always released.