### PR TITLE
Ensure C89 compliance and enable more warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,16 @@ cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
 project(PROJ4 C)
 set(PROJECT_INTERN_NAME PROJ)
 
+# Set warnings
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  set(CMAKE_C_FLAGS "/WX ${CMAKE_C_FLAGS}")
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror ${CMAKE_C_FLAGS}")
+elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror \
+    -Wc99-extensions -Wc11-extensions ${CMAKE_C_FLAGS}")
+endif()
+
 #################################################################################
 # PROJ4 CMake modules
 #################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,14 @@ set(PROJECT_INTERN_NAME PROJ)
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set(CMAKE_C_FLAGS "/WX ${CMAKE_C_FLAGS}")
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror \
+    -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat \
+    -Werror=format-security -Wshadow ${CMAKE_C_FLAGS}")
 elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror \
-    -Wc99-extensions -Wc11-extensions ${CMAKE_C_FLAGS}")
+    -Wc99-extensions -Wc11-extensions -Wunused-parameter -Wmissing-prototypes \
+    -Wmissing-declarations -Wformat -Werror=format-security -Wshadow \
+    -Wfloat-conversion ${CMAKE_C_FLAGS}")
 endif()
 
 #################################################################################

--- a/src/PJ_aeqd.c
+++ b/src/PJ_aeqd.c
@@ -35,7 +35,7 @@ enum Mode {
     N_POLE = 0,
     S_POLE = 1,
     EQUIT  = 2,
-    OBLIQ  = 3,
+    OBLIQ  = 3
 };
 
 struct pj_opaque {

--- a/src/PJ_airy.c
+++ b/src/PJ_airy.c
@@ -38,7 +38,7 @@ enum Mode {
     N_POLE = 0,
     S_POLE = 1,
     EQUIT  = 2,
-    OBLIQ  = 3,
+    OBLIQ  = 3
 };
 
 struct pj_opaque {


### PR DESCRIPTION
According to the contributing guidelines, the library is developed strictly in ANSI C 89. However, this is not enforced.

Additionally, we enable more warnings: apart from `-Wall` and `-Wextra` we enable a warning that makes sure all enumeration values are covered in a switch statement.

When compiling with Clang, we also turn on the warnings `-Wc99-extensions` and `-Wc11-extensions`.