### PR TITLE
Pipeline cleanup (WIP)

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -111,9 +111,6 @@ struct pj_opaque {
     int reversible;
     int steps;
     int verbose;
-    int *reverse_step;
-    int *omit_forward;
-    int *omit_inverse;
     char **argv;
     char **current_argv;
     PJ **pipeline;
@@ -183,17 +180,12 @@ static PJ_OBS pipeline_forward_obs (PJ_OBS point, PJ *P) {
     first_step = 1;
     last_step  = P->opaque->steps + 1;
 
-    for (i = first_step;  i != last_step;  i++) {
-        if (P->opaque->omit_forward[i])
-            continue;
-        if (P->opaque->reverse_step[i])
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_INV, point);
-        else
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_FWD, point);
-    }
+    for (i = first_step;  i != last_step;  i++)
+        point = proj_trans_obs (P->opaque->pipeline[i], 1, point);
 
     return point;
 }
+
 
 
 static PJ_OBS pipeline_reverse_obs (PJ_OBS point, PJ *P) {
@@ -201,14 +193,9 @@ static PJ_OBS pipeline_reverse_obs (PJ_OBS point, PJ *P) {
 
     first_step = P->opaque->steps;
     last_step  =  0;
-    for (i = first_step;  i != last_step;  i--) {
-        if (P->opaque->omit_inverse[i])
-            continue;
-        if (P->opaque->reverse_step[i])
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_FWD, point);
-        else
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_INV, point);
-    }
+
+    for (i = first_step;  i != last_step;  i--)
+        point = proj_trans_obs (P->opaque->pipeline[i], -1, point);
 
     return point;
 }
@@ -260,9 +247,6 @@ static void *destructor (PJ *P, int errlev) {
                 P->opaque->pipeline[i+1]->destructor (P->opaque->pipeline[i+1], errlev);
     pj_dealloc (P->opaque->pipeline);
 
-    pj_dealloc (P->opaque->reverse_step);
-    pj_dealloc (P->opaque->omit_forward);
-    pj_dealloc (P->opaque->omit_inverse);
     pj_dealloc (P->opaque->argv);
     pj_dealloc (P->opaque->current_argv);
 
@@ -278,18 +262,6 @@ static PJ *pj_create_pipeline (PJ *P, size_t steps) {
         return 0;
 
     P->opaque->steps = (int)steps;
-
-    P->opaque->reverse_step =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->reverse_step)
-        return 0;
-
-    P->opaque->omit_forward =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->omit_forward)
-        return 0;
-
-    P->opaque->omit_inverse =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->omit_inverse)
-        return 0;
 
     return P;
 }
@@ -318,6 +290,7 @@ static char **argv_params (paralist *params, size_t argc) {
     argv[i++] = argv_sentinel;
     return argv;
 }
+
 
 
 PJ *PROJECTION(pipeline) {
@@ -399,84 +372,35 @@ PJ *PROJECTION(pipeline) {
         for (j = i_pipeline + 1;  0 != strcmp ("step", argv[j]); j++)
             current_argv[current_argc++] = argv[j];
 
-        /* Finally handle non-symmetric steps and inverted steps */
-        for (j = 0;  j < current_argc; j++) {
-            if (0==strcmp("omit_inv", current_argv[j])) {
-                P->opaque->omit_inverse[i+1] = 1;
-                P->opaque->omit_forward[i+1] = 0;
-            }
-            if (0==strcmp("omit_fwd", current_argv[j])) {
-                P->opaque->omit_inverse[i+1] = 0;
-                P->opaque->omit_forward[i+1] = 1;
-            }
-            if (0==strcmp("inv", current_argv[j]))
-                P->opaque->reverse_step[i+1] = 1;
-        }
-
         proj_log_trace (P, "Pipeline: init - %s, %d", current_argv[0], current_argc);
         for (j = 1;  j < current_argc; j++)
             proj_log_trace (P, "    %s", current_argv[j]);
 
         next_step = pj_init_ctx (P->ctx, current_argc, current_argv);
+
         proj_log_trace (P, "Pipeline: Step %d at %p", i, next_step);
         if (0==next_step) {
             proj_log_error (P, "Pipeline: Bad step definition: %s", current_argv[0]);
             return destructor (P, PJD_ERR_MALFORMED_PIPELINE); /* ERROR: bad pipeline def */
         }
+
+        /* Is this step inverted? */
+        for (j = 0;  j < current_argc; j++)
+            if (0==strcmp("inv", current_argv[j]))
+                next_step->inverted = 1;
+
         P->opaque->pipeline[i+1] = next_step;
+
         proj_log_trace (P, "Pipeline:    step done");
     }
 
     proj_log_trace (P, "Pipeline: %d steps built. Determining i/o characteristics", nsteps);
 
     /* Determine forward input (= reverse output) data type */
-
-    /* First locate the first forward-active pipeline step */
-    for (i = 0;  i < nsteps;  i++)
-        if (0==P->opaque->omit_forward[i+1])
-            break;
-    if (i==nsteps) {
-        proj_log_error (P, "Pipeline: No forward steps");
-        return destructor (P, PJD_ERR_MALFORMED_PIPELINE);
-    }
-
-    if (P->opaque->reverse_step[i + 1])
-        P->left = P->opaque->pipeline[i + 1]->right;
-    else
-        P->left = P->opaque->pipeline[i + 1]->left;
-
-    if (P->left==PJ_IO_UNITS_CLASSIC) {
-        if (P->opaque->reverse_step[i + 1])
-            P->left = PJ_IO_UNITS_METERS;
-        else
-            P->left = PJ_IO_UNITS_RADIANS;
-    }
+    P->left = pj_left (P->opaque->pipeline[1]);
 
     /* Now, correspondingly determine forward output (= reverse input) data type */
-
-    /* First locate the last reverse-active pipeline step */
-    for (i = nsteps - 1;  i >= 0;  i--)
-        if (0==P->opaque->omit_inverse[i+1])
-            break;
-    if (i==-1) {
-        proj_log_error (P, "Pipeline: No reverse steps");
-        return destructor (P, PJD_ERR_MALFORMED_PIPELINE);
-    }
-
-    if (P->opaque->reverse_step[i + 1])
-        P->right = P->opaque->pipeline[i + 1]->left;
-    else
-        P->right = P->opaque->pipeline[i + 1]->right;
-
-    if (P->right==PJ_IO_UNITS_CLASSIC) {
-        if (P->opaque->reverse_step[i + 1])
-            P->right = PJ_IO_UNITS_RADIANS;
-        else
-            P->right = PJ_IO_UNITS_METERS;
-    }
-    proj_log_trace (P, "Pipeline: Units - left: [%s], right: [%s]\n",
-        P->left ==PJ_IO_UNITS_RADIANS? "angular": "linear",
-        P->right==PJ_IO_UNITS_RADIANS? "angular": "linear");
+    P->right = pj_right (P->opaque->pipeline[nsteps]);
 
     return P;
 }
@@ -493,14 +417,14 @@ int pj_pipeline_selftest (void) {
     double dist;
 
     /* forward-reverse geo->utm->geo */
-    P = proj_create (PJ_DEFAULT_CTX, "+proj=pipeline +zone=32 +step +proj=utm +ellps=GRS80 +step +proj=utm +ellps=GRS80 +inv");
+    P = proj_create (PJ_DEFAULT_CTX, "+proj=pipeline +zone=32 +step +proj=utm   +ellps=GRS80 +step +proj=utm   +ellps=GRS80 +inv");
     if (0==P)
         return 1000;
     /* zero initialize everything, then set (longitude, latitude, height) to (12, 55, 0) */
     a = b = proj_obs_null;
     a.coo.lpz.lam = PJ_TORAD(12);
     a.coo.lpz.phi = PJ_TORAD(55);
-    a.coo.lpz.z   = 0;
+    a.coo.lpz.z   = 10;
 
     /* Forward projection */
     b = proj_trans_obs (P, PJ_FWD, a);

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -66,12 +66,27 @@ PJ_OBS proj_obs (double x, double y, double z, double t) {
 
 
 
+enum pj_io_units pj_left (PJ *P) {
+    enum pj_io_units u = P->inverted? P->right: P->left;
+    if (u==PJ_IO_UNITS_RADIANS)
+        return PJ_IO_UNITS_RADIANS;
+    return PJ_IO_UNITS_METERS;
+}
 
+enum pj_io_units pj_right (PJ *P) {
+    enum pj_io_units u = P->inverted? P->left: P->right;
+    if (u==PJ_IO_UNITS_RADIANS)
+        return PJ_IO_UNITS_RADIANS;
+    return PJ_IO_UNITS_METERS;
+}
 
 /* Apply the transformation P to the coordinate coo */
 PJ_OBS proj_trans_obs (PJ *P, PJ_DIRECTION direction, PJ_OBS obs) {
     if (0==P)
         return obs;
+
+    if (P->inverted)
+        direction = -direction;
 
     switch (direction) {
         case PJ_FWD:

--- a/src/proj.def
+++ b/src/proj.def
@@ -146,6 +146,3 @@ EXPORTS
     proj_list_ellps                @132
     proj_list_units                @133
     proj_list_prime_meridians      @134
-
-    pj_left                        @135
-    pj_right                       @136

--- a/src/proj.def
+++ b/src/proj.def
@@ -146,3 +146,6 @@ EXPORTS
     proj_list_ellps                @132
     proj_list_units                @133
     proj_list_prime_meridians      @134
+
+    pj_left                        @135
+    pj_right                       @136

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -45,7 +45,6 @@ PJ_COORD proj_coord (double x, double y, double z, double t) {
 }
 
 
-
 /* Geodesic distance (in meter) between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, LP a, LP b) {
     double s12, azi1, azi2;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -64,6 +64,8 @@ typedef struct PJ_OBS PJ_OBS;
 #endif
 
 
+enum pj_io_units pj_left (PJ *P);
+enum pj_io_units pj_right (PJ *P);
 
 PJ_OBS   proj_obs   (double x, double y, double z, double t);
 PJ_OBS   proj_trans_obs   (PJ *P, PJ_DIRECTION direction, PJ_OBS obs);

--- a/src/projects.h
+++ b/src/projects.h
@@ -231,6 +231,7 @@ struct PJconsts {
     paralist *params;              /* Parameter list */
     struct geod_geodesic *geod;    /* For geodesic computations */
     struct pj_opaque *opaque;      /* Projection specific parameters, Defined in PJ_*.c */
+    int inverted;                  /* Tell high level API functions to swap inv/fwd */
 
 
     /*************************************************************************************


### PR DESCRIPTION
Some debugging cruft was left over in the inner loop of the pipeline drivers `pipeline_forward_obs`  and `pipeline_reverse_obs`, which meant that for each step in the pipeline, an extra function call and some additional futile memory management, was incurred.

While the debugging info at high debug levels could be useful, really, debugging a pipeline should be done by adding probe steps to the pipeline, printing out intermediate results in between the payload steps.

Only problem is that such probes do not exist yet. Basically, they should work as the code removed in this PR, while having the IO type `PJ_IO_UNITS_ANY` which does not exist either, but is anticipated in line 166 of `PJ_pipeline.c`.

Hence, this PR is just a first step. It appears that a lot needs to be done to properly clean up the pipeline code. First and foremost, we should disallow the "one directional steps" (`omit_fwd` and `omit_inv`), since we have yet to see a use case.

Next we need to go over all the classic projections once more, and make them return values in meters, rather than in units of the semimajor axis. This will let us eliminate the `PJ_IO_UNITS_CLASSIC` flag, and make projections honest about what they return.

With this in place, we can let the `pj_init` functions handle the `+inv` flag, by swapping the right and left indicators, and the inverse and forward functions. The latter can, however,  be done for the 4D cases only, since `pj_fwdobs` and `pj_invobs` functions have identical prototypes, while fwd and inv differ for the two and three dimensional stuff.

All in all an enormous, but potentially quite rewarding task.

But for now, I will take the more pragmatic step of introducing *two* probe functions - one for printing linear coordinates and one for printing angular. This sidesteps the PJ_IO_UNITS_ANY problem.

Also, the one-way steps should be eliminated, and the entire "swap funcs and flags" thing can be handled by the pipeline code, since it uses proj_trans_obs, which in turn calls pj_fwdobs and pj_invobs to do the heavy lifting. All in all, this will dramatically reduce the complexity of the pipeline code, while keeping the changes localized. It will probably also result in a slight speed improvement.