### PR TITLE
Adjust adjlon to use canonical M_PI defines

### DIFF
--- a/src/adjlon.c
+++ b/src/adjlon.c
@@ -1,15 +1,20 @@
 /* reduce argument to range +/- PI */
 #include <math.h>
-#include <projects.h>
-
-#define SPI     3.14159265359
-#define TWOPI   6.2831853071795864769
-#define ONEPI   3.14159265358979323846
+#include "projects.h"
 
 double adjlon (double lon) {
-    if (fabs(lon) <= SPI) return( lon );
-    lon += ONEPI;  /* adjust to 0..2pi rad */
-    lon -= TWOPI * floor(lon / TWOPI); /* remove integral # of 'revolutions'*/
-    lon -= ONEPI;  /* adjust back to -pi..pi rad */
-    return( lon );
+    /* Let lon slightly overshoot, to avoid spurious sign switching at the date line */
+    if (fabs (lon) < M_PI + 1e-12)
+        return lon;
+
+    /* adjust to 0..2pi range */
+    lon += M_PI;
+
+    /* remove integral # of 'revolutions'*/
+    lon -= M_TWOPI * floor(lon / M_TWOPI);
+
+    /* adjust back to -pi..pi range */
+    lon -= M_PI;
+
+    return lon;
 }


### PR DESCRIPTION
A year or so ago, @micahcochran put quite some effort into rationalizing the PI usage in PROJ.4, by ensuring that a number of useful M_PI related constants were defined in `projects.h`.

But apparently adjlon.c was left behind still using its own set of definitions - perhaps because it bends the values slightly, to avoid unwanted sign switching near the date line.

I have now reimplemented the "bending trick" to use the rationalized M_PI constants only.