### PR TITLE
Pipeline initialisation improvements

### DIFF
--- a/src/PJ_axisswap.c
+++ b/src/PJ_axisswap.c
@@ -127,36 +127,31 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
-    PJ_COORD in, out;
+    PJ_COORD out;
 
     out = proj_coord_error();
-    in = obs.coo;
 
     for (i=0; i<4; i++)
-        out.v[i] = in.v[Q->axis[i]] * Q->sign[i];
+        out.v[i] = coo.v[Q->axis[i]] * Q->sign[i];
 
-    obs.coo = out;
-    return obs;
+    return out;
 }
 
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD reverse_4d(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
-    PJ_COORD in, out;
+    PJ_COORD out;
 
     out = proj_coord_error();
-    in = obs.coo;
 
-    for (i=0; i<4; i++) {
-        out.v[Q->axis[i]] = in.v[i] * Q->sign[i];
-    }
+    for (i=0; i<4; i++)
+        out.v[Q->axis[i]] = coo.v[i] * Q->sign[i];
 
-    obs.coo = out;
-    return obs;
+    return out;
 }
 
 
@@ -182,7 +177,7 @@ PJ *PROJECTION(axisswap) {
     for (i=0; i<4; i++)
         Q->axis[i] = i+4;
 
-    /* check that all characteds are valid */
+    /* check that all characters are valid */
     for (i=0; i<strlen(order); i++)
         if (strchr("1234-,", order[i]) == 0) {
             proj_log_error(P, "axisswap: unknown axis '%c'", order[i]);
@@ -190,12 +185,12 @@ PJ *PROJECTION(axisswap) {
         }
 
     /* read axes numbers and signs */
-    for( s = order, n = 0; *s != '\0' && n < 4; ) {
+    for ( s = order, n = 0; *s != '\0' && n < 4; ) {
         Q->axis[n] = abs(atoi(s))-1;
         Q->sign[n++] = sign(atoi(s));
-        while( *s != '\0' && *s != ',' )
+        while ( *s != '\0' && *s != ',' )
             s++;
-        if( *s == ',' )
+        if ( *s == ',' )
             s++;
     }
 
@@ -212,8 +207,8 @@ PJ *PROJECTION(axisswap) {
 
     /* only map fwd/inv functions that are possible with the given axis setup */
     if (n == 4) {
-        P->fwdobs = forward_obs;
-        P->invobs = reverse_obs;
+        P->fwd4d = forward_4d;
+        P->inv4d = reverse_4d;
     }
     if (n == 3 && Q->axis[0] < 3 && Q->axis[1] < 3 && Q->axis[2] < 3) {
         P->fwd3d  = forward_3d;
@@ -224,7 +219,7 @@ PJ *PROJECTION(axisswap) {
         P->inv    = reverse_2d;
     }
 
-    if (P->fwdobs == NULL && P->fwd3d == NULL && P->fwd == NULL) {
+    if (P->fwd4d == NULL && P->fwd3d == NULL && P->fwd == NULL) {
         proj_log_error(P, "swapaxis: bad axis order");
         return pj_default_destructor(P, PJD_ERR_AXIS);
     }

--- a/src/PJ_deformation.c
+++ b/src/PJ_deformation.c
@@ -139,26 +139,26 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS in, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     double dt;
     XYZ shift;
-    PJ_OBS out = in;
+    PJ_COORD out = in;
 
     if (Q->t_obs != HUGE_VAL) {
             dt = Q->t_obs - Q->t_epoch;
         } else {
-            dt = in.coo.xyzt.t - Q->t_epoch;
+            dt = in.xyzt.t - Q->t_epoch;
     }
 
     if (Q->has_xy_grids) {
-        shift = get_xygrid_shift(P, in.coo.xyz);
-        out.coo.xyz.x += dt * shift.x;
-        out.coo.xyz.y += dt * shift.y;
+        shift = get_xygrid_shift(P, in.xyz);
+        out.xyz.x += dt * shift.x;
+        out.xyz.y += dt * shift.y;
     }
 
     if (Q->has_z_grids)
-        out.coo.xyz.z += dt * get_zgrid_shift(P, in.coo.xyz);
+        out.xyz.z += dt * get_zgrid_shift(P, in.xyz);
 
     return out;
 }
@@ -188,22 +188,22 @@ static LPZ reverse_3d(XYZ in, PJ *P) {
     return out.lpz;
 }
 
-static PJ_OBS reverse_obs(PJ_OBS in, PJ *P) {
+static PJ_COORD reverse_4d(PJ_COORD in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
-    PJ_OBS out = in;
+    PJ_COORD out = in;
     double dt;
 
     if (Q->t_obs != HUGE_VAL) {
             dt = Q->t_epoch - Q->t_obs;
         } else {
-            dt = Q->t_epoch - in.coo.xyzt.t;
+            dt = Q->t_epoch - in.xyzt.t;
     }
 
     if (Q->has_xy_grids)
-        out.coo.xyz = reverse_hshift(P, in.coo.xyz, dt);
+        out.xyz = reverse_hshift(P, in.xyz, dt);
 
     if (Q->has_z_grids)
-        out.coo.xyz.z = in.coo.xyz.z + dt * get_zgrid_shift(P, in.coo.xyz);
+        out.xyz.z = in.xyz.z + dt * get_zgrid_shift(P, in.xyz);
 
     return out;
 }
@@ -274,8 +274,8 @@ PJ *PROJECTION(deformation) {
        return destructor(P, PJD_ERR_MISSING_ARGS);
     }
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -423,35 +423,35 @@ static LPZ helmert_reverse_3d (XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS helmert_forward_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD helmert_forward_4d (PJ_COORD point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.coo.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.coo.xyzt.t;
+    if (point.xyzt.t != Q->t_obs) {
+        Q->t_obs = point.xyzt.t;
         update_parameters(P);
         build_rot_matrix(P);
     }
 
-    point.coo.xyz = helmert_forward_3d (point.coo.lpz, P);
+    point.xyz = helmert_forward_3d (point.lpz, P);
 
     return point;
 }
 
 
-static PJ_OBS helmert_reverse_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD helmert_reverse_4d (PJ_COORD point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.coo.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.coo.xyzt.t;
+    if (point.xyzt.t != Q->t_obs) {
+        Q->t_obs = point.xyzt.t;
         update_parameters(P);
         build_rot_matrix(P);
     }
 
-    point.coo.lpz = helmert_reverse_3d (point.coo.xyz, P);
+    point.lpz = helmert_reverse_3d (point.xyz, P);
 
     return point;
 }
@@ -468,8 +468,8 @@ PJ *TRANSFORMATION(helmert, 0) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = helmert_forward_obs;
-    P->invobs = helmert_reverse_obs;
+    P->fwd4d  = helmert_forward_4d;
+    P->inv4d  = helmert_reverse_4d;
     P->fwd3d  = helmert_forward_3d;
     P->inv3d  = helmert_reverse_3d;
     P->fwd    = helmert_forward;
@@ -671,8 +671,8 @@ int pj_helmert_selftest (void) {
        matrix is updated when necessary. Test coordinates from GNSStrans. */
     XYZ expect4a = {3370658.18890, 711877.42370, 5349787.12430};
     XYZ expect4b = {3370658.18087, 711877.42750, 5349787.12648};
-    PJ_OBS in4 = {{{3370658.378, 711877.314, 5349787.086, 2017.0}}};
-    PJ_OBS out;
+    PJ_COORD in4 = {{3370658.378, 711877.314, 5349787.086, 2017.0}};
+    PJ_COORD out;
 
     PJ *helmert = proj_create(
         0,
@@ -703,20 +703,20 @@ int pj_helmert_selftest (void) {
     ret = test (args5, in5, expect5, 0.001);  if (ret) return ret + 40;
 
     /* Run test 4 */
-    out = proj_trans_obs (helmert, PJ_FWD, in4);
-    if (proj_xyz_dist (out.coo.xyz, expect4a) > 1e-4) {
+    out = proj_trans (helmert, PJ_FWD, in4);
+    if (proj_xyz_dist (out.xyz, expect4a) > 1e-4) {
         proj_log_error(helmert, "Tolerance of test 4a not met!");
-        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.coo.xyz.x, in4.coo.xyz.y, in4.coo.xyz.z);
-        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.xyz.x, in4.xyz.y, in4.xyz.z);
+        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.xyz.x, out.xyz.y, out.xyz.z);
         return 31;
     }
 
-    in4.coo.xyzt.t = 2018.0;
-    out = proj_trans_obs (helmert, PJ_FWD, in4);
-    if (proj_xyz_dist (out.coo.xyz, expect4b) > 1e-4) {
+    in4.xyzt.t = 2018.0;
+    out = proj_trans (helmert, PJ_FWD, in4);
+    if (proj_xyz_dist (out.xyz, expect4b) > 1e-4) {
         proj_log_error(helmert, "Tolerance of test 4b not met!");
-        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.coo.xyz.x, in4.coo.xyz.y, in4.coo.xyz.z);
-        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.xyz.x, in4.xyz.y, in4.xyz.z);
+        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.xyz.x, out.xyz.y, out.xyz.z);
         return 32;
     }
 

--- a/src/PJ_hgridshift.c
+++ b/src/PJ_hgridshift.c
@@ -32,25 +32,23 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.xyz = forward_3d (obs.coo.lpz, P);
-    return point;
+static PJ_COORD forward_4d (PJ_COORD obs, PJ *P) {
+    obs.xyz = forward_3d (obs.lpz, P);
+    return obs;
 }
 
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.lpz = reverse_3d (obs.coo.xyz, P);
-    return point;
+static PJ_COORD reverse_4d (PJ_COORD obs, PJ *P) {
+    obs.lpz = reverse_3d (obs.xyz, P);
+    return obs;
 }
 
 
 
 PJ *PROJECTION(hgridshift) {
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwd4d  = forward_4d;
+    P->inv4d  = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;
@@ -82,7 +80,7 @@ int pj_hgridshift_selftest (void) {return 0;}
 #else
 int pj_hgridshift_selftest (void) {
     PJ *P;
-    PJ_OBS expect, a, b;
+    PJ_COORD expect, a, b;
     double dist;
 
     /* fail on purpose: +grids parameter is mandatory*/
@@ -104,20 +102,20 @@ int pj_hgridshift_selftest (void) {
     if (0==P)
         return 10;
 
-    a = proj_obs_null;
-    a.coo.lpz.lam = PJ_TORAD(173);
-    a.coo.lpz.phi = PJ_TORAD(-45);
+    a = proj_coord (0,0,0,0);
+    a.lpz.lam = PJ_TORAD(173);
+    a.lpz.phi = PJ_TORAD(-45);
 
-    dist = proj_roundtrip (P, PJ_FWD, 1, a.coo);
+    dist = proj_roundtrip (P, PJ_FWD, 1, a);
     if (dist > 0.00000001) {
         printf("dist: %f\n",dist);
         return 1;
     }
 
-    expect.coo.lpz.lam = PJ_TORAD(172.999892181021551);
-    expect.coo.lpz.phi = PJ_TORAD(-45.001620431954613);
-    b = proj_trans_obs(P, PJ_FWD, a);
-    if (proj_xy_dist(expect.coo.xy, b.coo.xy) > 1e-4)
+    expect.lpz.lam = PJ_TORAD(172.999892181021551);
+    expect.lpz.phi = PJ_TORAD(-45.001620431954613);
+    b = proj_trans(P, PJ_FWD, a);
+    if (proj_xy_dist(expect.xy, b.xy) > 1e-4)
         return 2;
 
     proj_destroy(P);

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -287,13 +287,13 @@ summing the tiny high order elements first.
 
 
 
-static PJ_OBS horner_forward_obs (PJ_OBS point, PJ *P) {
-    point.coo.uv = horner ((HORNER *) P->opaque, 1, point.coo.uv);
+static PJ_COORD horner_forward_4d (PJ_COORD point, PJ *P) {
+    point.uv = horner ((HORNER *) P->opaque, 1, point.uv);
     return point;
 }
 
-static PJ_OBS horner_reverse_obs (PJ_OBS point, PJ *P) {
-    point.coo.uv = horner ((HORNER *) P->opaque, -1, point.coo.uv);
+static PJ_COORD horner_reverse_4d (PJ_COORD point, PJ *P) {
+    point.uv = horner ((HORNER *) P->opaque, -1, point.uv);
     return point;
 }
 
@@ -369,13 +369,13 @@ polynomial evaluation engine.
 
 
 
-static PJ_OBS complex_horner_forward_obs (PJ_OBS point, PJ *P) {
-    point.coo.uv = complex_horner ((HORNER *) P->opaque, PJ_FWD, point.coo.uv);
+static PJ_COORD complex_horner_forward_4d (PJ_COORD point, PJ *P) {
+    point.uv = complex_horner ((HORNER *) P->opaque, PJ_FWD, point.uv);
     return point;
 }
 
-static PJ_OBS complex_horner_reverse_obs (PJ_OBS point, PJ *P) {
-    point.coo.uv = complex_horner ((HORNER *) P->opaque, PJ_INV, point.coo.uv);
+static PJ_COORD complex_horner_reverse_4d (PJ_COORD point, PJ *P) {
+    point.uv = complex_horner ((HORNER *) P->opaque, PJ_INV, point.uv);
     return point;
 }
 
@@ -429,13 +429,13 @@ PJ *PROJECTION(horner) {
 /*********************************************************************/
     int   degree = 0, n, complex_horner = 0;
     HORNER *Q;
-    P->fwdobs  =  horner_forward_obs;
-    P->invobs  =  horner_reverse_obs;
-    P->fwd3d   =  0;
-    P->inv3d   =  0;
-    P->fwd     =  0;
-    P->inv     =  0;
-    P->left    =  P->right  =  PJ_IO_UNITS_METERS;
+    P->fwd4d  = horner_forward_4d;
+    P->inv4d  = horner_reverse_4d;
+    P->fwd3d  =  0;
+    P->inv3d  =  0;
+    P->fwd    =  0;
+    P->inv    =  0;
+    P->left   =  P->right  =  PJ_IO_UNITS_METERS;
     P->destructor = horner_freeup;
 
     /* Polynomial degree specified? */
@@ -460,8 +460,8 @@ PJ *PROJECTION(horner) {
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
         if (0==parse_coefs (P, Q->inv_c, "inv_c", n))
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
-        P->fwdobs  =  complex_horner_forward_obs;
-        P->invobs  =  complex_horner_reverse_obs;
+        P->fwd4d = complex_horner_forward_4d;
+        P->inv4d = complex_horner_reverse_4d;
 
     }
     else {
@@ -518,7 +518,7 @@ char sb_utm32[] = {
 
 int pj_horner_selftest (void) {
     PJ *P;
-    PJ_OBS a, b, c;
+    PJ_COORD a, b, c;
     double dist;
 
     /* Real polynonia relating the technical coordinate system TC32 to "System 45 Bornholm" */
@@ -526,12 +526,12 @@ int pj_horner_selftest (void) {
     if (0==P)
         return 10;
 
-    a = b = proj_obs_null;
-    a.coo.uv.v = 6125305.4245;
-    a.coo.uv.u =  878354.8539;
+    a = b = proj_coord (0,0,0,0);
+    a.uv.v = 6125305.4245;
+    a.uv.u =  878354.8539;
 
     /* Check roundtrip precision for 1 iteration each way, starting in forward direction */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a.coo);
+    dist = proj_roundtrip (P, PJ_FWD, 1, a);
     if (dist > 0.01)
         return 1;
 
@@ -541,26 +541,26 @@ int pj_horner_selftest (void) {
         return 11;
 
     /* Test value: utm32_ed50(620000, 6130000) = sb_ed50(495136.8544, 6130821.2945) */
-    a = b = c = proj_obs_null;
-    a.coo.uv.v = 6130821.2945;
-    a.coo.uv.u =  495136.8544;
-    c.coo.uv.v = 6130000.0000;
-    c.coo.uv.u =  620000.0000;
+    a = b = c = proj_coord (0,0,0,0);
+    a.uv.v = 6130821.2945;
+    a.uv.u =  495136.8544;
+    c.uv.v = 6130000.0000;
+    c.uv.u =  620000.0000;
 
     /* Forward projection */
-    b = proj_trans_obs (P, PJ_FWD, a);
-    dist = proj_xy_dist (b.coo.xy, c.coo.xy);
+    b = proj_trans (P, PJ_FWD, a);
+    dist = proj_xy_dist (b.xy, c.xy);
     if (dist > 0.001)
         return 2;
 
     /* Inverse projection */
-    b = proj_trans_obs (P, PJ_INV, c);
-    dist = proj_xy_dist (b.coo.xy, a.coo.xy);
+    b = proj_trans (P, PJ_INV, c);
+    dist = proj_xy_dist (b.xy, a.xy);
     if (dist > 0.001)
         return 3;
 
     /* Check roundtrip precision for 1 iteration each way */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a.coo);
+    dist = proj_roundtrip (P, PJ_FWD, 1, a);
     if (dist > 0.01)
         return 4;
 

--- a/src/PJ_latlong.c
+++ b/src/PJ_latlong.c
@@ -54,12 +54,12 @@ static LP inverse(XY xy, PJ *P) {
     return lp;
 }
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     (void) P;
     return obs;
 }
 
-static PJ_OBS inverse_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD inverse_4d(PJ_COORD obs, PJ *P) {
     (void) P;
     return obs;
 }
@@ -70,8 +70,8 @@ PJ *PROJECTION(latlong) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -85,8 +85,8 @@ PJ *PROJECTION(longlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -100,8 +100,8 @@ PJ *PROJECTION(latlon) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -115,8 +115,8 @@ PJ *PROJECTION(lonlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -235,10 +235,9 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.xyz = forward_3d(obs.coo.lpz, P);
-    return point;
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+    obs.xyz = forward_3d(obs.lpz, P);
+    return obs;
 }
 
 
@@ -263,10 +262,9 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.lpz = reverse_3d(obs.coo.xyz, P);
-    return point;
+static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+    obs.lpz = reverse_3d(obs.xyz, P);
+    return obs;
 }
 
 
@@ -276,8 +274,8 @@ PJ *PROJECTION(molodensky) {
         return pj_default_destructor(P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = forward_2d;
@@ -320,7 +318,7 @@ int pj_molodensky_selftest (void) {return 0;}
 #else
 int pj_molodensky_selftest (void) {
 
-    PJ_OBS in, res, exp;
+    PJ_COORD in, res, exp;
     PJ *P;
 
     /* Test the abridged Molodensky first. Example from appendix 3 of Deakin (2004). */
@@ -332,28 +330,28 @@ int pj_molodensky_selftest (void) {
     if (0==P)
         return 10;
 
-    in.coo.lpz.lam = PJ_TORAD(144.9667);
-    in.coo.lpz.phi = PJ_TORAD(-37.8);
-    in.coo.lpz.z   = 50.0;
+    in.lpz.lam = PJ_TORAD(144.9667);
+    in.lpz.phi = PJ_TORAD(-37.8);
+    in.lpz.z   = 50.0;
 
-    exp.coo.lpz.lam = PJ_TORAD(144.968);
-    exp.coo.lpz.phi = PJ_TORAD(-37.79848);
-    exp.coo.lpz.z   = 46.378;
+    exp.lpz.lam = PJ_TORAD(144.968);
+    exp.lpz.phi = PJ_TORAD(-37.79848);
+    exp.lpz.z   = 46.378;
 
-    res = proj_trans_obs(P, PJ_FWD, in);
+    res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.coo.lp, exp.coo.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
         proj_destroy(P);
         return 11;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in.coo) > 1) {
+    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
         proj_destroy(P);
         return 12;
     }
 
-    if (res.coo.lpz.z - exp.coo.lpz.z > 1e-3) {
+    if (res.lpz.z - exp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 13;
     }
@@ -369,20 +367,20 @@ int pj_molodensky_selftest (void) {
     if (0==P)
         return 20;
 
-    res = proj_trans_obs(P, PJ_FWD, in);
+    res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.coo.lp, exp.coo.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
         proj_destroy(P);
         return 21;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in.coo) > 1) {
+    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
         proj_destroy(P);
         return 22;
     }
 
-    if (res.coo.lpz.z - exp.coo.lpz.z > 1e-3) {
+    if (res.lpz.z - exp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 23;
     }

--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -86,10 +86,10 @@ static void *destructor(PJ *P, int errlev) {
         return 0;
     if (0==P->opaque)
         return pj_default_destructor (P, errlev);
-        
+
     if (P->opaque->link)
         P->opaque->link->destructor (P->opaque->link, errlev);
-        
+
     return pj_default_destructor(P, errlev);
 }
 
@@ -135,7 +135,7 @@ static ARGS ob_tran_target_params (paralist *params) {
     args.argv = pj_calloc (argc - 1, sizeof (char *));
     if (0==args.argv)
         return args;
-    
+
     /* Copy all args *except* the proj=ob_tran arg to the argv array */
     for (i = 0;  params != 0;  params = params->next) {
         if (0==strcmp (params->param, "proj=ob_tran"))
@@ -287,14 +287,14 @@ int pj_ob_tran_selftest (void) {
     a = proj_coord (300000, 400000, 0, 0);
     b.lpz.lam = -proj_torad (42 + (45 + 22.377/60)/60);
     b.lpz.phi =  proj_torad (85 + (35 + 28.083/60)/60);
-    a = proj_trans_coord (P, -1, a);
+    a = proj_trans (P, -1, a);
     d = proj_lp_dist (P, a.lp, b.lp);
     if (d > 1e-3)
         return 2;
 
     a = proj_coord (proj_torad(10), proj_torad(20), 0, 0);
     b = proj_coord (-1384841.18787, 7581707.88240, 0, 0);
-    a = proj_trans_coord (P, 1, a);
+    a = proj_trans (P, 1, a);
     d = proj_xy_dist (a.xy, b.xy);
     if (d > 1e-3)
         return 3;

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -118,8 +118,8 @@ struct pj_opaque {
 
 
 
-static PJ_OBS pipeline_forward_obs (PJ_OBS, PJ *P);
-static PJ_OBS pipeline_reverse_obs (PJ_OBS, PJ *P);
+static PJ_COORD pipeline_forward_4d (PJ_COORD, PJ *P);
+static PJ_COORD pipeline_reverse_4d (PJ_COORD, PJ *P);
 static XYZ    pipeline_forward_3d (LPZ lpz, PJ *P);
 static LPZ    pipeline_reverse_3d (XYZ xyz, PJ *P);
 static XY     pipeline_forward (LP lpz, PJ *P);
@@ -174,61 +174,61 @@ static LP     pipeline_reverse (XY xyz, PJ *P);
 
 
 
-static PJ_OBS pipeline_forward_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P) {
     int i, first_step, last_step;
 
     first_step = 1;
     last_step  = P->opaque->steps + 1;
 
     for (i = first_step;  i != last_step;  i++)
-        point = proj_trans_obs (P->opaque->pipeline[i], 1, point);
+        point = proj_trans (P->opaque->pipeline[i], 1, point);
 
     return point;
 }
 
 
 
-static PJ_OBS pipeline_reverse_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD pipeline_reverse_4d (PJ_COORD point, PJ *P) {
     int i, first_step, last_step;
 
     first_step = P->opaque->steps;
     last_step  =  0;
 
     for (i = first_step;  i != last_step;  i--)
-        point = proj_trans_obs (P->opaque->pipeline[i], -1, point);
+        point = proj_trans (P->opaque->pipeline[i], -1, point);
 
     return point;
 }
 
 
-/* Delegate the work to pipeline_forward_obs() */
+/* Delegate the work to pipeline_forward_4d() */
 static XYZ pipeline_forward_3d (LPZ lpz, PJ *P) {
-    PJ_OBS point = proj_obs_null;
-    point.coo.lpz = lpz;
-    point = pipeline_forward_obs (point, P);
-    return point.coo.xyz;
+    PJ_COORD point = {{0,0,0,0}};
+    point.lpz = lpz;
+    point = pipeline_forward_4d (point, P);
+    return point.xyz;
 }
 
-/* Delegate the work to pipeline_reverse_obs() */
+/* Delegate the work to pipeline_reverse_4d() */
 static LPZ pipeline_reverse_3d (XYZ xyz, PJ *P) {
-    PJ_OBS point = proj_obs_null;
-    point.coo.xyz = xyz;
-    point = pipeline_reverse_obs (point, P);
-    return point.coo.lpz;
+    PJ_COORD point = {{0,0,0,0}};
+    point.xyz = xyz;
+    point = pipeline_reverse_4d (point, P);
+    return point.lpz;
 }
 
 static XY pipeline_forward (LP lp, PJ *P) {
-    PJ_OBS point = proj_obs_null;
-    point.coo.lp = lp;
-    point = pipeline_forward_obs (point, P);
-    return point.coo.xy;
+    PJ_COORD point = {{0,0,0,0}};
+    point.lp = lp;
+    point = pipeline_forward_4d (point, P);
+    return point.xy;
 }
 
 static LP pipeline_reverse (XY xy, PJ *P) {
-    PJ_OBS point = proj_obs_null;
-    point.coo.xy = xy;
-    point = pipeline_reverse_obs (point, P);
-    return point.coo.lp;
+    PJ_COORD point = {{0,0,0,0}};
+    point.xy = xy;
+    point = pipeline_reverse_4d (point, P);
+    return point.lp;
 }
 
 
@@ -298,8 +298,8 @@ PJ *PROJECTION(pipeline) {
     int i_pipeline = -1, i_first_step = -1, i_current_step;
     char **argv, **current_argv;
 
-    P->fwdobs =  pipeline_forward_obs;
-    P->invobs =  pipeline_reverse_obs;
+    P->fwd4d  = pipeline_forward_4d;
+    P->inv4d  = pipeline_reverse_4d;
     P->fwd3d  =  pipeline_forward_3d;
     P->inv3d  =  pipeline_reverse_3d;
     P->fwd    =  pipeline_forward;
@@ -412,7 +412,7 @@ int pj_pipeline_selftest (void) {return 0;}
 
 int pj_pipeline_selftest (void) {
     PJ *P;
-    PJ_OBS a, b;
+    PJ_COORD a, b;
     XY cph_utm32 = {691875.63214,  6098907.82501};
     double dist;
 
@@ -421,19 +421,19 @@ int pj_pipeline_selftest (void) {
     if (0==P)
         return 1000;
     /* zero initialize everything, then set (longitude, latitude, height) to (12, 55, 0) */
-    a = b = proj_obs_null;
-    a.coo.lpz.lam = PJ_TORAD(12);
-    a.coo.lpz.phi = PJ_TORAD(55);
-    a.coo.lpz.z   = 10;
+    a = b = proj_coord (0,0,0,0);
+    a.lpz.lam = PJ_TORAD(12);
+    a.lpz.phi = PJ_TORAD(55);
+    a.lpz.z   = 10;
 
     /* Forward projection */
-    b = proj_trans_obs (P, PJ_FWD, a);
-    if (proj_lp_dist (P, a.coo.lp, b.coo.lp) > 1e-4)
+    b = proj_trans (P, PJ_FWD, a);
+    if (proj_lp_dist (P, a.lp, b.lp) > 1e-4)
         return 1001;
 
     /* Inverse projection (still same result: pipeline is symmetrical) */
-    a = proj_trans_obs (P, PJ_INV, b);
-    if (proj_lp_dist (P, a.coo.lp, b.coo.lp) > 1e-4)
+    a = proj_trans (P, PJ_INV, b);
+    if (proj_lp_dist (P, a.lp, b.lp) > 1e-4)
         return 1002;
 
     proj_destroy (P);
@@ -444,19 +444,19 @@ int pj_pipeline_selftest (void) {
         return 2000;
 
     /* zero initialize everything, then set (easting, northing) to utm(12, 55) */
-    a = b = proj_obs_null;
-    a.coo.xy = cph_utm32;
+    a = b = proj_coord (0,0,0,0);
+    a.xy = cph_utm32;
 
     /* Forward projection */
-    b = proj_trans_obs (P, PJ_FWD, a);
-    if (proj_xy_dist (a.coo.xy, b.coo.xy) > 1e-4)
+    b = proj_trans (P, PJ_FWD, a);
+    if (proj_xy_dist (a.xy, b.xy) > 1e-4)
         return 2001;
 
     /* Inverse projection */
-    a = proj_trans_obs (P, PJ_INV, b);
-    if (proj_xy_dist (a.coo.xy, b.coo.xy) > 1e-4)
+    a = proj_trans (P, PJ_INV, b);
+    if (proj_xy_dist (a.xy, b.xy) > 1e-4)
         return 2001;
-    if (proj_xyz_dist (a.coo.xyz, b.coo.xyz) > 1e-4)
+    if (proj_xyz_dist (a.xyz, b.xyz) > 1e-4)
         return 2002;
 
     proj_destroy (P);
@@ -468,37 +468,37 @@ int pj_pipeline_selftest (void) {
         return 3000;
 
 
-    a = b = proj_obs_null;
-    a.coo.lpz.lam = PJ_TORAD(12);
-    a.coo.lpz.phi = PJ_TORAD(55);
+    a = b = proj_coord (0,0,0,0);
+    a.lpz.lam = PJ_TORAD(12);
+    a.lpz.phi = PJ_TORAD(55);
 
     /* Forward projection */
-    b = proj_trans_obs (P, PJ_FWD, a);
-    if (proj_xy_dist (cph_utm32, b.coo.xy) > 1e-4)
+    b = proj_trans (P, PJ_FWD, a);
+    if (proj_xy_dist (cph_utm32, b.xy) > 1e-4)
         return 3001;
 
     /* Inverse projection */
-    b = proj_trans_obs (P, PJ_INV, b);
-    if (proj_lp_dist (P, a.coo.lp, b.coo.lp) > 1e-4)
+    b = proj_trans (P, PJ_INV, b);
+    if (proj_lp_dist (P, a.lp, b.lp) > 1e-4)
         return 3002;
 
 
     /* Since we use pj_lp_dist to determine success above, we should also test that it works */
 
     /* Geodesic distance between two points with angular 2D coordinates */
-    a.coo.lp.lam = PJ_TORAD(12);
-    a.coo.lp.phi = PJ_TORAD(60);
-    b.coo.lp.lam = PJ_TORAD(12);
-    b.coo.lp.phi = PJ_TORAD(61);
-    dist = proj_lp_dist (P, a.coo.lp, b.coo.lp);
+    a.lp.lam = PJ_TORAD(12);
+    a.lp.phi = PJ_TORAD(60);
+    b.lp.lam = PJ_TORAD(12);
+    b.lp.phi = PJ_TORAD(61);
+    dist = proj_lp_dist (P, a.lp, b.lp);
     if (fabs (111420.727870234 - dist) > 1e-4)
         return 4001;
 
-    a.coo.lp.lam = PJ_TORAD(12);
-    a.coo.lp.phi = PJ_TORAD(0.);
-    b.coo.lp.lam = PJ_TORAD(12);
-    b.coo.lp.phi = PJ_TORAD(1.);
-    dist = proj_lp_dist (P, a.coo.lp, b.coo.lp);
+    a.lp.lam = PJ_TORAD(12);
+    a.lp.phi = PJ_TORAD(0.);
+    b.lp.lam = PJ_TORAD(12);
+    b.lp.phi = PJ_TORAD(1.);
+    dist = proj_lp_dist (P, a.lp, b.lp);
     if (fabs (110574.388554153 - dist) > 1e-4)
         return 4002;
 
@@ -516,11 +516,11 @@ int pj_pipeline_selftest (void) {
     if (0==P)
         return 5000;
 
-    a.coo.xy.x =  700000.0;
-    a.coo.xy.y = 6000000.0;
+    a.xy.x =  700000.0;
+    a.xy.y = 6000000.0;
 
-    b = proj_trans_obs(P, PJ_FWD, a);
-    dist = proj_xy_dist(a.coo.xy, b.coo.xy);
+    b = proj_trans(P, PJ_FWD, a);
+    dist = proj_xy_dist(a.xy, b.xy);
     if (dist > 1e-7)
         return 5001;
 

--- a/src/PJ_sch.c
+++ b/src/PJ_sch.c
@@ -1,6 +1,4 @@
 /******************************************************************************
- * $Id$
- *
  * Project:  SCH Coordinate system
  * Purpose:  Implementation of SCH Coordinate system
  * References :

--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -33,15 +33,15 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.xyz = forward_3d (obs.coo.lpz, P);
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+    PJ_COORD point;
+    point.xyz = forward_3d (obs.lpz, P);
     return point;
 }
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.lpz = reverse_3d (obs.coo.xyz, P);
+static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+    PJ_COORD point;
+    point.lpz = reverse_3d (obs.xyz, P);
     return point;
 }
 
@@ -62,8 +62,8 @@ PJ *PROJECTION(vgridshift) {
         return pj_default_destructor(P, PJD_ERR_FAILED_TO_LOAD_GRID);
     }
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;
@@ -82,7 +82,7 @@ int pj_vgridshift_selftest (void) {return 0;}
 #else
 int pj_vgridshift_selftest (void) {
     PJ *P;
-    PJ_OBS expect, a, b;
+    PJ_COORD expect, a, b;
     double dist;
     int failures = 0;
 
@@ -105,29 +105,29 @@ int pj_vgridshift_selftest (void) {
     if (0==P)
         return 10;
 
-    a = proj_obs_null;
-    a.coo.lpz.lam = PJ_TORAD(12.5);
-    a.coo.lpz.phi = PJ_TORAD(55.5);
+    a = proj_coord(0,0,0,0);
+    a.lpz.lam = PJ_TORAD(12.5);
+    a.lpz.phi = PJ_TORAD(55.5);
 
-    dist = proj_roundtrip (P, PJ_FWD, 1, a.coo);
+    dist = proj_roundtrip (P, PJ_FWD, 1, a);
     if (dist > 0.00000001)
         return 1;
 
     expect = a;
     /* Appears there is a difference between the egm96_15.gtx distributed by OSGeo4W,  */
     /* and the one from http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx    */
-    /* Was: expect.coo.lpz.z   = -36.021305084228515625;  (download.osgeo.org)         */
-    /* Was: expect.coo.lpz.z   = -35.880001068115234000;  (OSGeo4W)                    */
+    /* Was: expect.lpz.z   = -36.021305084228515625;  (download.osgeo.org)         */
+    /* Was: expect.lpz.z   = -35.880001068115234000;  (OSGeo4W)                    */
     /* This is annoying, but must be handled elsewhere. So for now, we check for both. */
-    expect.coo.lpz.z   = -36.021305084228516;
+    expect.lpz.z   = -36.021305084228516;
     failures = 0;
-    b = proj_trans_obs(P, PJ_FWD, a);
-    if (proj_xyz_dist(expect.coo.xyz, b.coo.xyz) > 1e-4)  failures++;
-    expect.coo.lpz.z   = -35.880001068115234000;
-    if (proj_xyz_dist(expect.coo.xyz, b.coo.xyz) > 1e-4)  failures++;
+    b = proj_trans(P, PJ_FWD, a);
+    if (proj_xyz_dist(expect.xyz, b.xyz) > 1e-4)  failures++;
+    expect.lpz.z   = -35.880001068115234000;
+    if (proj_xyz_dist(expect.xyz, b.xyz) > 1e-4)  failures++;
     if (failures > 1)
         return 2;
-    
+
     proj_destroy (P);
 
     return 0;

--- a/src/cct.c
+++ b/src/cct.c
@@ -72,6 +72,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 ***********************************************************************/
 
 #include "optargpm.h"
+#include "proj_internal.h"
 #include <proj.h>
 #include "projects.h"
 #include <stdio.h>
@@ -79,6 +80,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 #include <ctype.h>
 #include <string.h>
 #include <math.h>
+
 
 double proj_strtod(const char *str, char **endptr);
 double proj_atof(const char *str);
@@ -211,17 +213,13 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    input_unit   =  P->left;
-    output_unit  =  P->right;
-    if (PJ_IO_UNITS_CLASSIC==P->left)
-        input_unit = PJ_IO_UNITS_RADIANS;
-    if (PJ_IO_UNITS_CLASSIC==P->right)
-        output_unit = PJ_IO_UNITS_METERS;
-    if (direction==-1) {
-        enum pj_io_units swap = input_unit;
-        input_unit = output_unit;
-        output_unit = swap;
-    }
+    /* We have no API call for inverting an operation, so we brute force it. */
+    if (direction==-1)
+        P->inverted = !(P->inverted);
+    direction = 1;
+
+    input_unit   =  proj_angular_left (P)?  PJ_IO_UNITS_RADIANS: PJ_IO_UNITS_METERS;
+    output_unit  =  proj_angular_right (P)? PJ_IO_UNITS_RADIANS: PJ_IO_UNITS_METERS;
 
     /* Allocate input buffer */
     buf = calloc (1, 10000);
@@ -264,7 +262,7 @@ int main(int argc, char **argv) {
             point.lpzt.lam = proj_torad (point.lpzt.lam);
             point.lpzt.phi = proj_torad (point.lpzt.phi);
         }
-        point = proj_trans_coord (P, direction, point);
+        point = proj_trans (P, direction, point);
         if (PJ_IO_UNITS_RADIANS==output_unit) {
             point.lpzt.lam = proj_todeg (point.lpzt.lam);
             point.lpzt.phi = proj_todeg (point.lpzt.phi);

--- a/src/gie.c
+++ b/src/gie.c
@@ -532,7 +532,7 @@ static int expect (char *args) {
     }
     T.e = torad_if_needed (T.P, T.dir==PJ_FWD? PJ_INV:PJ_FWD, T.e);
 
-    T.b = proj_trans_coord (T.P, T.dir, T.a);
+    T.b = proj_trans (T.P, T.dir, T.a);
     T.b = torad_if_needed (T.P, T.dir==PJ_FWD? PJ_INV:PJ_FWD, T.b);
 
     if (T.nargs < 2) {

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -30,40 +30,12 @@
  *****************************************************************************/
 #define PJ_INTERNAL_C
 #include "proj_internal.h"
-#include <projects.h>
+#include "projects.h"
 #include <geodesic.h>
 
 #include <stddef.h>
 #include <stdarg.h>
 #include <errno.h>
-
-
-
-
-/* Used for zero-initializing new objects */
-const PJ_COORD proj_coord_null = {{0, 0, 0, 0}};
-const PJ_OBS   proj_obs_null = {
-    {{0, 0, 0, 0}}
-};
-
-
-
-/* Initialize PJ_OBS struct */
-PJ_OBS proj_obs (double x, double y, double z, double t) {
-    PJ_OBS res;
-    res.coo = proj_coord (x, y, z, t);
-    return res;
-}
-
-
-
-
-
-
-
-
-
-
 
 
 enum pj_io_units pj_left (PJ *P) {
@@ -80,29 +52,6 @@ enum pj_io_units pj_right (PJ *P) {
     return PJ_IO_UNITS_METERS;
 }
 
-/* Apply the transformation P to the coordinate coo */
-PJ_OBS proj_trans_obs (PJ *P, PJ_DIRECTION direction, PJ_OBS obs) {
-    if (0==P)
-        return obs;
-
-    if (P->inverted)
-        direction = -direction;
-
-    switch (direction) {
-        case PJ_FWD:
-            return pj_fwdobs (obs, P);
-        case PJ_INV:
-            return  pj_invobs (obs, P);
-        case PJ_IDENT:
-            return obs;
-        default:
-            break;
-    }
-
-    proj_errno_set (P, EINVAL);
-    return proj_obs_error ();
-}
-
 
 /* Work around non-constness of MSVC HUGE_VAL by providing functions rather than constants */
 PJ_COORD proj_coord_error (void) {
@@ -111,60 +60,10 @@ PJ_COORD proj_coord_error (void) {
     return c;
 }
 
-PJ_OBS proj_obs_error (void) {
-    PJ_OBS obs;
-    obs.coo = proj_coord_error ();
-    return obs;
-}
 
-
-
-PJ_OBS pj_fwdobs (PJ_OBS obs, PJ *P) {
-    if (0!=P->fwdobs) {
-        obs  =  P->fwdobs (obs, P);
-        return obs;
-    }
-    if (0!=P->fwd3d) {
-        obs.coo.xyz  =  pj_fwd3d (obs.coo.lpz, P);
-        return obs;
-    }
-    if (0!=P->fwd) {
-        obs.coo.xy  =  pj_fwd (obs.coo.lp, P);
-        return obs;
-    }
-    proj_errno_set (P, EINVAL);
-    return proj_obs_error ();
-}
-
-
-PJ_OBS pj_invobs (PJ_OBS obs, PJ *P) {
-    if (0!=P->invobs) {
-        obs  =  P->invobs (obs, P);
-        return obs;
-    }
-    if (0!=P->inv3d) {
-        obs.coo.lpz  =  pj_inv3d (obs.coo.xyz, P);
-        return obs;
-    }
-    if (0!=P->inv) {
-        obs.coo.lp  =  pj_inv (obs.coo.xy, P);
-        return obs;
-    }
-    proj_errno_set (P, EINVAL);
-    return proj_obs_error ();
-}
-
-
-
-PJ_COORD pj_fwdcoord (PJ_COORD coo, PJ *P) {
-    if (0!=P->fwdcoord)
-        return P->fwdcoord (coo, P);
-    if (0!=P->fwdobs) {
-        PJ_OBS obs = proj_obs_null;
-        obs.coo = coo;
-        obs  =  P->fwdobs (obs, P);
-        return obs.coo;
-    }
+PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
+    if (0!=P->fwd4d)
+        return P->fwd4d (coo, P);
     if (0!=P->fwd3d) {
         coo.xyz  =  pj_fwd3d (coo.lpz, P);
         return coo;
@@ -178,15 +77,9 @@ PJ_COORD pj_fwdcoord (PJ_COORD coo, PJ *P) {
 }
 
 
-PJ_COORD pj_invcoord (PJ_COORD coo, PJ *P) {
-    if (0!=P->invcoord)
-        return P->invcoord (coo, P);
-    if (0!=P->invobs) {
-        PJ_OBS obs = proj_obs_null;
-        obs.coo = coo;
-        obs  =  P->invobs (obs, P);
-        return obs.coo;
-    }
+PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
+    if (0!=P->inv4d)
+        return P->inv4d (coo, P);
     if (0!=P->inv3d) {
         coo.lpz  =  pj_inv3d (coo.xyz, P);
         return coo;

--- a/src/proj.def
+++ b/src/proj.def
@@ -97,52 +97,52 @@ EXPORTS
     proj_create_crs_to_crs          @93
     proj_destroy                    @94
 
-    proj_trans_obs                  @95
-    proj_trans_coord                @96
-    proj_transform                  @97
-    proj_transform_coord            @98
-    proj_roundtrip                  @99
+    proj_trans                      @95
+    proj_trans_array                @96
+    proj_trans_generic              @97
+    proj_roundtrip                  @98
 
-    proj_coord                     @100
-    proj_obs                       @101
-    proj_coord_error               @102
-    proj_obs_error                 @103
+    proj_coord                      @99
+    proj_coord_error               @100
 
-    proj_errno                     @104
-    proj_errno_set                 @105
-    proj_errno_reset               @106
-    proj_errno_restore             @107
-    proj_context_errno_set         @108
+    proj_errno                     @101
+    proj_errno_set                 @102
+    proj_errno_reset               @103
+    proj_errno_restore             @104
+    proj_context_errno_set         @105
 
-    proj_context_create            @109
-    proj_context_set               @110
-    proj_context_inherit           @111
-    proj_context_destroy           @112
+    proj_context_create            @106
+    proj_context_set               @107
+    proj_context_inherit           @108
+    proj_context_destroy           @109
 
-    proj_lp_dist                   @113
-    proj_xy_dist                   @114
-    proj_xyz_dist                  @115
+    proj_lp_dist                   @110
+    proj_xy_dist                   @111
+    proj_xyz_dist                  @112
 
-    proj_log_level                 @116
-    proj_log_func                  @117
-    proj_log_error                 @118
-    proj_log_debug                 @119
-    proj_log_trace                 @120
+    proj_log_level                 @113
+    proj_log_func                  @114
+    proj_log_error                 @115
+    proj_log_debug                 @116
+    proj_log_trace                 @117
 
-    proj_info                      @121
-    proj_pj_info                   @122
-    proj_grid_info                 @123
-    proj_init_info                 @124
+    proj_info                      @118
+    proj_pj_info                   @119
+    proj_grid_info                 @120
+    proj_init_info                 @121
 
-    proj_torad                     @125
-    proj_todeg                     @126
-    proj_rtodms                    @127
-    proj_dmstor                    @128
+    proj_torad                     @122
+    proj_todeg                     @123
+    proj_rtodms                    @124
+    proj_dmstor                    @125
 
-    proj_derivatives               @129
-    proj_factors                   @130
+    proj_derivatives               @126
+    proj_factors                   @127
 
-    proj_list_operations           @131
-    proj_list_ellps                @132
-    proj_list_units                @133
-    proj_list_prime_meridians      @134
+    proj_list_operations           @128
+    proj_list_ellps                @129
+    proj_list_units                @130
+    proj_list_prime_meridians      @131
+
+    proj_angular_left              @132
+    proj_angular_right             @133

--- a/src/proj.h
+++ b/src/proj.h
@@ -368,10 +368,16 @@ enum PJ_DIRECTION {
 };
 typedef enum PJ_DIRECTION PJ_DIRECTION;
 
-PJ_COORD proj_trans_coord (PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
 
 
-size_t proj_transform (
+
+int proj_angular_left (PJ *P);
+int proj_angular_right (PJ *P);
+
+PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
+
+
+size_t proj_trans_generic (
     PJ *P,
     PJ_DIRECTION direction,
     double *x, size_t sx, size_t nx,
@@ -380,7 +386,7 @@ size_t proj_transform (
     double *t, size_t st, size_t nt
 );
 
-int proj_transform_coord (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord);
+int proj_trans_array (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord);
 
 /* Initializers */
 PJ_COORD proj_coord (double x, double y, double z, double t);

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -44,6 +44,13 @@ PJ_COORD proj_coord (double x, double y, double z, double t) {
     return res;
 }
 
+/* We do not want to bubble enum pj_io_units up to the API level, so we provide these predicates instead */
+int proj_angular_left (PJ *P) {
+    return pj_left (P)==PJ_IO_UNITS_RADIANS;
+}
+int proj_angular_right (PJ *P) {
+    return pj_right (P)==PJ_IO_UNITS_RADIANS;
+}
 
 /* Geodesic distance (in meter) between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, LP a, LP b) {
@@ -84,14 +91,14 @@ double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD coo) {
     switch (direction) {
         case PJ_FWD:
             for (i = 0;  i < n;  i++) {
-                u  =  pj_fwdcoord (o, P);
-                o  =  pj_invcoord (u, P);
+                u  =  pj_fwd4d (o, P);
+                o  =  pj_inv4d (u, P);
             }
             break;
         case PJ_INV:
             for (i = 0;  i < n;  i++) {
-                u  =  pj_invcoord (o, P);
-                o  =  pj_fwdcoord (u, P);
+                u  =  pj_inv4d (o, P);
+                o  =  pj_fwd4d (u, P);
             }
             break;
         default:
@@ -108,17 +115,18 @@ double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD coo) {
 }
 
 
-
 /* Apply the transformation P to the coordinate coo */
-PJ_COORD proj_trans_coord (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
+PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
     if (0==P)
         return coo;
+    if (P->inverted)
+        direction = -direction;
 
     switch (direction) {
         case PJ_FWD:
-            return pj_fwdcoord (coo, P);
+            return pj_fwd4d (coo, P);
         case PJ_INV:
-            return  pj_invcoord (coo, P);
+            return  pj_inv4d (coo, P);
         case PJ_IDENT:
             return coo;
         default:
@@ -131,8 +139,29 @@ PJ_COORD proj_trans_coord (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
 
 
 
+/*****************************************************************************/
+int proj_trans_array (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord) {
+/******************************************************************************
+    Batch transform an array of PJ_COORD.
+
+    Returns 0 if all coordinates are transformed without error, otherwise
+    returns error number.
+******************************************************************************/
+    size_t i;
+
+    for (i = 0;  i < n;  i++) {
+        coord[i] = proj_trans (P, direction, coord[i]);
+        if (proj_errno(P))
+            return proj_errno (P);
+    }
+
+   return 0;
+}
+
+
+
 /*************************************************************************************/
-size_t proj_transform (
+size_t proj_trans_generic (
     PJ *P,
     PJ_DIRECTION direction,
     double *x, size_t sx, size_t nx,
@@ -189,11 +218,15 @@ size_t proj_transform (
     Return value: Number of transformations completed.
 
 **************************************************************************************/
-    PJ_COORD coord = proj_coord_null;
+    PJ_COORD coord = {{0,0,0,0}};
     size_t i, nmin;
     double null_broadcast = 0;
+
     if (0==P)
         return 0;
+
+    if (P->inverted)
+        direction = -direction;
 
     /* ignore lengths of null arrays */
     if (0==x) nx = 0;
@@ -244,9 +277,9 @@ size_t proj_transform (
         coord.xyzt.t = *t;
 
         if (PJ_FWD==direction)
-            coord = pj_fwdcoord (coord, P);
+            coord = pj_fwd4d (coord, P);
         else
-            coord = pj_invcoord (coord, P);
+            coord = pj_inv4d (coord, P);
 
         /* in all full length cases, we overwrite the input with the output */
         if (nx > 1)  {
@@ -279,24 +312,6 @@ size_t proj_transform (
         *t = coord.xyzt.t;
 
     return i;
-}
-
-/*****************************************************************************/
-int proj_transform_coord (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord) {
-/******************************************************************************
-    Batch transform an array of PJ_COORD.
-
-    Returns 0 if all coordinates are transformed without error, otherwise
-    returns error number.
-******************************************************************************/
-    size_t i;
-    for (i=0; i<n; i++) {
-        coord[i] = proj_trans_coord(P, direction, coord[i]);
-        if (proj_errno(P))
-            return proj_errno(P);
-    }
-
-    return 0;
 }
 
 
@@ -554,7 +569,7 @@ PJ_PROJ_INFO proj_pj_info(PJ *P) {
 
     /* this does not take into account that a pipeline potentially does not */
     /* have an inverse.                                                     */
-    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->invobs != 0);
+    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->inv4d != 0);
 
     return info;
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -99,6 +99,7 @@ void proj_log_trace (PJ *P, const char *fmt, ...);
 void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION log);
 
 void pj_inherit_ellipsoid_defs(const PJ *src, PJ *dst);
+int pj_calc_ellps_params(PJ *P, double a, double es);
 
 /* Lowest level: Minimum support for fileapi */
 void proj_fileapi_set (PJ *P, void *fileapi);

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -48,14 +48,6 @@
 extern "C" {
 #endif
 
-
-
-struct PJ_OBS {
-    PJ_COORD coo;        /* coordinate data */
-};
-typedef struct PJ_OBS PJ_OBS;
-
-
 #ifndef PJ_TODEG
 #define PJ_TODEG(rad)  ((rad)*180.0/M_PI)
 #endif
@@ -67,29 +59,16 @@ typedef struct PJ_OBS PJ_OBS;
 enum pj_io_units pj_left (PJ *P);
 enum pj_io_units pj_right (PJ *P);
 
-PJ_OBS   proj_obs   (double x, double y, double z, double t);
-PJ_OBS   proj_trans_obs   (PJ *P, PJ_DIRECTION direction, PJ_OBS obs);
+PJ_COORD   proj_trans   (PJ *P, PJ_DIRECTION direction, PJ_COORD obs);
 
 PJ_COORD proj_coord_error (void);
-PJ_OBS   proj_obs_error (void);
-#ifndef PJ_INTERNAL_C
-extern const PJ_COORD proj_coord_null;
-extern const PJ_OBS   proj_obs_null;
-#endif
-/* Part of MSVC workaround: Make proj_*_null look function-like for symmetry with proj_*_error */
-#define proj_coord_null(x) proj_coord_null
-#define proj_obs_null(x) proj_obs_null
-
 
 void proj_context_errno_set (PJ_CONTEXT *ctx, int err);
 void proj_context_set (PJ *P, PJ_CONTEXT *ctx);
 void proj_context_inherit (PJ *parent, PJ *child);
 
-
-PJ_OBS pj_fwdobs (PJ_OBS obs, PJ *P);
-PJ_OBS pj_invobs (PJ_OBS obs, PJ *P);
-PJ_COORD pj_fwdcoord (PJ_COORD coo, PJ *P);
-PJ_COORD pj_invcoord (PJ_COORD coo, PJ *P);
+PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P);
+PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P);
 
 /* Grid functionality */
 int             proj_vgrid_init(PJ *P, const char *grids);

--- a/src/projects.h
+++ b/src/projects.h
@@ -173,10 +173,7 @@ typedef struct { double u, v, w; }     UVW;
 
 /* Forward declarations and typedefs for stuff needed inside the PJ object */
 struct PJconsts;
-struct PJ_OBS;
-#ifndef PROJ_INTERNAL_H
-typedef struct PJ_OBS PJ_OBS;
-#endif
+
 union  PJ_COORD;
 struct geod_geodesic;
 struct pj_opaque;
@@ -211,6 +208,7 @@ struct PJ_AREA {
 
 struct projCtx_t;
 typedef struct projCtx_t projCtx_t;
+
 
 /* base projection data structure */
 struct PJconsts {
@@ -254,10 +252,9 @@ struct PJconsts {
     LP  (*inv)(XY,    PJ *);
     XYZ (*fwd3d)(LPZ, PJ *);
     LPZ (*inv3d)(XYZ, PJ *);
-    PJ_OBS (*fwdobs)(PJ_OBS, PJ *);
-    PJ_OBS (*invobs)(PJ_OBS, PJ *);
-    PJ_COORD (*fwdcoord)(PJ_COORD, PJ *);
-    PJ_COORD (*invcoord)(PJ_COORD, PJ *);
+    PJ_COORD (*fwd4d)(PJ_COORD, PJ *);
+    PJ_COORD (*inv4d)(PJ_COORD, PJ *);
+
 
     void (*spc)(LP, PJ *, struct FACTORS *);
 


### PR DESCRIPTION
Move pipeline initialisation logic to PJ_pipeline.c and decrease the number of special cases to handle in pj_init.c.

With the changes made in #639 it is now easier to take control of the pipeline initialisation as part of the setup of that operation instead of doing it as special cases in pj_init. With these changes ellipsoid setup is handled better for pipelines than previously.