### PR TITLE
Improve ISO 19000 alignment

### DIFF
--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -461,7 +461,7 @@ static PJ_OBS helmert_reverse_obs (PJ_OBS point, PJ *P) {
 #define ARCSEC_TO_RAD (DEG_TO_RAD / 3600.0)
 
 /***********************************************************************/
-PJ *PROJECTION(helmert) {
+PJ *OPERATION(helmert, PJ_IO_UNITS_METERS, PJ_IO_UNITS_METERS, 0) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = pj_calloc (1, sizeof (struct pj_opaque_helmert));
     if (0==Q)

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -461,7 +461,7 @@ static PJ_OBS helmert_reverse_obs (PJ_OBS point, PJ *P) {
 #define ARCSEC_TO_RAD (DEG_TO_RAD / 3600.0)
 
 /***********************************************************************/
-PJ *OPERATION(helmert, PJ_IO_UNITS_METERS, PJ_IO_UNITS_METERS, 0) {
+PJ *TRANSFORMATION(helmert, PJ_IO_UNITS_METERS, PJ_IO_UNITS_METERS, 0) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = pj_calloc (1, sizeof (struct pj_opaque_helmert));
     if (0==Q)

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -461,7 +461,7 @@ static PJ_OBS helmert_reverse_obs (PJ_OBS point, PJ *P) {
 #define ARCSEC_TO_RAD (DEG_TO_RAD / 3600.0)
 
 /***********************************************************************/
-PJ *TRANSFORMATION(helmert, PJ_IO_UNITS_METERS, PJ_IO_UNITS_METERS, 0) {
+PJ *TRANSFORMATION(helmert, 0) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = pj_calloc (1, sizeof (struct pj_opaque_helmert));
     if (0==Q)

--- a/src/projects.h
+++ b/src/projects.h
@@ -584,7 +584,7 @@ extern struct PJ_PRIME_MERIDIANS pj_prime_meridians[];
 #ifdef PJ_LIB__
 #define PROJ_HEAD(id, name) static const char des_##id [] = name
 
-#define OPERATION(name, LEFT, RIGHT, NEED_ELLPS)             \
+#define OPERATION(name, NEED_ELLPS)                          \
                                                              \
 pj_projection_specific_setup_##name (PJ *P);                 \
 C_NAMESPACE PJ *pj_##name (PJ *P);                           \
@@ -601,19 +601,19 @@ C_NAMESPACE PJ *pj_##name (PJ *P) {                          \
     P->destructor = pj_default_destructor;                   \
     P->descr = des_##name;                                   \
     P->need_ellps = NEED_ELLPS;                              \
-    P->left  = LEFT;                                         \
-    P->right = RIGHT;                                        \
+    P->left  = PJ_IO_UNITS_RADIANS;                          \
+    P->right = PJ_IO_UNITS_CLASSIC;                          \
     return P;                                                \
 }                                                            \
                                                              \
 PJ *pj_projection_specific_setup_##name (PJ *P)
 
 /* In ISO19000 lingo, an operation is either a conversion or a transformation */
-#define CONVERSION(name, left, right, need_ellps)      OPERATION (name, left, right, need_ellps)
-#define TRANSFORMATION(name, left, right, need_ellps)  OPERATION (name, left, right, need_ellps)
+#define CONVERSION(name, need_ellps)      OPERATION (name, need_ellps)
+#define TRANSFORMATION(name, need_ellps)  OPERATION (name, need_ellps)
 
 /* In PROJ.4 a projection is a conversion taking angular input and giving scaled linear output */
-#define PROJECTION(name) CONVERSION (name, PJ_IO_UNITS_RADIANS, PJ_IO_UNITS_CLASSIC, 1)
+#define PROJECTION(name) CONVERSION (name, 1)
 
 #endif /* def PJ_LIB__ */
 


### PR DESCRIPTION
Predating the ISO 19000 series by more than a decade, it is not surprising that PROJ.4 concepts are not entirely aligned with ISO 19000., and hence are slightly out of tune with how the general geoprocessing software stack views the world.

There is, however, plenty of low hanging fruit, where we can significantly improve the alignment by small code adjustments. This is a first example, introducing explicit conceptual differentiation between conversions and transformations.

In ISO 19000 lingo, a ***conversion*** is of mathematical nature, and hence in principle *exact*, while a ***transformation*** is based on physical observations, and hence depending on our present knowledge of the environment.

So e.g. projections are conversions, while datum shifts are typically transformations. The union of conversions and transformations is called ***operations***.

This PR grew from a discussion with @kbevers about how to tell the PROJ.4 plumbing that a given operation did not need access to ellipsoid information. The problem is that PROJ.4 init functionality insists that a spheroid is specified, but in cases like the Helmert transformation, it is not needed, and you must specify a dummy.

So to introduce a better communication between the `PJ_***.c` individual operation implementation code, and the `pj_init.c` plumbing code,  let's introduce a new setup macro `OPERATION`, replacing `PROJECTION`, which now becomes a specialization (i.e. a *partial evaluation*) of `OPERATION`.