### PR TITLE
Use HAVE_C99_MATH instead of _WIN32_ and __ANSI__

### DIFF
--- a/src/projects.h
+++ b/src/projects.h
@@ -84,7 +84,7 @@ extern "C" {
 #endif
 
 /* prototype hypot for systems where absent */
-#if !defined(_WIN32) || !defined(__ANSI__)
+#if !(defined(HAVE_C99_MATH) && HAVE_C99_MATH)
 extern double hypot(double, double);
 #endif
 


### PR DESCRIPTION
HAVE_C99_MATH was recently added to the build system as a safer way to
determine if non-ansi math functions are available on the current
system. Previously different combinations of tests including \_WIN32_ and
__ANSI\_\_ have been in use, but cases where that strategy has failed is
known. Hence this change to a hopefully more robust check of math
function availability.

See also #547 and #555 