### PR TITLE
change suspicious loop exit condition in nad_cvt

### DIFF
--- a/src/nad_cvt.c
+++ b/src/nad_cvt.c
@@ -1,70 +1,70 @@
 #define PJ_LIB__
-#include <projects.h>
-#define MAX_TRY 10
+#include "projects.h"
+#define MAX_ITERATIONS 10
 #define TOL 1e-12
-	LP
-nad_cvt(LP in, int inverse, struct CTABLE *ct) {
-	LP t, tb;
+
+LP nad_cvt(LP in, int inverse, struct CTABLE *ct) {
+	LP t, tb,del, dif;
+	int i = MAX_ITERATIONS;
+	const double toltol = TOL*TOL;
 
 	if (in.lam == HUGE_VAL)
 		return in;
+
 	/* normalize input to ll origin */
 	tb = in;
 	tb.lam -= ct->ll.lam;
 	tb.phi -= ct->ll.phi;
-	tb.lam = adjlon(tb.lam - M_PI) + M_PI;
-	t = nad_intr(tb, ct);
-	if (inverse) {
-		LP del, dif;
-		int i = MAX_TRY;
+	tb.lam = adjlon (tb.lam - M_PI) + M_PI;
 
-		if (t.lam == HUGE_VAL) return t;
-		t.lam = tb.lam + t.lam;
-		t.phi = tb.phi - t.phi;
+	t = nad_intr (tb, ct);
+	if (t.lam == HUGE_VAL)
+    	return t;
 
-		do {
-			del = nad_intr(t, ct);
-
-                        /* This case used to return failure, but I have
-                           changed it to return the first order approximation
-                           of the inverse shift.  This avoids cases where the
-                           grid shift *into* this grid came from another grid.
-                           While we aren't returning optimally correct results
-                           I feel a close result in this case is better than
-                           no result.  NFW
-                           To demonstrate use -112.5839956 49.4914451 against
-                           the NTv2 grid shift file from Canada. */
-			if (del.lam == HUGE_VAL)
-                        {
-                            if( getenv( "PROJ_DEBUG" ) != NULL )
-                                fprintf( stderr,
-                                         "Inverse grid shift iteration failed, presumably at grid edge.\n"
-                                         "Using first approximation.\n" );
-                            /* return del */;
-                            break;
-                        }
-
-	    	dif.lam = t.lam - del.lam - tb.lam;
-    		dif.phi = t.phi + del.phi - tb.phi;
-			t.lam -= dif.lam;
-			t.phi -= dif.phi;
-		} while (--i && hypot (dif.lam, dif.phi) > TOL);
-		if (i < 0) {
-                    if( getenv( "PROJ_DEBUG" ) != NULL )
-                        fprintf( stderr,
-                                 "Inverse grid shift iterator failed to converge.\n" );
-                    t.lam = t.phi = HUGE_VAL;
-                    return t;
-		}
-		in.lam = adjlon(t.lam + ct->ll.lam);
-		in.phi = t.phi + ct->ll.phi;
-	} else {
-		if (t.lam == HUGE_VAL)
-			in = t;
-		else {
-			in.lam -= t.lam;
-			in.phi += t.phi;
-		}
+	if (!inverse) {
+		in.lam -= t.lam;
+		in.phi += t.phi;
+		return in;
 	}
+
+	t.lam = tb.lam + t.lam;
+	t.phi = tb.phi - t.phi;
+
+	do {
+		del = nad_intr(t, ct);
+
+        /* This case used to return failure, but I have
+           changed it to return the first order approximation
+           of the inverse shift.  This avoids cases where the
+           grid shift *into* this grid came from another grid.
+           While we aren't returning optimally correct results
+           I feel a close result in this case is better than
+           no result.  NFW
+           To demonstrate use -112.5839956 49.4914451 against
+           the NTv2 grid shift file from Canada. */
+		if (del.lam == HUGE_VAL)
+		    break;
+
+    	dif.lam = t.lam - del.lam - tb.lam;
+   		dif.phi = t.phi + del.phi - tb.phi;
+		t.lam -= dif.lam;
+		t.phi -= dif.phi;
+
+	} while (--i && (dif.lam*dif.lam + dif.phi*dif.phi > toltol)); /* prob. slightly faster than hypot() */
+
+	if (i==0) {
+    	/* If we had access to a context, this should go through pj_log, and we should set ctx->errno */
+	    if (getenv ("PROJ_DEBUG"))
+            fprintf( stderr, "Inverse grid shift iterator failed to converge.\n" );
+		t.lam = t.phi = HUGE_VAL;
+		return t;
+	}
+
+	/* and again: pj_log and ctx->errno */
+	if (del.lam==HUGE_VAL && getenv ("PROJ_DEBUG"))
+    	fprintf (stderr, "Inverse grid shift iteration failed, presumably at grid edge.\nUsing first approximation.\n");
+
+	in.lam = adjlon (t.lam + ct->ll.lam);
+	in.phi = t.phi + ct->ll.phi;
 	return in;
 }

--- a/src/nad_cvt.c
+++ b/src/nad_cvt.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <projects.h>
-#define MAX_TRY 9
+#define MAX_TRY 10
 #define TOL 1e-12
 	LP
 nad_cvt(LP in, int inverse, struct CTABLE *ct) {
@@ -34,22 +34,24 @@ nad_cvt(LP in, int inverse, struct CTABLE *ct) {
                            no result.  NFW
                            To demonstrate use -112.5839956 49.4914451 against
                            the NTv2 grid shift file from Canada. */
-			if (del.lam == HUGE_VAL) 
+			if (del.lam == HUGE_VAL)
                         {
                             if( getenv( "PROJ_DEBUG" ) != NULL )
-                                fprintf( stderr, 
+                                fprintf( stderr,
                                          "Inverse grid shift iteration failed, presumably at grid edge.\n"
                                          "Using first approximation.\n" );
                             /* return del */;
                             break;
                         }
 
-			t.lam -= dif.lam = t.lam - del.lam - tb.lam;
-			t.phi -= dif.phi = t.phi + del.phi - tb.phi;
-		} while (i-- && fabs(dif.lam) > TOL && fabs(dif.phi) > TOL);
+	    	dif.lam = t.lam - del.lam - tb.lam;
+    		dif.phi = t.phi + del.phi - tb.phi;
+			t.lam -= dif.lam;
+			t.phi -= dif.phi;
+		} while (--i && hypot (dif.lam, dif.phi) > TOL);
 		if (i < 0) {
                     if( getenv( "PROJ_DEBUG" ) != NULL )
-                        fprintf( stderr, 
+                        fprintf( stderr,
                                  "Inverse grid shift iterator failed to converge.\n" );
                     t.lam = t.phi = HUGE_VAL;
                     return t;

--- a/src/nad_cvt.c
+++ b/src/nad_cvt.c
@@ -4,34 +4,34 @@
 #define TOL 1e-12
 
 LP nad_cvt(LP in, int inverse, struct CTABLE *ct) {
-	LP t, tb,del, dif;
-	int i = MAX_ITERATIONS;
-	const double toltol = TOL*TOL;
+    LP t, tb,del, dif;
+    int i = MAX_ITERATIONS;
+    const double toltol = TOL*TOL;
 
-	if (in.lam == HUGE_VAL)
-		return in;
+    if (in.lam == HUGE_VAL)
+        return in;
 
-	/* normalize input to ll origin */
-	tb = in;
-	tb.lam -= ct->ll.lam;
-	tb.phi -= ct->ll.phi;
-	tb.lam = adjlon (tb.lam - M_PI) + M_PI;
+    /* normalize input to ll origin */
+    tb = in;
+    tb.lam -= ct->ll.lam;
+    tb.phi -= ct->ll.phi;
+    tb.lam = adjlon (tb.lam - M_PI) + M_PI;
 
-	t = nad_intr (tb, ct);
-	if (t.lam == HUGE_VAL)
-    	return t;
+    t = nad_intr (tb, ct);
+    if (t.lam == HUGE_VAL)
+        return t;
 
-	if (!inverse) {
-		in.lam -= t.lam;
-		in.phi += t.phi;
-		return in;
-	}
+    if (!inverse) {
+        in.lam -= t.lam;
+        in.phi += t.phi;
+        return in;
+    }
 
-	t.lam = tb.lam + t.lam;
-	t.phi = tb.phi - t.phi;
+    t.lam = tb.lam + t.lam;
+    t.phi = tb.phi - t.phi;
 
-	do {
-		del = nad_intr(t, ct);
+    do {
+        del = nad_intr(t, ct);
 
         /* This case used to return failure, but I have
            changed it to return the first order approximation
@@ -42,29 +42,29 @@ LP nad_cvt(LP in, int inverse, struct CTABLE *ct) {
            no result.  NFW
            To demonstrate use -112.5839956 49.4914451 against
            the NTv2 grid shift file from Canada. */
-		if (del.lam == HUGE_VAL)
-		    break;
+        if (del.lam == HUGE_VAL)
+            break;
 
-    	dif.lam = t.lam - del.lam - tb.lam;
-   		dif.phi = t.phi + del.phi - tb.phi;
-		t.lam -= dif.lam;
-		t.phi -= dif.phi;
+        dif.lam = t.lam - del.lam - tb.lam;
+           dif.phi = t.phi + del.phi - tb.phi;
+        t.lam -= dif.lam;
+        t.phi -= dif.phi;
 
-	} while (--i && (dif.lam*dif.lam + dif.phi*dif.phi > toltol)); /* prob. slightly faster than hypot() */
+    } while (--i && (dif.lam*dif.lam + dif.phi*dif.phi > toltol)); /* prob. slightly faster than hypot() */
 
-	if (i==0) {
-    	/* If we had access to a context, this should go through pj_log, and we should set ctx->errno */
-	    if (getenv ("PROJ_DEBUG"))
+    if (i==0) {
+        /* If we had access to a context, this should go through pj_log, and we should set ctx->errno */
+        if (getenv ("PROJ_DEBUG"))
             fprintf( stderr, "Inverse grid shift iterator failed to converge.\n" );
-		t.lam = t.phi = HUGE_VAL;
-		return t;
-	}
+        t.lam = t.phi = HUGE_VAL;
+        return t;
+    }
 
-	/* and again: pj_log and ctx->errno */
-	if (del.lam==HUGE_VAL && getenv ("PROJ_DEBUG"))
-    	fprintf (stderr, "Inverse grid shift iteration failed, presumably at grid edge.\nUsing first approximation.\n");
+    /* and again: pj_log and ctx->errno */
+    if (del.lam==HUGE_VAL && getenv ("PROJ_DEBUG"))
+        fprintf (stderr, "Inverse grid shift iteration failed, presumably at grid edge.\nUsing first approximation.\n");
 
-	in.lam = adjlon (t.lam + ct->ll.lam);
-	in.phi = t.phi + ct->ll.phi;
-	return in;
+    in.lam = adjlon (t.lam + ct->ll.lam);
+    in.phi = t.phi + ct->ll.phi;
+    return in;
 }


### PR DESCRIPTION
This loop exit condition in nad_cvt.c looks suspicious:

    while (i-- && fabs(dif.lam) > TOL && fabs(dif.phi) > TOL)

This would mean that we exit the iteration if ***either*** `dif.lam` ***or*** `dif.phi` converged. Hence, we may exit as soon as one dimension is OK, while the other may still be kilometers off.

I have changed it to

    while (--i && hypot (dif.lam, dif.phi) > TOL)

This introduces a slightly stronger convergence criterium (we must be "inside the disk", rather than "inside the box"), and as the "inside the box" criterium was apparently misimplemented, the criterium change is even stronger.

This will probably introduce small regressions in all tests involving NADCON style datum shifts.

I discovered the suspicious loop condition while reviewing PR #588, where @kbevers uses essentially the same code.  I may, however, have misunderstood subtle aspects of this, so please try to find time to review this!