### PR TITLE
Make tol a parameter in pj phi2 (lcc, merc, omerc, gstmerc)

### DIFF
--- a/src/PJ_calcofi.c
+++ b/src/PJ_calcofi.c
@@ -57,7 +57,7 @@ static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     l1 = (xy.y - oy) * tan(ROTATION_ANGLE);
     l2 = -xy.x - l1 + PT_O_LAMBDA;
     ry = l2 * cos(ROTATION_ANGLE) * sin(ROTATION_ANGLE) + xy.y;
-    ry = pj_phi2(P->ctx, exp(-ry), P->e); /*inverse Mercator*/
+    ry = pj_phi2(P, exp(-ry), 1e-10); /* inverse Mercator */
     xy.x = PT_O_LINE - RAD_TO_DEG *
         (ry - PT_O_PHI) * DEG_TO_LINE / cos(ROTATION_ANGLE);
     xy.y = PT_O_STATION + RAD_TO_DEG *

--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -93,7 +93,6 @@ static void special(LP lp, PJ *P, struct FACTORS *fac) {
 PJ *PROJECTION(lcc) {
     double cosphi, sinphi;
     int secant;
-    int itol;
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
 
     if (0==Q)

--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -4,7 +4,7 @@
 #include "projects.h"
 
 PROJ_HEAD(lcc, "Lambert Conformal Conic")
-    "\n\tConic, Sph&Ell\n\tlat_1= and lat_2= or lat_0";
+    "\n\tConic, Sph&Ell\n\tlat_1= and lat_2= or lat_0=. tol=";
 
 # define EPS10  1.e-10
 
@@ -14,6 +14,7 @@ struct pj_opaque {
     double n;
     double rho0;
     double c;
+    double tol;
     int    ellips;
 };
 
@@ -57,7 +58,7 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
             xy.y = -xy.y;
         }
         if (Q->ellips) {
-            lp.phi = pj_phi2(P->ctx, pow(rho / Q->c, 1./Q->n), P->e);
+            lp.phi = pj_phi2(P, pow(rho / Q->c, 1./Q->n), Q->tol);
             if (lp.phi == HUGE_VAL) {
                 proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
                 return lp;
@@ -92,12 +93,18 @@ static void special(LP lp, PJ *P, struct FACTORS *fac) {
 PJ *PROJECTION(lcc) {
     double cosphi, sinphi;
     int secant;
+    int itol;
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
 
     if (0==Q)
         return pj_default_destructor (P, ENOMEM);
     P->opaque = Q;
 
+    /* convergence tolerance for pj_phi2, used in inverse case */
+    if (!pj_param(P->ctx, P->params, "ttol").i)
+        Q->tol = 1e-10;
+    else
+        Q->tol = pj_param(P->ctx, P->params, "ttol").f;
 
     Q->phi1 = pj_param(P->ctx, P->params, "rlat_1").f;
     if (pj_param(P->ctx, P->params, "tlat_2").i)

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -111,9 +111,6 @@ struct pj_opaque {
     int reversible;
     int steps;
     int verbose;
-    int *reverse_step;
-    int *omit_forward;
-    int *omit_inverse;
     char **argv;
     char **current_argv;
     PJ **pipeline;
@@ -183,17 +180,12 @@ static PJ_OBS pipeline_forward_obs (PJ_OBS point, PJ *P) {
     first_step = 1;
     last_step  = P->opaque->steps + 1;
 
-    for (i = first_step;  i != last_step;  i++) {
-        if (P->opaque->omit_forward[i])
-            continue;
-        if (P->opaque->reverse_step[i])
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_INV, point);
-        else
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_FWD, point);
-    }
+    for (i = first_step;  i != last_step;  i++)
+        point = proj_trans_obs (P->opaque->pipeline[i], 1, point);
 
     return point;
 }
+
 
 
 static PJ_OBS pipeline_reverse_obs (PJ_OBS point, PJ *P) {
@@ -201,14 +193,9 @@ static PJ_OBS pipeline_reverse_obs (PJ_OBS point, PJ *P) {
 
     first_step = P->opaque->steps;
     last_step  =  0;
-    for (i = first_step;  i != last_step;  i--) {
-        if (P->opaque->omit_inverse[i])
-            continue;
-        if (P->opaque->reverse_step[i])
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_FWD, point);
-        else
-            point = proj_trans_obs (P->opaque->pipeline[i], PJ_INV, point);
-    }
+
+    for (i = first_step;  i != last_step;  i--)
+        point = proj_trans_obs (P->opaque->pipeline[i], -1, point);
 
     return point;
 }
@@ -260,9 +247,6 @@ static void *destructor (PJ *P, int errlev) {
                 P->opaque->pipeline[i+1]->destructor (P->opaque->pipeline[i+1], errlev);
     pj_dealloc (P->opaque->pipeline);
 
-    pj_dealloc (P->opaque->reverse_step);
-    pj_dealloc (P->opaque->omit_forward);
-    pj_dealloc (P->opaque->omit_inverse);
     pj_dealloc (P->opaque->argv);
     pj_dealloc (P->opaque->current_argv);
 
@@ -278,18 +262,6 @@ static PJ *pj_create_pipeline (PJ *P, size_t steps) {
         return 0;
 
     P->opaque->steps = (int)steps;
-
-    P->opaque->reverse_step =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->reverse_step)
-        return 0;
-
-    P->opaque->omit_forward =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->omit_forward)
-        return 0;
-
-    P->opaque->omit_inverse =  pj_calloc (steps + 2, sizeof(int));
-    if (0==P->opaque->omit_inverse)
-        return 0;
 
     return P;
 }
@@ -318,6 +290,7 @@ static char **argv_params (paralist *params, size_t argc) {
     argv[i++] = argv_sentinel;
     return argv;
 }
+
 
 
 PJ *PROJECTION(pipeline) {
@@ -399,84 +372,35 @@ PJ *PROJECTION(pipeline) {
         for (j = i_pipeline + 1;  0 != strcmp ("step", argv[j]); j++)
             current_argv[current_argc++] = argv[j];
 
-        /* Finally handle non-symmetric steps and inverted steps */
-        for (j = 0;  j < current_argc; j++) {
-            if (0==strcmp("omit_inv", current_argv[j])) {
-                P->opaque->omit_inverse[i+1] = 1;
-                P->opaque->omit_forward[i+1] = 0;
-            }
-            if (0==strcmp("omit_fwd", current_argv[j])) {
-                P->opaque->omit_inverse[i+1] = 0;
-                P->opaque->omit_forward[i+1] = 1;
-            }
-            if (0==strcmp("inv", current_argv[j]))
-                P->opaque->reverse_step[i+1] = 1;
-        }
-
         proj_log_trace (P, "Pipeline: init - %s, %d", current_argv[0], current_argc);
         for (j = 1;  j < current_argc; j++)
             proj_log_trace (P, "    %s", current_argv[j]);
 
         next_step = pj_init_ctx (P->ctx, current_argc, current_argv);
+
         proj_log_trace (P, "Pipeline: Step %d at %p", i, next_step);
         if (0==next_step) {
             proj_log_error (P, "Pipeline: Bad step definition: %s", current_argv[0]);
             return destructor (P, PJD_ERR_MALFORMED_PIPELINE); /* ERROR: bad pipeline def */
         }
+
+        /* Is this step inverted? */
+        for (j = 0;  j < current_argc; j++)
+            if (0==strcmp("inv", current_argv[j]))
+                next_step->inverted = 1;
+
         P->opaque->pipeline[i+1] = next_step;
+
         proj_log_trace (P, "Pipeline:    step done");
     }
 
     proj_log_trace (P, "Pipeline: %d steps built. Determining i/o characteristics", nsteps);
 
     /* Determine forward input (= reverse output) data type */
-
-    /* First locate the first forward-active pipeline step */
-    for (i = 0;  i < nsteps;  i++)
-        if (0==P->opaque->omit_forward[i+1])
-            break;
-    if (i==nsteps) {
-        proj_log_error (P, "Pipeline: No forward steps");
-        return destructor (P, PJD_ERR_MALFORMED_PIPELINE);
-    }
-
-    if (P->opaque->reverse_step[i + 1])
-        P->left = P->opaque->pipeline[i + 1]->right;
-    else
-        P->left = P->opaque->pipeline[i + 1]->left;
-
-    if (P->left==PJ_IO_UNITS_CLASSIC) {
-        if (P->opaque->reverse_step[i + 1])
-            P->left = PJ_IO_UNITS_METERS;
-        else
-            P->left = PJ_IO_UNITS_RADIANS;
-    }
+    P->left = pj_left (P->opaque->pipeline[1]);
 
     /* Now, correspondingly determine forward output (= reverse input) data type */
-
-    /* First locate the last reverse-active pipeline step */
-    for (i = nsteps - 1;  i >= 0;  i--)
-        if (0==P->opaque->omit_inverse[i+1])
-            break;
-    if (i==-1) {
-        proj_log_error (P, "Pipeline: No reverse steps");
-        return destructor (P, PJD_ERR_MALFORMED_PIPELINE);
-    }
-
-    if (P->opaque->reverse_step[i + 1])
-        P->right = P->opaque->pipeline[i + 1]->left;
-    else
-        P->right = P->opaque->pipeline[i + 1]->right;
-
-    if (P->right==PJ_IO_UNITS_CLASSIC) {
-        if (P->opaque->reverse_step[i + 1])
-            P->right = PJ_IO_UNITS_RADIANS;
-        else
-            P->right = PJ_IO_UNITS_METERS;
-    }
-    proj_log_trace (P, "Pipeline: Units - left: [%s], right: [%s]\n",
-        P->left ==PJ_IO_UNITS_RADIANS? "angular": "linear",
-        P->right==PJ_IO_UNITS_RADIANS? "angular": "linear");
+    P->right = pj_right (P->opaque->pipeline[nsteps]);
 
     return P;
 }
@@ -493,14 +417,14 @@ int pj_pipeline_selftest (void) {
     double dist;
 
     /* forward-reverse geo->utm->geo */
-    P = proj_create (PJ_DEFAULT_CTX, "+proj=pipeline +zone=32 +step +proj=utm +ellps=GRS80 +step +proj=utm +ellps=GRS80 +inv");
+    P = proj_create (PJ_DEFAULT_CTX, "+proj=pipeline +zone=32 +step +proj=utm   +ellps=GRS80 +step +proj=utm   +ellps=GRS80 +inv");
     if (0==P)
         return 1000;
     /* zero initialize everything, then set (longitude, latitude, height) to (12, 55, 0) */
     a = b = proj_obs_null;
     a.coo.lpz.lam = PJ_TORAD(12);
     a.coo.lpz.phi = PJ_TORAD(55);
-    a.coo.lpz.z   = 0;
+    a.coo.lpz.z   = 10;
 
     /* Forward projection */
     b = proj_trans_obs (P, PJ_FWD, a);

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -66,12 +66,27 @@ PJ_OBS proj_obs (double x, double y, double z, double t) {
 
 
 
+enum pj_io_units pj_left (PJ *P) {
+    enum pj_io_units u = P->inverted? P->right: P->left;
+    if (u==PJ_IO_UNITS_RADIANS)
+        return PJ_IO_UNITS_RADIANS;
+    return PJ_IO_UNITS_METERS;
+}
 
+enum pj_io_units pj_right (PJ *P) {
+    enum pj_io_units u = P->inverted? P->left: P->right;
+    if (u==PJ_IO_UNITS_RADIANS)
+        return PJ_IO_UNITS_RADIANS;
+    return PJ_IO_UNITS_METERS;
+}
 
 /* Apply the transformation P to the coordinate coo */
 PJ_OBS proj_trans_obs (PJ *P, PJ_DIRECTION direction, PJ_OBS obs) {
     if (0==P)
         return obs;
+
+    if (P->inverted)
+        direction = -direction;
 
     switch (direction) {
         case PJ_FWD:

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,28 +1,30 @@
 /* determine latitude angle phi-2 */
-#include <projects.h>
+#include <proj.h>
+#include "projects.h"
 
 #define TOL 1.0e-10
 #define N_ITER 15
 
-	double
-pj_phi2(projCtx ctx, double ts, double e) {
-	double eccnth, Phi, con;
+
+double pj_phi2(PJ *P, double ts, double tolerance) {
+	double ehalf, phi;
 	int i;
 
-	eccnth = .5 * e;
-	Phi = M_HALFPI - 2. * atan (ts);
-	i = N_ITER;
-	for(;;) {
-		double dphi;
-		con = e * sin (Phi);
-		dphi = M_HALFPI - 2. * atan (ts * pow((1. - con) /
-		   (1. + con), eccnth)) - Phi;
-		Phi += dphi;
-		if( fabs(dphi) > TOL && --i )
-			continue;
-                break;
+    ehalf = P->e/2;
+    phi = M_HALFPI - 2 * atan (ts);
+
+    for (i = 0;  i < N_ITER;  i++) {
+		double previous, con;
+
+        con = P->e * sin (phi);
+        previous = phi;
+		phi = M_HALFPI - 2 * atan (ts * pow ( (1. - con) / (1. + con), ehalf) );
+
+        if ( fabs (phi - previous) < TOL)
+            break;
 	}
-	if (i <= 0)
-		pj_ctx_set_errno( ctx, -18 );
-	return Phi;
+
+    if (i==N_ITER)
+		proj_errno_set (P, PJD_ERR_NON_CON_INV_PHI2);
+	return phi;
 }

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -20,7 +20,7 @@ double pj_phi2(PJ *P, double ts, double tolerance) {
         previous = phi;
 		phi = M_HALFPI - 2 * atan (ts * pow ( (1. - con) / (1. + con), ehalf) );
 
-        if ( fabs (phi - previous) < TOL)
+        if ( fabs (phi - previous) < tolerance)
             break;
 	}
 

--- a/src/proj.def
+++ b/src/proj.def
@@ -146,3 +146,6 @@ EXPORTS
     proj_list_ellps                @132
     proj_list_units                @133
     proj_list_prime_meridians      @134
+
+    pj_left                        @135
+    pj_right                       @136

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -45,7 +45,6 @@ PJ_COORD proj_coord (double x, double y, double z, double t) {
 }
 
 
-
 /* Geodesic distance (in meter) between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, LP a, LP b) {
     double s12, azi1, azi2;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -64,6 +64,8 @@ typedef struct PJ_OBS PJ_OBS;
 #endif
 
 
+enum pj_io_units pj_left (PJ *P);
+enum pj_io_units pj_right (PJ *P);
 
 PJ_OBS   proj_obs   (double x, double y, double z, double t);
 PJ_OBS   proj_trans_obs   (PJ *P, PJ_DIRECTION direction, PJ_OBS obs);

--- a/src/projects.h
+++ b/src/projects.h
@@ -231,6 +231,7 @@ struct PJconsts {
     paralist *params;              /* Parameter list */
     struct geod_geodesic *geod;    /* For geodesic computations */
     struct pj_opaque *opaque;      /* Projection specific parameters, Defined in PJ_*.c */
+    int inverted;                  /* Tell high level API functions to swap inv/fwd */
 
 
     /*************************************************************************************

--- a/src/projects.h
+++ b/src/projects.h
@@ -702,8 +702,7 @@ double  pj_inv_mlfn(projCtx, double, double, double *);
 double  pj_qsfn(double, double, double);
 double  pj_tsfn(double, double, double);
 double  pj_msfn(double, double, double);
-double  pj_phi2(projCtx, double, double);
-double  pj_qsfn_(double, PJ *);
+double  pj_phi2(PJ *, double, double);
 double *pj_authset(double);
 double  pj_authlat(double, double *);
 


### PR DESCRIPTION
In a recent mailing list discussion, Dmitry Mefed revealed that the roundtrip precision was insufficient for Lambert Conformal Conic (lcc).

The solution was to change `TOL` in `pj_phi2.c` from 1e-10 to 1e-13 and recompiling.

This makes the iteration in `pj_phi2` take a few extra steps, which affects run time - not only for lcc, but also for merc, omerc, gstmerc, and calcofi.

To avoid that, this PR introduces a separate setup parameter `tol=`, indicating the desired precision level., for lcc, merc, omerc and gstmerc.

The tol parameter defaults to 1e-10 (the original value from `pj_phi2.c`), so not specifying it will result in status quo. It has been left out from the CalCOFI case, due to its rather special, and probably not precision intensive, use case.

It would probably be better to let the `tol=` parameter somehow indicate the target precision, rather than a more abstact (although related) convergence target, but I'm not sure how to do this in a sufficient general way, since that will probably mean that `tol=` should become a general PROJ.4 parameter. So I have left this aspect out for now.