### PR TITLE
Eliminate the last traces of PJ_OBS

### DIFF
--- a/src/PJ_axisswap.c
+++ b/src/PJ_axisswap.c
@@ -127,36 +127,31 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD forward_obs(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
-    PJ_COORD in, out;
+    PJ_COORD out;
 
     out = proj_coord_error();
-    in = obs.coo;
 
     for (i=0; i<4; i++)
-        out.v[i] = in.v[Q->axis[i]] * Q->sign[i];
+        out.v[i] = coo.v[Q->axis[i]] * Q->sign[i];
 
-    obs.coo = out;
-    return obs;
+    return out;
 }
 
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD reverse_obs(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
-    PJ_COORD in, out;
+    PJ_COORD out;
 
     out = proj_coord_error();
-    in = obs.coo;
 
-    for (i=0; i<4; i++) {
-        out.v[Q->axis[i]] = in.v[i] * Q->sign[i];
-    }
+    for (i=0; i<4; i++)
+        out.v[Q->axis[i]] = coo.v[i] * Q->sign[i];
 
-    obs.coo = out;
-    return obs;
+    return out;
 }
 
 
@@ -182,7 +177,7 @@ PJ *PROJECTION(axisswap) {
     for (i=0; i<4; i++)
         Q->axis[i] = i+4;
 
-    /* check that all characteds are valid */
+    /* check that all characters are valid */
     for (i=0; i<strlen(order); i++)
         if (strchr("1234-,", order[i]) == 0) {
             proj_log_error(P, "axisswap: unknown axis '%c'", order[i]);
@@ -190,12 +185,12 @@ PJ *PROJECTION(axisswap) {
         }
 
     /* read axes numbers and signs */
-    for( s = order, n = 0; *s != '\0' && n < 4; ) {
+    for ( s = order, n = 0; *s != '\0' && n < 4; ) {
         Q->axis[n] = abs(atoi(s))-1;
         Q->sign[n++] = sign(atoi(s));
-        while( *s != '\0' && *s != ',' )
+        while ( *s != '\0' && *s != ',' )
             s++;
-        if( *s == ',' )
+        if ( *s == ',' )
             s++;
     }
 
@@ -212,8 +207,8 @@ PJ *PROJECTION(axisswap) {
 
     /* only map fwd/inv functions that are possible with the given axis setup */
     if (n == 4) {
-        P->fwdobs = forward_obs;
-        P->invobs = reverse_obs;
+        P->fwdobs = P->fwd4d = forward_obs;
+        P->invobs = P->inv4d = reverse_obs;
     }
     if (n == 3 && Q->axis[0] < 3 && Q->axis[1] < 3 && Q->axis[2] < 3) {
         P->fwd3d  = forward_3d;

--- a/src/PJ_axisswap.c
+++ b/src/PJ_axisswap.c
@@ -127,7 +127,7 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_COORD forward_obs(PJ_COORD coo, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD out;
@@ -141,7 +141,7 @@ static PJ_COORD forward_obs(PJ_COORD coo, PJ *P) {
 }
 
 
-static PJ_COORD reverse_obs(PJ_COORD coo, PJ *P) {
+static PJ_COORD reverse_4d(PJ_COORD coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD out;
@@ -207,8 +207,8 @@ PJ *PROJECTION(axisswap) {
 
     /* only map fwd/inv functions that are possible with the given axis setup */
     if (n == 4) {
-        P->fwdobs = P->fwd4d = forward_obs;
-        P->invobs = P->inv4d = reverse_obs;
+        P->fwd4d = forward_4d;
+        P->inv4d = reverse_4d;
     }
     if (n == 3 && Q->axis[0] < 3 && Q->axis[1] < 3 && Q->axis[2] < 3) {
         P->fwd3d  = forward_3d;
@@ -219,7 +219,7 @@ PJ *PROJECTION(axisswap) {
         P->inv    = reverse_2d;
     }
 
-    if (P->fwdobs == NULL && P->fwd3d == NULL && P->fwd == NULL) {
+    if (P->fwd4d == NULL && P->fwd3d == NULL && P->fwd == NULL) {
         proj_log_error(P, "swapaxis: bad axis order");
         return pj_default_destructor(P, PJD_ERR_AXIS);
     }

--- a/src/PJ_deformation.c
+++ b/src/PJ_deformation.c
@@ -139,26 +139,26 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS in, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     double dt;
     XYZ shift;
-    PJ_OBS out = in;
+    PJ_COORD out = in;
 
     if (Q->t_obs != HUGE_VAL) {
             dt = Q->t_obs - Q->t_epoch;
         } else {
-            dt = in.coo.xyzt.t - Q->t_epoch;
+            dt = in.xyzt.t - Q->t_epoch;
     }
 
     if (Q->has_xy_grids) {
-        shift = get_xygrid_shift(P, in.coo.xyz);
-        out.coo.xyz.x += dt * shift.x;
-        out.coo.xyz.y += dt * shift.y;
+        shift = get_xygrid_shift(P, in.xyz);
+        out.xyz.x += dt * shift.x;
+        out.xyz.y += dt * shift.y;
     }
 
     if (Q->has_z_grids)
-        out.coo.xyz.z += dt * get_zgrid_shift(P, in.coo.xyz);
+        out.xyz.z += dt * get_zgrid_shift(P, in.xyz);
 
     return out;
 }
@@ -188,22 +188,22 @@ static LPZ reverse_3d(XYZ in, PJ *P) {
     return out.lpz;
 }
 
-static PJ_OBS reverse_obs(PJ_OBS in, PJ *P) {
+static PJ_COORD reverse_4d(PJ_COORD in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
-    PJ_OBS out = in;
+    PJ_COORD out = in;
     double dt;
 
     if (Q->t_obs != HUGE_VAL) {
             dt = Q->t_epoch - Q->t_obs;
         } else {
-            dt = Q->t_epoch - in.coo.xyzt.t;
+            dt = Q->t_epoch - in.xyzt.t;
     }
 
     if (Q->has_xy_grids)
-        out.coo.xyz = reverse_hshift(P, in.coo.xyz, dt);
+        out.xyz = reverse_hshift(P, in.xyz, dt);
 
     if (Q->has_z_grids)
-        out.coo.xyz.z = in.coo.xyz.z + dt * get_zgrid_shift(P, in.coo.xyz);
+        out.xyz.z = in.xyz.z + dt * get_zgrid_shift(P, in.xyz);
 
     return out;
 }
@@ -274,8 +274,8 @@ PJ *PROJECTION(deformation) {
        return destructor(P, PJD_ERR_MISSING_ARGS);
     }
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwdobs = P->fwd4d = forward_4d;
+    P->invobs = P->fwd4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;

--- a/src/PJ_deformation.c
+++ b/src/PJ_deformation.c
@@ -274,8 +274,8 @@ PJ *PROJECTION(deformation) {
        return destructor(P, PJD_ERR_MISSING_ARGS);
     }
 
-    P->fwdobs = P->fwd4d = forward_4d;
-    P->invobs = P->fwd4d = reverse_4d;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -468,8 +468,8 @@ PJ *TRANSFORMATION(helmert, 0) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = P->fwd4d = helmert_forward_4d;
-    P->invobs = P->inv4d = helmert_reverse_4d;
+    P->fwd4d  = helmert_forward_4d;
+    P->inv4d  = helmert_reverse_4d;
     P->fwd3d  = helmert_forward_3d;
     P->inv3d  = helmert_reverse_3d;
     P->fwd    = helmert_forward;

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -423,35 +423,35 @@ static LPZ helmert_reverse_3d (XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS helmert_forward_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD helmert_forward_4d (PJ_COORD point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.coo.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.coo.xyzt.t;
+    if (point.xyzt.t != Q->t_obs) {
+        Q->t_obs = point.xyzt.t;
         update_parameters(P);
         build_rot_matrix(P);
     }
 
-    point.coo.xyz = helmert_forward_3d (point.coo.lpz, P);
+    point.xyz = helmert_forward_3d (point.lpz, P);
 
     return point;
 }
 
 
-static PJ_OBS helmert_reverse_obs (PJ_OBS point, PJ *P) {
+static PJ_COORD helmert_reverse_4d (PJ_COORD point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.coo.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.coo.xyzt.t;
+    if (point.xyzt.t != Q->t_obs) {
+        Q->t_obs = point.xyzt.t;
         update_parameters(P);
         build_rot_matrix(P);
     }
 
-    point.coo.lpz = helmert_reverse_3d (point.coo.xyz, P);
+    point.lpz = helmert_reverse_3d (point.xyz, P);
 
     return point;
 }
@@ -468,8 +468,8 @@ PJ *TRANSFORMATION(helmert, 0) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = helmert_forward_obs;
-    P->invobs = helmert_reverse_obs;
+    P->fwdobs = P->fwd4d = helmert_forward_4d;
+    P->invobs = P->inv4d = helmert_reverse_4d;
     P->fwd3d  = helmert_forward_3d;
     P->inv3d  = helmert_reverse_3d;
     P->fwd    = helmert_forward;
@@ -671,8 +671,8 @@ int pj_helmert_selftest (void) {
        matrix is updated when necessary. Test coordinates from GNSStrans. */
     XYZ expect4a = {3370658.18890, 711877.42370, 5349787.12430};
     XYZ expect4b = {3370658.18087, 711877.42750, 5349787.12648};
-    PJ_OBS in4 = {{{3370658.378, 711877.314, 5349787.086, 2017.0}}};
-    PJ_OBS out;
+    PJ_COORD in4 = {{3370658.378, 711877.314, 5349787.086, 2017.0}};
+    PJ_COORD out;
 
     PJ *helmert = proj_create(
         0,
@@ -703,20 +703,20 @@ int pj_helmert_selftest (void) {
     ret = test (args5, in5, expect5, 0.001);  if (ret) return ret + 40;
 
     /* Run test 4 */
-    out = proj_trans_obs (helmert, PJ_FWD, in4);
-    if (proj_xyz_dist (out.coo.xyz, expect4a) > 1e-4) {
+    out = proj_trans (helmert, PJ_FWD, in4);
+    if (proj_xyz_dist (out.xyz, expect4a) > 1e-4) {
         proj_log_error(helmert, "Tolerance of test 4a not met!");
-        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.coo.xyz.x, in4.coo.xyz.y, in4.coo.xyz.z);
-        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.xyz.x, in4.xyz.y, in4.xyz.z);
+        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.xyz.x, out.xyz.y, out.xyz.z);
         return 31;
     }
 
-    in4.coo.xyzt.t = 2018.0;
-    out = proj_trans_obs (helmert, PJ_FWD, in4);
-    if (proj_xyz_dist (out.coo.xyz, expect4b) > 1e-4) {
+    in4.xyzt.t = 2018.0;
+    out = proj_trans (helmert, PJ_FWD, in4);
+    if (proj_xyz_dist (out.xyz, expect4b) > 1e-4) {
         proj_log_error(helmert, "Tolerance of test 4b not met!");
-        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.coo.xyz.x, in4.coo.xyz.y, in4.coo.xyz.z);
-        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        proj_log_error(helmert, "  In:  %10.10f, %10.10f, %10.10f", in4.xyz.x, in4.xyz.y, in4.xyz.z);
+        proj_log_error(helmert, "  Out: %10.10f, %10.10f, %10.10f", out.xyz.x, out.xyz.y, out.xyz.z);
         return 32;
     }
 

--- a/src/PJ_hgridshift.c
+++ b/src/PJ_hgridshift.c
@@ -47,8 +47,8 @@ static PJ_COORD reverse_4d (PJ_COORD obs, PJ *P) {
 
 PJ *PROJECTION(hgridshift) {
 
-    P->fwdobs = P->fwd4d = forward_4d;
-    P->invobs = P->inv4d = reverse_4d;
+    P->fwd4d  = forward_4d;
+    P->inv4d  = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -460,8 +460,8 @@ PJ *PROJECTION(horner) {
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
         if (0==parse_coefs (P, Q->inv_c, "inv_c", n))
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
-        P->fwd4d  =  P->fwd4d = complex_horner_forward_4d;
-        P->inv4d  =  P->inv4d = complex_horner_reverse_4d;
+        P->fwd4d = complex_horner_forward_4d;
+        P->inv4d = complex_horner_reverse_4d;
 
     }
     else {

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -429,13 +429,13 @@ PJ *PROJECTION(horner) {
 /*********************************************************************/
     int   degree = 0, n, complex_horner = 0;
     HORNER *Q;
-    P->fwdobs  =  P->fwd4d = horner_forward_4d;
-    P->invobs  =  P->inv4d = horner_reverse_4d;
-    P->fwd3d   =  0;
-    P->inv3d   =  0;
-    P->fwd     =  0;
-    P->inv     =  0;
-    P->left    =  P->right  =  PJ_IO_UNITS_METERS;
+    P->fwd4d  = horner_forward_4d;
+    P->inv4d  = horner_reverse_4d;
+    P->fwd3d  =  0;
+    P->inv3d  =  0;
+    P->fwd    =  0;
+    P->inv    =  0;
+    P->left   =  P->right  =  PJ_IO_UNITS_METERS;
     P->destructor = horner_freeup;
 
     /* Polynomial degree specified? */
@@ -460,8 +460,8 @@ PJ *PROJECTION(horner) {
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
         if (0==parse_coefs (P, Q->inv_c, "inv_c", n))
             return horner_freeup (P, PJD_ERR_MISSING_ARGS);
-        P->fwdobs  =  P->fwd4d = complex_horner_forward_4d;
-        P->invobs  =  P->inv4d = complex_horner_reverse_4d;
+        P->fwd4d  =  P->fwd4d = complex_horner_forward_4d;
+        P->inv4d  =  P->inv4d = complex_horner_reverse_4d;
 
     }
     else {

--- a/src/PJ_latlong.c
+++ b/src/PJ_latlong.c
@@ -54,12 +54,12 @@ static LP inverse(XY xy, PJ *P) {
     return lp;
 }
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     (void) P;
     return obs;
 }
 
-static PJ_OBS inverse_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD inverse_4d(PJ_COORD obs, PJ *P) {
     (void) P;
     return obs;
 }
@@ -70,8 +70,8 @@ PJ *PROJECTION(latlong) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->invobs = P->inv4d = inverse_4d;
+    P->fwdobs = P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -85,8 +85,8 @@ PJ *PROJECTION(longlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->invobs = P->inv4d = inverse_4d;
+    P->fwdobs = P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -100,8 +100,8 @@ PJ *PROJECTION(latlon) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->invobs = P->inv4d = inverse_4d;
+    P->fwdobs = P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -115,8 +115,8 @@ PJ *PROJECTION(lonlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = inverse_obs;
-    P->fwdobs = forward_obs;
+    P->invobs = P->inv4d = inverse_4d;
+    P->fwdobs = P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 

--- a/src/PJ_latlong.c
+++ b/src/PJ_latlong.c
@@ -70,8 +70,8 @@ PJ *PROJECTION(latlong) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = P->inv4d = inverse_4d;
-    P->fwdobs = P->fwd4d = forward_4d;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -85,8 +85,8 @@ PJ *PROJECTION(longlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = P->inv4d = inverse_4d;
-    P->fwdobs = P->fwd4d = forward_4d;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -100,8 +100,8 @@ PJ *PROJECTION(latlon) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = P->inv4d = inverse_4d;
-    P->fwdobs = P->fwd4d = forward_4d;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 
@@ -115,8 +115,8 @@ PJ *PROJECTION(lonlat) {
     P->y0 = 0.0;
     P->inv = inverse;
     P->fwd = forward;
-    P->invobs = P->inv4d = inverse_4d;
-    P->fwdobs = P->fwd4d = forward_4d;
+    P->inv4d = inverse_4d;
+    P->fwd4d = forward_4d;
     P->left = PJ_IO_UNITS_RADIANS;
     P->right = PJ_IO_UNITS_RADIANS;
 

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -235,10 +235,9 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 }
 
 
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.xyz = forward_3d(obs.coo.lpz, P);
-    return point;
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+    obs.xyz = forward_3d(obs.lpz, P);
+    return obs;
 }
 
 
@@ -263,10 +262,9 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 }
 
 
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
-    PJ_OBS point;
-    point.coo.lpz = reverse_3d(obs.coo.xyz, P);
-    return point;
+static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+    obs.lpz = reverse_3d(obs.xyz, P);
+    return obs;
 }
 
 
@@ -276,8 +274,8 @@ PJ *PROJECTION(molodensky) {
         return pj_default_destructor(P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwdobs = P->fwd4d = forward_4d;
+    P->invobs = P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = forward_2d;
@@ -320,7 +318,7 @@ int pj_molodensky_selftest (void) {return 0;}
 #else
 int pj_molodensky_selftest (void) {
 
-    PJ_OBS in, res, exp;
+    PJ_COORD in, res, exp;
     PJ *P;
 
     /* Test the abridged Molodensky first. Example from appendix 3 of Deakin (2004). */
@@ -332,28 +330,28 @@ int pj_molodensky_selftest (void) {
     if (0==P)
         return 10;
 
-    in.coo.lpz.lam = PJ_TORAD(144.9667);
-    in.coo.lpz.phi = PJ_TORAD(-37.8);
-    in.coo.lpz.z   = 50.0;
+    in.lpz.lam = PJ_TORAD(144.9667);
+    in.lpz.phi = PJ_TORAD(-37.8);
+    in.lpz.z   = 50.0;
 
-    exp.coo.lpz.lam = PJ_TORAD(144.968);
-    exp.coo.lpz.phi = PJ_TORAD(-37.79848);
-    exp.coo.lpz.z   = 46.378;
+    exp.lpz.lam = PJ_TORAD(144.968);
+    exp.lpz.phi = PJ_TORAD(-37.79848);
+    exp.lpz.z   = 46.378;
 
-    res = proj_trans_obs(P, PJ_FWD, in);
+    res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.coo.lp, exp.coo.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
         proj_destroy(P);
         return 11;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in.coo) > 1) {
+    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
         proj_destroy(P);
         return 12;
     }
 
-    if (res.coo.lpz.z - exp.coo.lpz.z > 1e-3) {
+    if (res.lpz.z - exp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 13;
     }
@@ -369,20 +367,20 @@ int pj_molodensky_selftest (void) {
     if (0==P)
         return 20;
 
-    res = proj_trans_obs(P, PJ_FWD, in);
+    res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.coo.lp, exp.coo.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
         proj_destroy(P);
         return 21;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in.coo) > 1) {
+    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
         proj_destroy(P);
         return 22;
     }
 
-    if (res.coo.lpz.z - exp.coo.lpz.z > 1e-3) {
+    if (res.lpz.z - exp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 23;
     }

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -274,8 +274,8 @@ PJ *PROJECTION(molodensky) {
         return pj_default_destructor(P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = P->fwd4d = forward_4d;
-    P->invobs = P->inv4d = reverse_4d;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = forward_2d;

--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -86,10 +86,10 @@ static void *destructor(PJ *P, int errlev) {
         return 0;
     if (0==P->opaque)
         return pj_default_destructor (P, errlev);
-        
+
     if (P->opaque->link)
         P->opaque->link->destructor (P->opaque->link, errlev);
-        
+
     return pj_default_destructor(P, errlev);
 }
 
@@ -135,7 +135,7 @@ static ARGS ob_tran_target_params (paralist *params) {
     args.argv = pj_calloc (argc - 1, sizeof (char *));
     if (0==args.argv)
         return args;
-    
+
     /* Copy all args *except* the proj=ob_tran arg to the argv array */
     for (i = 0;  params != 0;  params = params->next) {
         if (0==strcmp (params->param, "proj=ob_tran"))
@@ -287,14 +287,14 @@ int pj_ob_tran_selftest (void) {
     a = proj_coord (300000, 400000, 0, 0);
     b.lpz.lam = -proj_torad (42 + (45 + 22.377/60)/60);
     b.lpz.phi =  proj_torad (85 + (35 + 28.083/60)/60);
-    a = proj_trans_coord (P, -1, a);
+    a = proj_trans (P, -1, a);
     d = proj_lp_dist (P, a.lp, b.lp);
     if (d > 1e-3)
         return 2;
 
     a = proj_coord (proj_torad(10), proj_torad(20), 0, 0);
     b = proj_coord (-1384841.18787, 7581707.88240, 0, 0);
-    a = proj_trans_coord (P, 1, a);
+    a = proj_trans (P, 1, a);
     d = proj_xy_dist (a.xy, b.xy);
     if (d > 1e-3)
         return 3;

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -298,8 +298,8 @@ PJ *PROJECTION(pipeline) {
     int i_pipeline = -1, i_first_step = -1, i_current_step;
     char **argv, **current_argv;
 
-    P->fwdobs =  P->fwd4d = pipeline_forward_4d;
-    P->invobs =  P->inv4d = pipeline_reverse_4d;
+    P->fwd4d  = pipeline_forward_4d;
+    P->inv4d  = pipeline_reverse_4d;
     P->fwd3d  =  pipeline_forward_3d;
     P->inv3d  =  pipeline_reverse_3d;
     P->fwd    =  pipeline_forward;

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -316,8 +316,8 @@ PJ *PROJECTION(unitconvert) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = P->fwd4d = forward_4d;
-    P->invobs = P->inv4d = reverse_4d;
+    P->fwd4d  = forward_4d;
+    P->inv4d  = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = forward_2d;

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -19,7 +19,7 @@ date. A time unit conversion is performed like
 distance units are converted in the same manner, with meter being the
 central unit.
 
-The modified Julian date is chosen as the pivout unit since it has a
+The modified Julian date is chosen as the pivot unit since it has a
 fairly high precision, goes sufficiently long backwards in time, has no
 danger of hitting the upper limit in the near future and it is a fairly
 common time unit in astronomy and geodesy. Note that we are using the
@@ -266,40 +266,40 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_OBS forward_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
 /************************************************************************
     Forward conversion of time units
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_OBS out;
+    PJ_COORD out;
 
     /* delegate unit conversion of physical dimensions to the 3D function */
-    out.coo.xyz = forward_3d(obs.coo.lpz, P);
+    out.xyz = forward_3d(obs.lpz, P);
 
     if (Q->t_in_id >= 0)
-        out.coo.xyzt.t = time_units[Q->t_in_id].t_in( obs.coo.xyzt.t );
+        out.xyzt.t = time_units[Q->t_in_id].t_in( obs.xyzt.t );
     if (Q->t_out_id >= 0)
-        out.coo.xyzt.t = time_units[Q->t_out_id].t_out( out.coo.xyzt.t );
+        out.xyzt.t = time_units[Q->t_out_id].t_out( out.xyzt.t );
 
     return out;
 }
 
 
 /***********************************************************************/
-static PJ_OBS reverse_obs(PJ_OBS obs, PJ *P) {
+static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
 /************************************************************************
     Reverse conversion of time units
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_OBS out;
+    PJ_COORD out;
 
     /* delegate unit conversion of physical dimensions to the 3D function */
-    out.coo.lpz = reverse_3d(obs.coo.xyz, P);
+    out.lpz = reverse_3d(obs.xyz, P);
 
     if (Q->t_out_id >= 0)
-        out.coo.xyzt.t = time_units[Q->t_out_id].t_in( obs.coo.xyzt.t );
+        out.xyzt.t = time_units[Q->t_out_id].t_in( obs.xyzt.t );
     if (Q->t_in_id >= 0)
-        out.coo.xyzt.t = time_units[Q->t_in_id].t_out( out.coo.xyzt.t );
+        out.xyzt.t = time_units[Q->t_in_id].t_out( out.xyzt.t );
 
     return out;
 }
@@ -316,8 +316,8 @@ PJ *PROJECTION(unitconvert) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    P->fwdobs = forward_obs;
-    P->invobs = reverse_obs;
+    P->fwdobs = P->fwd4d = forward_4d;
+    P->invobs = P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = forward_2d;
@@ -396,23 +396,23 @@ int pj_unitconvert_selftest (void) {return 0;}
 #else
 
 static int test_time(char* args, double tol, double t_in, double t_exp) {
-    PJ_OBS in, out;
+    PJ_COORD in, out;
     PJ *P = proj_create(PJ_DEFAULT_CTX, args);
     int ret = 0;
 
     if (P == 0)
         return 5;
 
-    in.coo.xyzt.t = t_in;
+    in.xyzt.t = t_in;
 
-    out = proj_trans_obs(P, PJ_FWD, in);
-    if (fabs(out.coo.xyzt.t - t_exp) > tol) {
-        proj_log_error(P, "out: %10.10g, expect: %10.10g", out.coo.xyzt.t, t_exp);
+    out = proj_trans(P, PJ_FWD, in);
+    if (fabs(out.xyzt.t - t_exp) > tol) {
+        proj_log_error(P, "out: %10.10g, expect: %10.10g", out.xyzt.t, t_exp);
         ret = 1;
     }
-    out = proj_trans_obs(P, PJ_INV, out);
-    if (fabs(out.coo.xyzt.t - t_in) > tol) {
-        proj_log_error(P, "out: %10.10g, expect: %10.10g", out.coo.xyzt.t, t_in);
+    out = proj_trans(P, PJ_INV, out);
+    if (fabs(out.xyzt.t - t_in) > tol) {
+        proj_log_error(P, "out: %10.10g, expect: %10.10g", out.xyzt.t, t_in);
         ret = 2;
     }
     pj_free(P);
@@ -422,25 +422,25 @@ static int test_time(char* args, double tol, double t_in, double t_exp) {
 }
 
 static int test_xyz(char* args, double tol, PJ_TRIPLET in, PJ_TRIPLET exp) {
-    PJ_OBS out, obs_in;
+    PJ_COORD out, obs_in;
     PJ *P = proj_create(PJ_DEFAULT_CTX, args);
     int ret = 0;
 
     if (P == 0)
         return 5;
 
-    obs_in.coo.xyz = in.xyz;
-    out = proj_trans_obs(P, PJ_FWD, obs_in);
-    if (proj_xyz_dist(out.coo.xyz, exp.xyz) > tol) {
+    obs_in.xyz = in.xyz;
+    out = proj_trans(P, PJ_FWD, obs_in);
+    if (proj_xyz_dist(out.xyz, exp.xyz) > tol) {
         printf("exp: %10.10g, %10.10g, %10.10g\n", exp.xyz.x, exp.xyz.y, exp.xyz.z);
-        printf("out: %10.10g, %10.10g, %10.10g\n", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        printf("out: %10.10g, %10.10g, %10.10g\n", out.xyz.x, out.xyz.y, out.xyz.z);
         ret = 1;
     }
 
-    out = proj_trans_obs(P, PJ_INV, out);
-    if (proj_xyz_dist(out.coo.xyz, in.xyz) > tol) {
+    out = proj_trans(P, PJ_INV, out);
+    if (proj_xyz_dist(out.xyz, in.xyz) > tol) {
         printf("exp: %g, %g, %g\n", in.xyz.x, in.xyz.y, in.xyz.z);
-        printf("out: %g, %g, %g\n", out.coo.xyz.x, out.coo.xyz.y, out.coo.xyz.z);
+        printf("out: %g, %g, %g\n", out.xyz.x, out.xyz.y, out.xyz.z);
         ret += 2;
     }
     proj_destroy(P);

--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -62,8 +62,8 @@ PJ *PROJECTION(vgridshift) {
         return pj_default_destructor(P, PJD_ERR_FAILED_TO_LOAD_GRID);
     }
 
-    P->fwdobs = P->fwd4d = forward_4d;
-    P->invobs = P->inv4d = reverse_4d;
+    P->fwd4d = forward_4d;
+    P->inv4d = reverse_4d;
     P->fwd3d  = forward_3d;
     P->inv3d  = reverse_3d;
     P->fwd    = 0;

--- a/src/cct.c
+++ b/src/cct.c
@@ -72,6 +72,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 ***********************************************************************/
 
 #include "optargpm.h"
+#include "proj_internal.h"
 #include <proj.h>
 #include "projects.h"
 #include <stdio.h>
@@ -79,6 +80,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 #include <ctype.h>
 #include <string.h>
 #include <math.h>
+
 
 double proj_strtod(const char *str, char **endptr);
 double proj_atof(const char *str);
@@ -211,17 +213,12 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    input_unit   =  P->left;
-    output_unit  =  P->right;
-    if (PJ_IO_UNITS_CLASSIC==P->left)
-        input_unit = PJ_IO_UNITS_RADIANS;
-    if (PJ_IO_UNITS_CLASSIC==P->right)
-        output_unit = PJ_IO_UNITS_METERS;
-    if (direction==-1) {
-        enum pj_io_units swap = input_unit;
-        input_unit = output_unit;
-        output_unit = swap;
-    }
+    if (direction==-1)
+        P->inverted = !(P->inverted);
+    direction = 1;
+
+    input_unit   =  pj_left (P);
+    output_unit  =  pj_right (P);
 
     /* Allocate input buffer */
     buf = calloc (1, 10000);
@@ -264,7 +261,7 @@ int main(int argc, char **argv) {
             point.lpzt.lam = proj_torad (point.lpzt.lam);
             point.lpzt.phi = proj_torad (point.lpzt.phi);
         }
-        point = proj_trans_coord (P, direction, point);
+        point = proj_trans (P, direction, point);
         if (PJ_IO_UNITS_RADIANS==output_unit) {
             point.lpzt.lam = proj_todeg (point.lpzt.lam);
             point.lpzt.phi = proj_todeg (point.lpzt.phi);

--- a/src/cct.c
+++ b/src/cct.c
@@ -213,12 +213,13 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    /* We have no API call for inverting an operation, so we brute force it. */
     if (direction==-1)
         P->inverted = !(P->inverted);
     direction = 1;
 
-    input_unit   =  pj_left (P);
-    output_unit  =  pj_right (P);
+    input_unit   =  proj_angular_left (P)?  PJ_IO_UNITS_RADIANS: PJ_IO_UNITS_METERS;
+    output_unit  =  proj_angular_right (P)? PJ_IO_UNITS_RADIANS: PJ_IO_UNITS_METERS;
 
     /* Allocate input buffer */
     buf = calloc (1, 10000);

--- a/src/gie.c
+++ b/src/gie.c
@@ -532,7 +532,7 @@ static int expect (char *args) {
     }
     T.e = torad_if_needed (T.P, T.dir==PJ_FWD? PJ_INV:PJ_FWD, T.e);
 
-    T.b = proj_trans_coord (T.P, T.dir, T.a);
+    T.b = proj_trans (T.P, T.dir, T.a);
     T.b = torad_if_needed (T.P, T.dir==PJ_FWD? PJ_INV:PJ_FWD, T.b);
 
     if (T.nargs < 2) {

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -53,7 +53,6 @@ enum pj_io_units pj_right (PJ *P) {
 }
 
 
-
 /* Work around non-constness of MSVC HUGE_VAL by providing functions rather than constants */
 PJ_COORD proj_coord_error (void) {
     PJ_COORD c;
@@ -65,8 +64,6 @@ PJ_COORD proj_coord_error (void) {
 PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
     if (0!=P->fwd4d)
         return P->fwd4d (coo, P);
-    if (0!=P->fwdobs)
-        return P->fwdobs (coo, P);
     if (0!=P->fwd3d) {
         coo.xyz  =  pj_fwd3d (coo.lpz, P);
         return coo;
@@ -83,8 +80,6 @@ PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
 PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
     if (0!=P->inv4d)
         return P->inv4d (coo, P);
-    if (0!=P->invobs)
-        return P->invobs (coo, P);
     if (0!=P->inv3d) {
         coo.lpz  =  pj_inv3d (coo.xyz, P);
         return coo;

--- a/src/proj.def
+++ b/src/proj.def
@@ -143,3 +143,6 @@ EXPORTS
     proj_list_ellps                @129
     proj_list_units                @130
     proj_list_prime_meridians      @131
+
+    proj_angular_left              @132
+    proj_angular_right             @133

--- a/src/proj.def
+++ b/src/proj.def
@@ -97,52 +97,49 @@ EXPORTS
     proj_create_crs_to_crs          @93
     proj_destroy                    @94
 
-    proj_trans_obs                  @95
-    proj_trans_coord                @96
-    proj_transform                  @97
-    proj_transform_coord            @98
-    proj_roundtrip                  @99
+    proj_trans                      @95
+    proj_trans_array                @96
+    proj_trans_generic              @97
+    proj_roundtrip                  @98
 
-    proj_coord                     @100
-    proj_obs                       @101
-    proj_coord_error               @102
-    proj_obs_error                 @103
+    proj_coord                      @99
+    proj_coord_error               @100
 
-    proj_errno                     @104
-    proj_errno_set                 @105
-    proj_errno_reset               @106
-    proj_errno_restore             @107
-    proj_context_errno_set         @108
+    proj_errno                     @101
+    proj_errno_set                 @102
+    proj_errno_reset               @103
+    proj_errno_restore             @104
+    proj_context_errno_set         @105
 
-    proj_context_create            @109
-    proj_context_set               @110
-    proj_context_inherit           @111
-    proj_context_destroy           @112
+    proj_context_create            @106
+    proj_context_set               @107
+    proj_context_inherit           @108
+    proj_context_destroy           @109
 
-    proj_lp_dist                   @113
-    proj_xy_dist                   @114
-    proj_xyz_dist                  @115
+    proj_lp_dist                   @110
+    proj_xy_dist                   @111
+    proj_xyz_dist                  @112
 
-    proj_log_level                 @116
-    proj_log_func                  @117
-    proj_log_error                 @118
-    proj_log_debug                 @119
-    proj_log_trace                 @120
+    proj_log_level                 @113
+    proj_log_func                  @114
+    proj_log_error                 @115
+    proj_log_debug                 @116
+    proj_log_trace                 @117
 
-    proj_info                      @121
-    proj_pj_info                   @122
-    proj_grid_info                 @123
-    proj_init_info                 @124
+    proj_info                      @118
+    proj_pj_info                   @119
+    proj_grid_info                 @120
+    proj_init_info                 @121
 
-    proj_torad                     @125
-    proj_todeg                     @126
-    proj_rtodms                    @127
-    proj_dmstor                    @128
+    proj_torad                     @122
+    proj_todeg                     @123
+    proj_rtodms                    @124
+    proj_dmstor                    @125
 
-    proj_derivatives               @129
-    proj_factors                   @130
+    proj_derivatives               @126
+    proj_factors                   @127
 
-    proj_list_operations           @131
-    proj_list_ellps                @132
-    proj_list_units                @133
-    proj_list_prime_meridians      @134
+    proj_list_operations           @128
+    proj_list_ellps                @129
+    proj_list_units                @130
+    proj_list_prime_meridians      @131

--- a/src/proj.h
+++ b/src/proj.h
@@ -368,10 +368,10 @@ enum PJ_DIRECTION {
 };
 typedef enum PJ_DIRECTION PJ_DIRECTION;
 
-PJ_COORD proj_trans_coord (PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
+PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
 
 
-size_t proj_transform (
+size_t proj_trans_generic (
     PJ *P,
     PJ_DIRECTION direction,
     double *x, size_t sx, size_t nx,
@@ -380,7 +380,7 @@ size_t proj_transform (
     double *t, size_t st, size_t nt
 );
 
-int proj_transform_coord (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord);
+int proj_trans_array (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord);
 
 /* Initializers */
 PJ_COORD proj_coord (double x, double y, double z, double t);

--- a/src/proj.h
+++ b/src/proj.h
@@ -368,6 +368,12 @@ enum PJ_DIRECTION {
 };
 typedef enum PJ_DIRECTION PJ_DIRECTION;
 
+
+
+
+int proj_angular_left (PJ *P);
+int proj_angular_right (PJ *P);
+
 PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
 
 

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -44,6 +44,13 @@ PJ_COORD proj_coord (double x, double y, double z, double t) {
     return res;
 }
 
+/* We do not want to bubble enum pj_io_units up to the API level, so we provide these predicates instead */
+int proj_angular_left (PJ *P) {
+    return pj_left (P)==PJ_IO_UNITS_RADIANS;
+}
+int proj_angular_right (PJ *P) {
+    return pj_right (P)==PJ_IO_UNITS_RADIANS;
+}
 
 /* Geodesic distance (in meter) between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, LP a, LP b) {
@@ -108,8 +115,6 @@ double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD coo) {
 }
 
 
-
-
 /* Apply the transformation P to the coordinate coo */
 PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
     if (0==P)
@@ -131,7 +136,6 @@ PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
     proj_errno_set (P, EINVAL);
     return proj_coord_error ();
 }
-
 
 
 
@@ -565,7 +569,7 @@ PJ_PROJ_INFO proj_pj_info(PJ *P) {
 
     /* this does not take into account that a pipeline potentially does not */
     /* have an inverse.                                                     */
-    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->invobs != 0);
+    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->inv4d != 0);
 
     return info;
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -48,14 +48,6 @@
 extern "C" {
 #endif
 
-
-
-struct PJ_OBS {
-    PJ_COORD coo;        /* coordinate data */
-};
-typedef struct PJ_OBS PJ_OBS;
-
-
 #ifndef PJ_TODEG
 #define PJ_TODEG(rad)  ((rad)*180.0/M_PI)
 #endif
@@ -67,29 +59,16 @@ typedef struct PJ_OBS PJ_OBS;
 enum pj_io_units pj_left (PJ *P);
 enum pj_io_units pj_right (PJ *P);
 
-PJ_OBS   proj_obs   (double x, double y, double z, double t);
-PJ_OBS   proj_trans_obs   (PJ *P, PJ_DIRECTION direction, PJ_OBS obs);
+PJ_COORD   proj_trans   (PJ *P, PJ_DIRECTION direction, PJ_COORD obs);
 
 PJ_COORD proj_coord_error (void);
-PJ_OBS   proj_obs_error (void);
-#ifndef PJ_INTERNAL_C
-extern const PJ_COORD proj_coord_null;
-extern const PJ_OBS   proj_obs_null;
-#endif
-/* Part of MSVC workaround: Make proj_*_null look function-like for symmetry with proj_*_error */
-#define proj_coord_null(x) proj_coord_null
-#define proj_obs_null(x) proj_obs_null
-
 
 void proj_context_errno_set (PJ_CONTEXT *ctx, int err);
 void proj_context_set (PJ *P, PJ_CONTEXT *ctx);
 void proj_context_inherit (PJ *parent, PJ *child);
 
-
-PJ_OBS pj_fwdobs (PJ_OBS obs, PJ *P);
-PJ_OBS pj_invobs (PJ_OBS obs, PJ *P);
-PJ_COORD pj_fwdcoord (PJ_COORD coo, PJ *P);
-PJ_COORD pj_invcoord (PJ_COORD coo, PJ *P);
+PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P);
+PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P);
 
 /* Grid functionality */
 int             proj_vgrid_init(PJ *P, const char *grids);

--- a/src/projects.h
+++ b/src/projects.h
@@ -209,6 +209,7 @@ struct PJ_AREA {
 struct projCtx_t;
 typedef struct projCtx_t projCtx_t;
 
+
 /* base projection data structure */
 struct PJconsts {
 
@@ -254,8 +255,6 @@ struct PJconsts {
     PJ_COORD (*fwd4d)(PJ_COORD, PJ *);
     PJ_COORD (*inv4d)(PJ_COORD, PJ *);
 
-    PJ_COORD (*fwdobs)(PJ_COORD, PJ *);
-    PJ_COORD (*invobs)(PJ_COORD, PJ *);
 
     void (*spc)(LP, PJ *, struct FACTORS *);
 

--- a/src/projects.h
+++ b/src/projects.h
@@ -173,10 +173,7 @@ typedef struct { double u, v, w; }     UVW;
 
 /* Forward declarations and typedefs for stuff needed inside the PJ object */
 struct PJconsts;
-struct PJ_OBS;
-#ifndef PROJ_INTERNAL_H
-typedef struct PJ_OBS PJ_OBS;
-#endif
+
 union  PJ_COORD;
 struct geod_geodesic;
 struct pj_opaque;
@@ -254,10 +251,11 @@ struct PJconsts {
     LP  (*inv)(XY,    PJ *);
     XYZ (*fwd3d)(LPZ, PJ *);
     LPZ (*inv3d)(XYZ, PJ *);
-    PJ_OBS (*fwdobs)(PJ_OBS, PJ *);
-    PJ_OBS (*invobs)(PJ_OBS, PJ *);
-    PJ_COORD (*fwdcoord)(PJ_COORD, PJ *);
-    PJ_COORD (*invcoord)(PJ_COORD, PJ *);
+    PJ_COORD (*fwd4d)(PJ_COORD, PJ *);
+    PJ_COORD (*inv4d)(PJ_COORD, PJ *);
+
+    PJ_COORD (*fwdobs)(PJ_COORD, PJ *);
+    PJ_COORD (*invobs)(PJ_COORD, PJ *);
 
     void (*spc)(LP, PJ *, struct FACTORS *);
 


### PR DESCRIPTION
PJ_OBS eliminated, API adjusted to reflect that we now have only one 4D data type, so we do not have to decorate API calls with "_obs" and "_coord"

Fixes #627 and simplifies a lot of stuff.