### PR TITLE
Allow nested pipelines.

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -377,10 +377,12 @@ PJ *PROJECTION(pipeline) {
 
         if (0==strcmp ("proj=pipeline", argv[i])) {
             if (-1 != i_pipeline) {
-                proj_log_error (P, "Pipeline: Nesting invalid");
-                return destructor (P, PJD_ERR_MALFORMED_PIPELINE); /* ERROR: nested pipelines */
+                /* mark nested "proj=pipeline" and subsequent "step" for later processign */
+                argv[i] = "NESTEDPIPE";
+                if (i+1 < argc) argv[++i] = "NESTEDPIPE";
+            } else {
+                i_pipeline = i;
             }
-            i_pipeline = i;
         }
     }
     nsteps--; /* Last instance of +step is just a sentinel */
@@ -406,8 +408,10 @@ PJ *PROJECTION(pipeline) {
         proj_log_trace (P, "Pipeline: Building arg list for step no. %d", i);
 
         /* First add the step specific args */
-        for (j = i_current_step + 1;  0 != strcmp ("step", argv[j]); j++)
-            current_argv[current_argc++] = argv[j];
+        for (j = i_current_step + 1;  0 != strcmp ("step", argv[j]); j++) {
+            if (strcmp("NESTEDPIPE", argv[j]))
+                current_argv[current_argc++] = argv[j];
+        }
 
         i_current_step = j;
 

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -377,12 +377,10 @@ PJ *PROJECTION(pipeline) {
 
         if (0==strcmp ("proj=pipeline", argv[i])) {
             if (-1 != i_pipeline) {
-                /* mark nested "proj=pipeline" and subsequent "step" for later processign */
-                argv[i] = "NESTEDPIPE";
-                if (i+1 < argc) argv[++i] = "NESTEDPIPE";
-            } else {
-                i_pipeline = i;
+                proj_log_error (P, "Pipeline: Nesting only allowed when child pipelines are wrapped in +init's");
+                return destructor (P, PJD_ERR_MALFORMED_PIPELINE); /* ERROR: nested pipelines */
             }
+            i_pipeline = i;
         }
     }
     nsteps--; /* Last instance of +step is just a sentinel */
@@ -408,10 +406,8 @@ PJ *PROJECTION(pipeline) {
         proj_log_trace (P, "Pipeline: Building arg list for step no. %d", i);
 
         /* First add the step specific args */
-        for (j = i_current_step + 1;  0 != strcmp ("step", argv[j]); j++) {
-            if (strcmp("NESTEDPIPE", argv[j]))
-                current_argv[current_argc++] = argv[j];
-        }
+        for (j = i_current_step + 1;  0 != strcmp ("step", argv[j]); j++)
+            current_argv[current_argc++] = argv[j];
 
         i_current_step = j;
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -381,8 +381,9 @@ pj_init_plus_ctx( projCtx ctx, const char *definition )
 
                 if( argc+1 == MAX_ARG )
                 {
-                    pj_ctx_set_errno( ctx, -44 );
-                    goto bum_call;
+                    pj_dalloc( defn_copy );
+                    pj_ctx_set_errno( ctx, PJD_ERR_UNPARSEABLE_CS_DEF );
+                    return 0;
                 }
 
                 argv[argc++] = defn_copy + i + 1;
@@ -410,9 +411,7 @@ pj_init_plus_ctx( projCtx ctx, const char *definition )
     /* perform actual initialization */
     result = pj_init_ctx( ctx, argc, argv );
 
-bum_call:
     pj_dalloc( defn_copy );
-
     return result;
 }
 

--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -62,7 +62,8 @@ pj_err_list[] = {
     "missing required arguments",                                      /* -54 */
     "lat_0 = 0",                                                       /* -55 */
     "ellipsoidal usage unsupported",                                   /* -56 */
-    
+    "only one +init allowed for non-pipeline operations",              /* -57 */
+
     /* When adding error messages, remember to update ID defines in
        projects.h, and transient_error array in pj_transform                  */
 };

--- a/src/projects.h
+++ b/src/projects.h
@@ -532,6 +532,7 @@ struct FACTORS {
 #define PJD_ERR_MISSING_ARGS            -54
 #define PJD_ERR_LAT_0_IS_ZERO           -55
 #define PJD_ERR_ELLIPSOIDAL_UNSUPPORTED -56
+#define PJD_ERR_TOO_MANY_INITS          -57
 
 struct projFileAPI_t;
 


### PR DESCRIPTION
The previous behaviour was to quit pipeline initialization when
encountering a nested pipeline definition. With this commit that
behaviour is changed so that nested pipelines are expanded into one big
pipeline. Example:

    +proj=pipeline +step +proj=pipeline +step +proj=merc

is turned into

    +proj=pipeline +step +proj=merc

This is useful in init-files where steps in complicated transformations
can be grouped in "sub-pipelines". These "sub-pipelines" can then be
used as individual steps in a larger and more complicated pipeline.