### PR TITLE
Make proj_roundtrip do a real TrLib style Poder dual autochecking dance.

### DIFF
--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -318,8 +318,8 @@ int pj_cart_selftest (void) {
     b = proj_trans (P, PJ_FWD, a);
 
     /* Check roundtrip precision for 10000 iterations each way */
-    dist = proj_roundtrip (P, PJ_FWD, 10000, a);
-    dist = proj_roundtrip (P, PJ_INV, 10000, b);
+    dist = proj_roundtrip (P, PJ_FWD, 10000, &a);
+    dist = proj_roundtrip (P, PJ_INV, 10000, &b);
     if (dist > 2e-9)
         return 7;
 
@@ -331,7 +331,7 @@ int pj_cart_selftest (void) {
     a.lpz.z   = 100;
 
     /* Forward projection: Ellipsoidal-to-3D-Cartesian */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    dist = proj_roundtrip (P, PJ_FWD, 1, &a);
     if (dist > 1e-12)
         return 8;
 
@@ -342,7 +342,7 @@ int pj_cart_selftest (void) {
     a.lpz.z   = 100;
 
     /* Forward projection: Ellipsoidal-to-3D-Cartesian */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    dist = proj_roundtrip (P, PJ_FWD, 1, &a);
     if (dist > 1e-12)
         return 9;
 

--- a/src/PJ_hgridshift.c
+++ b/src/PJ_hgridshift.c
@@ -105,8 +105,9 @@ int pj_hgridshift_selftest (void) {
     a = proj_coord (0,0,0,0);
     a.lpz.lam = PJ_TORAD(173);
     a.lpz.phi = PJ_TORAD(-45);
+    b = a;
 
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    dist = proj_roundtrip (P, PJ_FWD, 1, &b);
     if (dist > 0.00000001) {
         printf("dist: %f\n",dist);
         return 1;

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -531,7 +531,7 @@ int pj_horner_selftest (void) {
     a.uv.u =  878354.8539;
 
     /* Check roundtrip precision for 1 iteration each way, starting in forward direction */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    dist = proj_roundtrip (P, PJ_FWD, 1, &a);
     if (dist > 0.01)
         return 1;
 
@@ -560,7 +560,7 @@ int pj_horner_selftest (void) {
         return 3;
 
     /* Check roundtrip precision for 1 iteration each way */
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    dist = proj_roundtrip (P, PJ_FWD, 1, &a);
     if (dist > 0.01)
         return 4;
 

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -318,7 +318,7 @@ int pj_molodensky_selftest (void) {return 0;}
 #else
 int pj_molodensky_selftest (void) {
 
-    PJ_COORD in, res, exp;
+    PJ_COORD in, c, res, xp;
     PJ *P;
 
     /* Test the abridged Molodensky first. Example from appendix 3 of Deakin (2004). */
@@ -334,24 +334,25 @@ int pj_molodensky_selftest (void) {
     in.lpz.phi = PJ_TORAD(-37.8);
     in.lpz.z   = 50.0;
 
-    exp.lpz.lam = PJ_TORAD(144.968);
-    exp.lpz.phi = PJ_TORAD(-37.79848);
-    exp.lpz.z   = 46.378;
+    xp.lpz.lam = PJ_TORAD(144.968);
+    xp.lpz.phi = PJ_TORAD(-37.79848);
+    xp.lpz.z   = 46.378;
 
     res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, xp.lp) > 2 ) { /* we don't expect much accuracy here... */
         proj_destroy(P);
         return 11;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
+    c = in;
+    if (proj_roundtrip(P, PJ_FWD, 100, &c) > 1) {
         proj_destroy(P);
         return 12;
     }
 
-    if (res.lpz.z - exp.lpz.z > 1e-3) {
+    if (res.lpz.z - xp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 13;
     }
@@ -369,18 +370,19 @@ int pj_molodensky_selftest (void) {
 
     res = proj_trans(P, PJ_FWD, in);
 
-    if (proj_lp_dist(P, res.lp, exp.lp) > 2 ) { /* we don't expect much accurecy here... */
+    if (proj_lp_dist(P, res.lp, xp.lp) > 2 ) { /* we don't expect much accurecy here... */
         proj_destroy(P);
         return 21;
     }
 
     /* let's try a roundtrip */
-    if (proj_roundtrip(P, PJ_FWD, 100, in) > 1) {
+    c = in;
+    if (proj_roundtrip(P, PJ_FWD, 100, &c) > 1) {
         proj_destroy(P);
         return 22;
     }
 
-    if (res.lpz.z - exp.lpz.z > 1e-3) {
+    if (res.lpz.z - xp.lpz.z > 1e-3) {
         proj_destroy(P);
         return 23;
     }

--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -109,7 +109,8 @@ int pj_vgridshift_selftest (void) {
     a.lpz.lam = PJ_TORAD(12.5);
     a.lpz.phi = PJ_TORAD(55.5);
 
-    dist = proj_roundtrip (P, PJ_FWD, 1, a);
+    expect = a;
+    dist = proj_roundtrip (P, PJ_FWD, 1, &expect);
     if (dist > 0.00000001)
         return 1;
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -488,11 +488,13 @@ static int roundtrip (char *args) {
     int ntrips;
     double d, r, ans;
     char *endp;
+    PJ_COORD c;
     ans = proj_strtod (args, &endp);
     ntrips = (int) (endp==args? 100: fabs(ans));
     d = strtod_scaled (endp, 1);
     d = d==HUGE_VAL?  T.tolerance:  d;
-    r = proj_roundtrip (T.P, PJ_FWD, ntrips, T.a);
+    c = T.a;
+    r = proj_roundtrip (T.P, PJ_FWD, ntrips, &c);
     if (r > d) {
         if (T.verbosity > -1) {
             if (0==T.op_ko && T.verbosity < 2)

--- a/src/proj.h
+++ b/src/proj.h
@@ -392,7 +392,7 @@ int proj_trans_array (PJ *P, PJ_DIRECTION direction, size_t n, PJ_COORD *coord);
 PJ_COORD proj_coord (double x, double y, double z, double t);
 
 /* Measure internal consistency - in forward or inverse direction */
-double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD coo);
+double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coord);
 
 /* Geodesic distance between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, LP a, LP b);


### PR DESCRIPTION
The backward-forward combo implemented in `proj_roundtrip` originates from a 1980s idea by Knud Poder, which he implemented in an enigmatic, yet elegant way in [TrLib](https://bitbucket.org/KMS/trlib).

Until now, the PROJ.4 implementation has provided means for evaluating algorithmic stability only: It returns a roundtrip deviation, without returning the result of the transformation.

This PR remedies that, by changing the `PJ_COORD`argument to `PJ_COORD *`, and writing the first half-step result back to the input argument.

Hence, `proj_roundtrip` now provides a transformation result, with an associated stability check.

