### PR TITLE
Change the initialization type of the some operations

### DIFF
--- a/src/PJ_axisswap.c
+++ b/src/PJ_axisswap.c
@@ -156,7 +156,7 @@ static PJ_COORD reverse_4d(PJ_COORD coo, PJ *P) {
 
 
 /***********************************************************************/
-PJ *PROJECTION(axisswap) {
+PJ *CONVERSION(axisswap,0) {
 /***********************************************************************/
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
     char *order, *s;

--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -42,7 +42,7 @@
 
 #define PJ_LIB__
 #include "proj_internal.h"
-#include <projects.h>
+#include "projects.h"
 #include <assert.h>
 #include <stddef.h>
 #include <math.h>
@@ -208,7 +208,7 @@ static LP cart_reverse (XY xy, PJ *P) {
 
 
 /*********************************************************************/
-PJ *PROJECTION(cart) {
+PJ *CONVERSION(cart,1) {
 /*********************************************************************/
     P->fwd3d  =  cartesian;
     P->inv3d  =  geodetic;

--- a/src/PJ_deformation.c
+++ b/src/PJ_deformation.c
@@ -222,7 +222,7 @@ static void *destructor(PJ *P, int errlev) {
 }
 
 
-PJ *PROJECTION(deformation) {
+PJ *TRANSFORMATION(deformation,1) {
     struct pj_opaque *Q = pj_calloc (1, sizeof (struct pj_opaque));
     if (0==Q)
         return pj_default_destructor(P, ENOMEM);

--- a/src/PJ_hgridshift.c
+++ b/src/PJ_hgridshift.c
@@ -45,7 +45,7 @@ static PJ_COORD reverse_4d (PJ_COORD obs, PJ *P) {
 
 
 
-PJ *PROJECTION(hgridshift) {
+PJ *TRANSFORMATION(hgridshift,0) {
 
     P->fwd4d  = forward_4d;
     P->inv4d  = reverse_4d;

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -268,7 +268,7 @@ static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
 }
 
 
-PJ *PROJECTION(molodensky) {
+PJ *TRANSFORMATION(molodensky,1) {
     struct pj_opaque_molodensky *Q = pj_calloc(1, sizeof(struct pj_opaque_molodensky));
     if (0==Q)
         return pj_default_destructor(P, ENOMEM);

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -306,7 +306,7 @@ static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
 
 
 /***********************************************************************/
-PJ *PROJECTION(unitconvert) {
+PJ *CONVERSION(unitconvert,0) {
 /***********************************************************************/
     struct pj_opaque_unitconvert *Q = pj_calloc (1, sizeof (struct pj_opaque_unitconvert));
     char *s, *name;

--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -46,7 +46,7 @@ static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
 }
 
 
-PJ *PROJECTION(vgridshift) {
+PJ *TRANSFORMATION(vgridshift,0) {
 
    if (!pj_param(P->ctx, P->params, "tgrids").i) {
         proj_log_error(P, "vgridshift: +grids parameter missing.");


### PR DESCRIPTION
Recently the ability to define operations as either `PROJECTION`'s, `CONVERSION`'s or `TRANSFORMATIONS`' s was introduced to the code base. This PR changes operations that are not projections to it's actual type.