### PR TITLE
Make sure to use the same context for pipeline childs as for the parent

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -436,7 +436,7 @@ PJ *PROJECTION(pipeline) {
         for (j = 1;  j < current_argc; j++)
             proj_log_trace (P, "    %s", current_argv[j]);
 
-        next_step = pj_init (current_argc, current_argv);
+        next_step = pj_init_ctx (P->ctx, current_argc, current_argv);
         proj_log_trace (P, "Pipeline: Step %d at %p", i, next_step);
         if (0==next_step) {
             proj_log_error (P, "Pipeline: Bad step definition: %s", current_argv[0]);


### PR DESCRIPTION
Currently the default context is used for pipeline children operations, no matter what context is set for the pipeline operation it self. This change makes sure that the parent context is propagated to it's children.