### PR TITLE
Replace some asserts by compile-time assertions

### DIFF
--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -43,7 +43,6 @@
 #define PJ_LIB__
 #include "proj_internal.h"
 #include "projects.h"
-#include <assert.h>
 #include <stddef.h>
 #include <math.h>
 #include <errno.h>

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -43,7 +43,6 @@ Last update: 2017-05-15
 ***********************************************************************/
 
 #define PJ_LIB__
-#include <assert.h>
 #include <stddef.h>
 #include <errno.h>
 #include "proj_internal.h"

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -78,7 +78,6 @@
 #define PJ_LIB__
 #include "proj_internal.h"
 #include "projects.h"
-#include <assert.h>
 #include <stddef.h>
 #include <math.h>
 #include <errno.h>

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -102,7 +102,6 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-20
 #include "proj_internal.h"
 #include "projects.h"
 
-#include <assert.h>
 #include <stddef.h>
 #include <errno.h>
 PROJ_HEAD(pipeline,         "Transformation pipeline manager");

--- a/src/nad2bin.c
+++ b/src/nad2bin.c
@@ -1,10 +1,10 @@
 /* Convert bivariate ASCII NAD27 to NAD83 tables to NTv2 binary structure */
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 
 #define PJ_LIB__
-#include <projects.h>
+#include "proj_internal.h"
+#include "projects.h"
 #define U_SEC_TO_RAD 4.848136811095359935899141023e-12
 
 /************************************************************************/
@@ -177,8 +177,8 @@ int main(int argc, char **argv) {
             exit(2);
 	}
 
-        assert( MAX_TAB_ID == 80 );
-        assert( sizeof(int) == 4 ); /* for ct.lim.lam/phi */
+        STATIC_ASSERT( MAX_TAB_ID == 80 );
+        STATIC_ASSERT( sizeof(pj_int32) == 4 ); /* for ct.lim.lam/phi */
 
         memset( header, 0, sizeof(header) );
 
@@ -267,13 +267,13 @@ int main(int argc, char **argv) {
         {
             unsigned char achHeader[11*16];
             double dfValue;
-            int nGSCount = ct.lim.lam * ct.lim.phi;
+            pj_int32 nGSCount = ct.lim.lam * ct.lim.phi;
             LP ur;
 
             ur.lam = ct.ll.lam + (ct.lim.lam-1) * ct.del.lam;
             ur.phi = ct.ll.phi + (ct.lim.phi-1) * ct.del.phi;
 
-            assert( sizeof(nGSCount) == 4 );
+            STATIC_ASSERT( sizeof(nGSCount) == 4 );
 
             memset( achHeader, 0, sizeof(achHeader) );
 

--- a/src/nad_init.c
+++ b/src/nad_init.c
@@ -32,16 +32,6 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef _WIN32_WCE
-/* assert.h includes all Windows API headers and causes 'LP' name clash.
- * Here assert we disable assert() for Windows CE.
- * TODO - mloskot: re-implement porting friendly assert
- */
-# define assert(exp)	((void)0)
-#else
-# include <assert.h>
-#endif /* _WIN32_WCE */
-
 /************************************************************************/
 /*                             swap_words()                             */
 /*                                                                      */

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -28,20 +28,11 @@
 
 #define PJ_LIB__
 
-#include <projects.h>
+#include "proj_internal.h"
+#include "projects.h"
 #include <string.h>
 #include <math.h>
 #include <errno.h>
-
-#ifdef _WIN32_WCE
-/* assert.h includes all Windows API headers and causes 'LP' name clash.
- * Here assert we disable assert() for Windows CE.
- * TODO - mloskot: re-implement porting friendly assert
- */
-# define assert(exp)	((void)0)
-#else
-# include <assert.h>
-#endif /* _WIN32_WCE */
 
 /************************************************************************/
 /*                             swap_words()                             */
@@ -431,23 +422,8 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
     int num_subfiles, subfile;
     int must_swap;
 
-    assert( sizeof(int) == 4 );
-    assert( sizeof(double) == 8 );
-#ifdef _MSC_VER
-#pragma warning( push )
-/* disable conditional expression is constant */
-#pragma warning( disable : 4127 )
-#endif
-    if( sizeof(int) != 4 || sizeof(double) != 8 )
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-    {
-        pj_log( ctx, PJ_LOG_ERROR,
-             "basic types of inappropraiate size in pj_gridinfo_init_ntv2()" );
-        pj_ctx_set_errno( ctx, -38 );
-        return 0;
-    }
+    STATIC_ASSERT( sizeof(pj_int32) == 4 );
+    STATIC_ASSERT( sizeof(double) == 8 );
 
 /* -------------------------------------------------------------------- */
 /*      Read the overview header.                                       */
@@ -541,8 +517,8 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
         ct->del.lam = *((double *) (header+9*16+8));
         ct->del.phi = *((double *) (header+8*16+8));
 
-        ct->lim.lam = (int) (fabs(ur.lam-ct->ll.lam)/ct->del.lam + 0.5) + 1;
-        ct->lim.phi = (int) (fabs(ur.phi-ct->ll.phi)/ct->del.phi + 0.5) + 1;
+        ct->lim.lam = (pj_int32) (fabs(ur.lam-ct->ll.lam)/ct->del.lam + 0.5) + 1;
+        ct->lim.phi = (pj_int32) (fabs(ur.phi-ct->ll.phi)/ct->del.phi + 0.5) + 1;
 
         pj_log( ctx, PJ_LOG_DEBUG_MINOR,
                 "NTv2 %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)\n",
@@ -669,23 +645,8 @@ static int pj_gridinfo_init_ntv1( projCtx ctx, PAFile fid, PJ_GRIDINFO *gi )
     struct CTABLE *ct;
     LP		ur;
 
-    assert( sizeof(int) == 4 );
-    assert( sizeof(double) == 8 );
-#ifdef _MSC_VER
-#pragma warning( push )
-/* disable conditional expression is constant */
-#pragma warning( disable : 4127 )
-#endif
-    if( sizeof(int) != 4 || sizeof(double) != 8 )
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-    {
-        pj_log( ctx, PJ_LOG_ERROR,
-                 "basic types of inappropraiate size in nad_load_ntv1()" );
-        pj_ctx_set_errno( ctx, -38 );
-        return 0;
-    }
+    STATIC_ASSERT( sizeof(pj_int32) == 4 );
+    STATIC_ASSERT( sizeof(double) == 8 );
 
 /* -------------------------------------------------------------------- */
 /*      Read the header.                                                */
@@ -734,8 +695,8 @@ static int pj_gridinfo_init_ntv1( projCtx ctx, PAFile fid, PJ_GRIDINFO *gi )
     ur.phi = *((double *) (header+40));
     ct->del.lam = *((double *) (header+104));
     ct->del.phi = *((double *) (header+88));
-    ct->lim.lam = (int) (fabs(ur.lam-ct->ll.lam)/ct->del.lam + 0.5) + 1;
-    ct->lim.phi = (int) (fabs(ur.phi-ct->ll.phi)/ct->del.phi + 0.5) + 1;
+    ct->lim.lam = (pj_int32) (fabs(ur.lam-ct->ll.lam)/ct->del.lam + 0.5) + 1;
+    ct->lim.phi = (pj_int32) (fabs(ur.phi-ct->ll.phi)/ct->del.phi + 0.5) + 1;
 
     pj_log( ctx, PJ_LOG_DEBUG_MINOR,
             "NTv1 %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)",
@@ -769,23 +730,8 @@ static int pj_gridinfo_init_gtx( projCtx ctx, PAFile fid, PJ_GRIDINFO *gi )
     double      xorigin,yorigin,xstep,ystep;
     int         rows, columns;
 
-    assert( sizeof(int) == 4 );
-    assert( sizeof(double) == 8 );
-#ifdef _MSC_VER
-#pragma warning( push )
-/* disable conditional expression is constant */
-#pragma warning( disable : 4127 )
-#endif
-    if( sizeof(int) != 4 || sizeof(double) != 8 )
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-    {
-        pj_log( ctx, PJ_LOG_ERROR,
-                "basic types of inappropraiate size in nad_load_gtx()" );
-        pj_ctx_set_errno( ctx, -38 );
-        return 0;
-    }
+    STATIC_ASSERT( sizeof(pj_int32) == 4 );
+    STATIC_ASSERT( sizeof(double) == 8 );
 
 /* -------------------------------------------------------------------- */
 /*      Read the header.                                                */

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -33,16 +33,6 @@
 #include <string.h>
 #include <math.h>
 
-#ifdef _WIN32_WCE
-/* assert.h includes all Windows API headers and causes 'LP' name clash.
- * Here assert we disable assert() for Windows CE.
- * TODO - mloskot: re-implement porting friendly assert
- */
-# define assert(exp)	((void)0)
-#else
-# include <assert.h>
-#endif /* _WIN32_WCE */
-
 static PJ_GRIDINFO *grid_list = NULL;
 #define PJ_MAX_PATH_LENGTH 1024
 

--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -69,10 +69,10 @@ extern "C" {
 
 
 
-#ifndef PROJ_H
 extern char const pj_release[]; /* global release id string */
 extern int pj_errno;    /* global error return code */
 
+#ifndef PROJ_H
 /* In proj.h these macros are replaced by the enumeration pj_log_level */
 #define PJ_LOG_NONE        0
 #define PJ_LOG_ERROR       1

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -48,6 +48,8 @@
 extern "C" {
 #endif
 
+#define STATIC_ASSERT(COND) ((void)sizeof(char[(COND) ? 1 : -1]))
+
 #ifndef PJ_TODEG
 #define PJ_TODEG(rad)  ((rad)*180.0/M_PI)
 #endif

--- a/src/projects.h
+++ b/src/projects.h
@@ -43,6 +43,7 @@
 #endif
 
 /* standard inclusions */
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,6 +77,14 @@ extern "C" {
 
 #ifndef ABS
 #  define ABS(x)        ((x<0) ? (-1*(x)) : x)
+#endif
+
+#if INT_MAX == 2147483647
+typedef int pj_int32;
+#elif LONG_MAX == 2147483647
+typedef long pj_int32;
+#else
+#warning It seems no 32-bit integer type is available
 #endif
 
 /* maximum path/filename */
@@ -618,7 +627,7 @@ PJ *pj_projection_specific_setup_##name (PJ *P)
 
 #define MAX_TAB_ID 80
 typedef struct { float lam, phi; } FLP;
-typedef struct { int lam, phi; } ILP;
+typedef struct { pj_int32 lam, phi; } ILP;
 
 struct CTABLE {
     char id[MAX_TAB_ID];    /* ascii info */


### PR DESCRIPTION
Decisions regarding the size of certain types are always made at compile time, hence this is where the assertion should take place.

If the assertions fail, there is now a compiler error.