### PR TITLE
Declare non-local variables as const where possible

### DIFF
--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -64,7 +64,7 @@ typedef struct {
     enum Region {north, south, equatorial} region;
 } CapMap;
 
-double rot[7][2][2] = ROT;
+static const double rot[7][2][2] = ROT;
 
 /**
  * Returns the sign of the double.
@@ -310,7 +310,7 @@ static LP healpix_sphere_inverse(XY xy) {
  * Return the vector sum a + b, where a and b are 2-dimensional vectors.
  * @param ret holds a + b.
  **/
-static void vector_add(double a[2], double b[2], double *ret) {
+static void vector_add(const double a[2], const double b[2], double *ret) {
     int i;
     for(i = 0; i < 2; i++) {
         ret[i] = a[i] + b[i];
@@ -322,7 +322,7 @@ static void vector_add(double a[2], double b[2], double *ret) {
  * Return the vector difference a - b, where a and b are 2-dimensional vectors.
  * @param ret holds a - b.
  **/
-static void vector_sub(double a[2], double b[2], double*ret) {
+static void vector_sub(const double a[2], const double b[2], double*ret) {
     int i;
     for(i = 0; i < 2; i++) {
         ret[i] = a[i] - b[i];
@@ -335,7 +335,7 @@ static void vector_sub(double a[2], double b[2], double*ret) {
  * b is a 2 x 1 matrix.
  * @param ret holds a*b.
  **/
-static void dot_product(double a[2][2], double b[2], double *ret) {
+static void dot_product(const double a[2][2], const double b[2], double *ret) {
     int i, j;
     int length = 2;
     for(i = 0; i < length; i++) {
@@ -453,7 +453,7 @@ static XY combine_caps(double x, double y, int north_square, int south_square,
     double vector[2];
     double v_min_c[2];
     double ret_dot[2];
-    double (*tmpRot)[2];
+    const double (*tmpRot)[2];
     int pole = 0;
 
     CapMap capmap = get_cap(x, y, north_square, south_square, inverse);

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -159,7 +159,7 @@ struct snyder_constants {
 };
 
 /* TODO put these in radians to avoid a later conversion */
-ISEA_STATIC
+ISEA_STATIC const
 struct snyder_constants constants[] = {
     {23.80018260, 62.15458023, 60.0, 3.75, 1.033, 0.968, 5.09, 1.195, 1.0},
     {20.07675127, 55.69063953, 54.0, 2.65, 1.030, 0.983, 3.59, 1.141, 1.027},
@@ -217,7 +217,7 @@ static int      tri_v1[] = {0, 0, 0, 0, 0, 0, 6, 7, 8, 9, 10, 2, 3, 4, 5, 1, 11,
 #define F_RAD 0.18871053072122403508
 
 /* triangle Centers */
-struct isea_geo icostriangles[] = {
+static const struct isea_geo icostriangles[] = {
     {0.0, 0.0},
     {-DEG144, E_RAD},
     {-DEG72, E_RAD},

--- a/src/PJ_mod_ster.c
+++ b/src/PJ_mod_ster.c
@@ -12,7 +12,7 @@ PROJ_HEAD(gs50, "Mod. Stereographic of 50 U.S.") "\n\tAzi(mod)";
 #define EPSLN 1e-12
 
 struct pj_opaque {
-    COMPLEX *zcoeff; \
+    const COMPLEX *zcoeff; \
     double  cchio, schio; \
     int     n;
 };
@@ -120,7 +120,7 @@ static PJ *setup(PJ *P) { /* general initialization */
 
 /* Miller Oblated Stereographic */
 PJ *PROJECTION(mil_os) {
-    static COMPLEX AB[] = {
+    static const COMPLEX AB[] = {
         {0.924500, 0.},
         {0.,       0.},
         {0.019430, 0.}
@@ -143,7 +143,7 @@ PJ *PROJECTION(mil_os) {
 
 /* Lee Oblated Stereographic */
 PJ *PROJECTION(lee_os) {
-    static COMPLEX AB[] = {
+    static const COMPLEX AB[] = {
         {0.721316,    0.},
         {0.,          0.},
         {-0.0088162, -0.00617325}
@@ -165,7 +165,7 @@ PJ *PROJECTION(lee_os) {
 
 
 PJ *PROJECTION(gs48) {
-    static COMPLEX /* 48 United States */
+    static const COMPLEX /* 48 United States */
     AB[] = {
         {0.98879,   0.},
         {0.,        0.},
@@ -191,7 +191,7 @@ PJ *PROJECTION(gs48) {
 
 
 PJ *PROJECTION(alsk) {
-    static COMPLEX  ABe[] = { /* Alaska ellipsoid */
+    static const COMPLEX  ABe[] = { /* Alaska ellipsoid */
         { .9945303, 0.},
         { .0052083, -.0027404},
         { .0072721,  .0048181},
@@ -200,7 +200,7 @@ PJ *PROJECTION(alsk) {
         { .3582802, -.2884586},
     };
 
-    static COMPLEX ABs[] = { /* Alaska sphere */
+    static const COMPLEX ABs[] = { /* Alaska sphere */
         { .9972523, 0.},
         { .0052513, -.0041175},
         { .0074606,  .0048125},
@@ -231,7 +231,7 @@ PJ *PROJECTION(alsk) {
 
 
 PJ *PROJECTION(gs50) {
-    static COMPLEX  ABe[] = { /* GS50 ellipsoid */
+    static const COMPLEX  ABe[] = { /* GS50 ellipsoid */
         { .9827497, 0.},
         { .0210669,  .0053804},
         {-.1031415, -.0571664},
@@ -244,7 +244,7 @@ PJ *PROJECTION(gs50) {
         {-.0210072,  .0834037}
     };
 
-    static COMPLEX ABs[] = { /* GS50 sphere */
+    static const COMPLEX ABs[] = { /* GS50 sphere */
         { .9842990, 0.},
         { .0211642,  .0037608},
         {-.1036018, -.0575102},

--- a/src/PJ_nzmg.c
+++ b/src/PJ_nzmg.c
@@ -34,7 +34,7 @@ PROJ_HEAD(nzmg, "New Zealand Map Grid") "\n\tfixed Earth";
 #define SEC5_TO_RAD 0.4848136811095359935899141023
 #define RAD_TO_SEC5 2.062648062470963551564733573
 
-static COMPLEX bf[] = {
+static const COMPLEX bf[] = {
     { .7557853228, 0.0},
     { .249204646,  0.003371507},
     {-.001541739,  0.041058560},
@@ -42,12 +42,12 @@ static COMPLEX bf[] = {
     {-.26623489,  -0.36249218},
     {-.6870983,   -1.1651967} };
 
-static double tphi[] = { 1.5627014243, .5185406398, -.03333098,
-                         -.1052906,   -.0368594,     .007317,
-                          .01220,      .00394,      -.0013 };
+static const double tphi[] = { 1.5627014243, .5185406398, -.03333098,
+                               -.1052906,   -.0368594,     .007317,
+                                .01220,      .00394,      -.0013 };
 
-static double tpsi[] = { .6399175073, -.1358797613, .063294409, -.02526853, .0117879,
-                        -.0055161,     .0026906,   -.001333,     .00067,   -.00034 };
+static const double tpsi[] = { .6399175073, -.1358797613, .063294409, -.02526853, .0117879,
+                              -.0055161,     .0026906,   -.001333,     .00067,   -.00034 };
 
 #define Nbf 5
 #define Ntpsi 9
@@ -57,7 +57,7 @@ static double tpsi[] = { .6399175073, -.1358797613, .063294409, -.02526853, .011
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     XY xy = {0.0,0.0};
     COMPLEX p;
-    double *C;
+    const double *C;
     int i;
 
     lp.phi = (lp.phi - P->phi0) * RAD_TO_SEC5;
@@ -77,7 +77,8 @@ static LP e_inverse (XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     LP lp = {0.0,0.0};
     int nn, i;
     COMPLEX p, f, fp, dp;
-    double den, *C;
+    double den;
+    const double *C;
 
     p.r = xy.y;
     p.i = xy.x;

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -273,7 +273,7 @@ static size_t argc_params (paralist *params) {
 }
 
 /* Sentinel for argument list */
-static char argv_sentinel[] = "step";
+static char *argv_sentinel = "step";
 
 /* turn paralist into argc/argv style argument list */
 static char **argv_params (paralist *params, size_t argc) {
@@ -363,7 +363,7 @@ PJ *OPERATION(pipeline,0) {
 
     /* Do some syntactical sanity checking */
     for (i = 0;  i < argc;  i++) {
-        if (0==strcmp ("step", argv[i])) {
+        if (0==strcmp (argv_sentinel, argv[i])) {
             if (-1==i_pipeline) {
                 proj_log_error (P, "Pipeline: +step before +proj=pipeline");
                 return destructor (P, PJD_ERR_MALFORMED_PIPELINE);

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -256,7 +256,7 @@ static double mjd_to_yyyymmdd(double mjd) {
 }
 
 
-struct TIME_UNITS time_units[] = {
+static const struct TIME_UNITS time_units[] = {
     {"mjd",         mjd_to_mjd,         mjd_to_mjd,         "Modified julian date"},
     {"decimalyear", decimalyear_to_mjd, mjd_to_decimalyear, "Decimal year"},
     {"gps_week",    gps_week_to_mjd,    mjd_to_gps_week,    "GPS Week"},

--- a/src/cs2cs.c
+++ b/src/cs2cs.c
@@ -26,6 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
+#include "proj.h"
 #include "projects.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -206,11 +207,11 @@ int main(int argc, char **argv)
               case 'l': /* list projections, ellipses or units */
                 if (!arg[1] || arg[1] == 'p' || arg[1] == 'P') {
                     /* list projections */
-                    struct PJ_LIST *lp;
+                    const struct PJ_LIST *lp;
                     int do_long = arg[1] == 'P', c;
                     char *str;
 
-                    for (lp = pj_get_list_ref() ; lp->id ; ++lp) {
+                    for (lp = proj_list_operations() ; lp->id ; ++lp) {
                         (void)printf("%s : ", lp->id);
                         if (do_long)  /* possibly multiline description */
                             (void)puts(*lp->descr);
@@ -222,28 +223,28 @@ int main(int argc, char **argv)
                         }
                     }
                 } else if (arg[1] == '=') { /* list projection 'descr' */
-                    struct PJ_LIST *lp;
+                    const struct PJ_LIST *lp;
 
                     arg += 2;
-                    for (lp = pj_get_list_ref() ; lp->id ; ++lp)
+                    for (lp = proj_list_operations() ; lp->id ; ++lp)
                         if (!strcmp(lp->id, arg)) {
                             (void)printf("%9s : %s\n", lp->id, *lp->descr);
                             break;
                         }
                 } else if (arg[1] == 'e') { /* list ellipses */
-                    struct PJ_ELLPS *le;
+                    const struct PJ_ELLPS *le;
 
-                    for (le = pj_get_ellps_ref(); le->id ; ++le)
+                    for (le = proj_list_ellps(); le->id ; ++le)
                         (void)printf("%9s %-16s %-16s %s\n",
                                      le->id, le->major, le->ell, le->name);
                 } else if (arg[1] == 'u') { /* list units */
-                    struct PJ_UNITS *lu;
+                    const struct PJ_UNITS *lu;
 
-                    for (lu = pj_get_units_ref(); lu->id ; ++lu)
+                    for (lu = proj_list_units(); lu->id ; ++lu)
                         (void)printf("%12s %-20s %s\n",
                                      lu->id, lu->to_meter, lu->name);
                 } else if (arg[1] == 'd') { /* list datums */
-                    struct PJ_DATUMS *ld;
+                    const struct PJ_DATUMS *ld;
 
                     printf("__datum_id__ __ellipse___ __definition/comments______________________________\n" );
                     for (ld = pj_get_datums_ref(); ld->id ; ++ld)
@@ -254,9 +255,9 @@ int main(int argc, char **argv)
                             printf( "%25s %s\n", " ", ld->comments );
                     }
                 } else if( arg[1] == 'm') { /* list prime meridians */
-                    struct PJ_PRIME_MERIDIANS *lpm;
+                    const struct PJ_PRIME_MERIDIANS *lpm;
 
-                    for (lpm = pj_get_prime_meridians_ref(); lpm->id ; ++lpm)
+                    for (lpm = proj_list_prime_meridians(); lpm->id ; ++lpm)
                         (void)printf("%12s %-30s\n",
                                      lpm->id, lpm->defn);
                 } else

--- a/src/emess.c
+++ b/src/emess.c
@@ -18,7 +18,7 @@
 #define EMESS_ROUTINE
 #include "emess.h"
 	void
-emess(int code, char *fmt, ...) {
+emess(int code, const char *fmt, ...) {
 	va_list args;
 
 	va_start(args, fmt);

--- a/src/emess.h
+++ b/src/emess.h
@@ -24,6 +24,6 @@ extern struct EMESS emess_dat;
 
 #endif /* use type */
 
-void emess(int, char *, ...);
+void emess(int, const char *, ...);
 
 #endif /* end EMESS_H */

--- a/src/geod.c
+++ b/src/geod.c
@@ -1,4 +1,6 @@
 /* <<<< Geodesic filter program >>>> */
+
+#include "proj.h"
 # include "projects.h"
 # include "geod_interface.h"
 # include "emess.h"
@@ -175,15 +177,15 @@ noargument:		   emess(1,"missing argument for -%c",*arg);
 				continue;
 			case 'l':
 				if (!arg[1] || arg[1] == 'e') { /* list of ellipsoids */
-                                    struct PJ_ELLPS *le;
+                                    const struct PJ_ELLPS *le;
                                     
-                                    for (le=pj_get_ellps_ref(); le->id ; ++le)
+                                    for (le=proj_list_ellps(); le->id ; ++le)
                                         (void)printf("%9s %-16s %-16s %s\n",
                                                      le->id, le->major, le->ell, le->name);
 				} else if (arg[1] == 'u') { /* list of units */
-                                    struct PJ_UNITS *lu;
+                                    const struct PJ_UNITS *lu;
                                     
-                                    for (lu = pj_get_units_ref();lu->id ; ++lu)
+                                    for (lu = proj_list_units();lu->id ; ++lu)
                                         (void)printf("%12s %-20s %s\n",
                                                      lu->id, lu->to_meter, lu->name);
 				} else

--- a/src/geod_set.c
+++ b/src/geod_set.c
@@ -2,6 +2,7 @@
 #define _IN_GEOD_SET
 
 #include <string.h>
+#include "proj.h"
 #include "projects.h"
 #include "geod_interface.h"
 #include "emess.h"
@@ -29,7 +30,7 @@ geod_set(int argc, char **argv) {
 	/* set units */
 	if ((name = pj_param(NULL,start, "sunits").s) != NULL) {
 		char *s;
-                struct PJ_UNITS *unit_list = pj_get_units_ref();
+                const struct PJ_UNITS *unit_list = proj_list_units();
 		for (i = 0; (s = unit_list[i].id) && strcmp(name, s) ; ++i) ;
 		if (!s)
 			emess(1,"%s unknown unit conversion id", name);

--- a/src/geodtest.c
+++ b/src/geodtest.c
@@ -20,7 +20,7 @@
 #  pragma warning (disable: 4706)
 #endif
 
-double wgs84_a = 6378137, wgs84_f = 1/298.257223563; /* WGS84 */
+static const double wgs84_a = 6378137, wgs84_f = 1/298.257223563; /* WGS84 */
 
 static int assertEquals(double x, double y, double d) {
   if (fabs(x - y) <= d)
@@ -29,8 +29,8 @@ static int assertEquals(double x, double y, double d) {
   return 1;
 }
 
-const int ncases = 20;
-double testcases[20][12] = {
+static const int ncases = 20;
+static const double testcases[20][12] = {
   {35.60777, -139.44815, 111.098748429560326,
    -11.17491, -69.95921, 129.289270889708762,
    8935244.5604818305, 80.50729714281974, 6273170.2055303837,

--- a/src/gie.c
+++ b/src/gie.c
@@ -199,8 +199,6 @@ static const char delim[] = {"--------------------------------------------------
 
 #define CMDLEN 250000
 
-int nfiles = 0;
-
 
 static const char usage[] = {
     "--------------------------------------------------------------------------------\n"
@@ -1316,7 +1314,7 @@ whitespace etc. The block is stored in G->args. Returns 1 on success, 0 otherwis
 
 
 
-char tc32_utm32[] = {
+static const char tc32_utm32[] = {
     " +proj=horner"
     " +ellps=intl"
     " +range=500000"
@@ -1330,7 +1328,7 @@ char tc32_utm32[] = {
 };
 
 
-char sb_utm32[] = {
+static const char sb_utm32[] = {
     " +proj=horner"
     " +ellps=intl"
     " +range=500000"

--- a/src/multistresstest.c
+++ b/src/multistresstest.c
@@ -54,7 +54,7 @@ typedef struct {
     int     skip;
 } TestItem;
 
-TestItem test_list[] = {
+static TestItem test_list[] = {
     {
         "+proj=utm +zone=11 +datum=WGS84",
         "+proj=latlong +datum=WGS84",

--- a/src/nad2bin.c
+++ b/src/nad2bin.c
@@ -13,8 +13,8 @@
 /*      Convert the byte order of the given word(s) in place.           */
 /************************************************************************/
 
-static int  byte_order_test = 1;
-#define IS_LSB	(((unsigned char *) (&byte_order_test))[0] == 1)
+static const int  byte_order_test = 1;
+#define IS_LSB	(((const unsigned char *) (&byte_order_test))[0] == 1)
 
 static void swap_words( void *data_in, int word_size, int word_count )
 

--- a/src/nad_init.c
+++ b/src/nad_init.c
@@ -38,8 +38,8 @@
 /*      Convert the byte order of the given word(s) in place.           */
 /************************************************************************/
 
-static int  byte_order_test = 1;
-#define IS_LSB	(((unsigned char *) (&byte_order_test))[0] == 1)
+static const int  byte_order_test = 1;
+#define IS_LSB	(((const unsigned char *) (&byte_order_test))[0] == 1)
 
 static void swap_words( void *data_in, int word_size, int word_count )
 

--- a/src/pj_datums.c
+++ b/src/pj_datums.c
@@ -25,8 +25,9 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
-#define PJ_DATUMS__
+#include "proj.h"
 
+#define PJ_DATUMS__
 #include <projects.h>
 
 /* 
@@ -35,7 +36,7 @@
  * datum name for the comments if available. 
  */
 
-C_NAMESPACE_VAR struct PJ_DATUMS pj_datums[] = {
+C_NAMESPACE_VAR const struct PJ_DATUMS pj_datums[] = {
 /* id       definition                               ellipse  comments */
 /* --       ----------                               -------  -------- */
 {"WGS84",   "towgs84=0,0,0",                         "WGS84", ""},
@@ -65,12 +66,11 @@ C_NAMESPACE_VAR struct PJ_DATUMS pj_datums[] = {
 };
 
 struct PJ_DATUMS *pj_get_datums_ref()
-
 {
-    return pj_datums;
+    return (struct PJ_DATUMS *)pj_datums;
 }
 
-C_NAMESPACE_VAR struct PJ_PRIME_MERIDIANS pj_prime_meridians[] = {
+C_NAMESPACE_VAR const struct PJ_PRIME_MERIDIANS pj_prime_meridians[] = {
     /* id        definition                         */
     /* --        ----------                         */
     {"greenwich", "0dE"},
@@ -90,8 +90,11 @@ C_NAMESPACE_VAR struct PJ_PRIME_MERIDIANS pj_prime_meridians[] = {
 };
 
 struct PJ_PRIME_MERIDIANS *pj_get_prime_meridians_ref()
+{
+    return (struct PJ_PRIME_MERIDIANS *)pj_prime_meridians;
+}
 
+const PJ_PRIME_MERIDIANS *proj_list_prime_meridians(void)
 {
     return pj_prime_meridians;
 }
-

--- a/src/pj_ell_set.c
+++ b/src/pj_ell_set.c
@@ -14,7 +14,7 @@ static int ellps_spherification (PJ *P);
 
 static paralist *pj_get_param (paralist *list, char *key);
 static char     *pj_param_value (paralist *list);
-static PJ_ELLPS *pj_find_ellps (char *name);
+static const PJ_ELLPS *pj_find_ellps (char *name);
 
 
 /***************************************************************************************/
@@ -125,7 +125,7 @@ int pj_ellipsoid (PJ *P) {
 static int ellps_ellps (PJ *P) {
 /***************************************************************************************/
     PJ B;
-    PJ_ELLPS *ellps;
+    const PJ_ELLPS *ellps;
     paralist *par = 0;
     char *name;
     int err;
@@ -419,7 +419,7 @@ static char *pj_param_value (paralist *list) {
 }
 
 
-static PJ_ELLPS *pj_find_ellps (char *name) {
+static const PJ_ELLPS *pj_find_ellps (char *name) {
     int i;
     char *s;
     if (0==name)

--- a/src/pj_ellps.c
+++ b/src/pj_ellps.c
@@ -1,8 +1,11 @@
 /* definition of standard geoids */
+
+#include "proj.h"
+
 #define PJ_ELLPS__
 #include "projects.h"
 
-C_NAMESPACE_VAR struct PJ_ELLPS
+C_NAMESPACE_VAR const struct PJ_ELLPS
 pj_ellps[] = {
 {"MERIT",	"a=6378137.0",		"rf=298.257",		"MERIT 1983"},
 {"SGS85",	"a=6378136.0",		"rf=298.257",		"Soviet Geodetic System 85"},
@@ -53,7 +56,11 @@ pj_ellps[] = {
 };
 
 struct PJ_ELLPS *pj_get_ellps_ref()
+{
+    return (struct PJ_ELLPS *)pj_ellps;
+}
 
+const PJ_ELLPS *proj_list_ellps(void)
 {
     return pj_ellps;
 }

--- a/src/pj_gauss.c
+++ b/src/pj_gauss.c
@@ -65,7 +65,7 @@ void *pj_gauss_ini(double e, double phi0, double *chi, double *rc) {
 }
 
 LP pj_gauss(projCtx ctx, LP elp, const void *data) {
-    struct GAUSS *en = (struct GAUSS *)data;
+    const struct GAUSS *en = (const struct GAUSS *)data;
     LP slp;
     (void) ctx;
 
@@ -77,7 +77,7 @@ LP pj_gauss(projCtx ctx, LP elp, const void *data) {
 }
 
 LP pj_inv_gauss(projCtx ctx, LP slp, const void *data) {
-    struct GAUSS *en = (struct GAUSS *)data;
+    const struct GAUSS *en = (const struct GAUSS *)data;
     LP elp;
     double num;
     int i;

--- a/src/pj_gc_reader.c
+++ b/src/pj_gc_reader.c
@@ -47,7 +47,7 @@ PJ_GridCatalog *pj_gc_readcatalog( projCtx ctx, const char *catalog_name )
     int entry_max;
     char line[302];
     
-    fid = pj_open_lib( ctx, (char *) catalog_name, "r" );
+    fid = pj_open_lib( ctx, catalog_name, "r" );
     if (fid == NULL) 
         return NULL;
 

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -40,8 +40,8 @@
 /*      Convert the byte order of the given word(s) in place.           */
 /************************************************************************/
 
-static int  byte_order_test = 1;
-#define IS_LSB	(1 == ((unsigned char *) (&byte_order_test))[0])
+static const int  byte_order_test = 1;
+#define IS_LSB	(1 == ((const unsigned char *) (&byte_order_test))[0])
 
 static void swap_words( unsigned char *data, int word_size, int word_count )
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -639,7 +639,7 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
     /* Axis orientation */
     if( (pj_param(ctx, start,"saxis").s) != NULL )
     {
-        static const char *axis_legal = "ewnsud";
+        const char *axis_legal = "ewnsud";
         const char *axis_arg = pj_param(ctx, start,"saxis").s;
         if( strlen(axis_arg) != 3 )
             return pj_default_destructor (PIN, PJD_ERR_AXIS);

--- a/src/pj_list.c
+++ b/src/pj_list.c
@@ -2,6 +2,8 @@
 ** Use local definition of PJ_LIST_H for subset.
 */
 
+#include "proj.h"
+
 #define USE_PJ_LIST_H 1
 #include "projects.h"
 
@@ -18,13 +20,18 @@
 
 /* Generate the null-terminated list of projection functions with associated mnemonics and descriptions */
 #define PROJ_HEAD(id, name) {#id, pj_##id, &pj_s_##id},
-struct PJ_LIST pj_list[] = {
+const struct PJ_LIST pj_list[] = {
 #include "pj_list.h"
 		{0,     0,  0},
 	};
 #undef PROJ_HEAD
 
 
-struct PJ_LIST  *pj_get_list_ref (void) {
+struct PJ_LIST *pj_get_list_ref()
+{
+    return (struct PJ_LIST *)pj_list;
+}
+
+const PJ_OPERATIONS *proj_list_operations(void) {
     return pj_list;
 }

--- a/src/pj_open_lib.c
+++ b/src/pj_open_lib.c
@@ -38,7 +38,7 @@
 static const char *(*pj_finder)(const char *) = NULL;
 static int path_count = 0;
 static char **search_path = NULL;
-static char * proj_lib_name =
+static const char * proj_lib_name =
 #ifdef PROJ_LIB
 PROJ_LIB;
 #else
@@ -93,8 +93,8 @@ void pj_set_searchpath ( int count, const char **path )
 
 /* just a couple of helper functions that lets other functions
    access the otherwise private search path */
-const char **proj_get_searchpath(void) {
-    return (const char **)search_path;
+const char * const *proj_get_searchpath(void) {
+    return (const char * const *)search_path;
 }
 
 int proj_get_path_count(void) {

--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <string.h>
 
-    static char *
+    static const char * const
 pj_err_list[] = {
     "no arguments in initialization list",                             /*  -1 */
     "no options found in 'init' file",                                 /*  -2 */
@@ -91,7 +91,7 @@ char *pj_strerrno(int err) {
     /* PROJ.4 error codes are negative */
     adjusted_err = - err - 1;
     if (adjusted_err < (sizeof(pj_err_list) / sizeof(char *)))
-        return(pj_err_list[adjusted_err]);
+        return (char *)pj_err_list[adjusted_err];
 
     sprintf( note, "invalid projection system error (%d)", (err > -9999)? err: -9999);
     return note;

--- a/src/pj_units.c
+++ b/src/pj_units.c
@@ -1,10 +1,14 @@
 /* definition of standard cartesian units */
+
+#include "proj.h"
+
 #define PJ_UNITS__
 #include <projects.h>
+
 /* Field 2 that contains the multiplier to convert named units to meters
 ** may be expressed by either a simple floating point constant or a
 ** numerator/denomenator values (e.g. 1/1000) */
-C_NAMESPACE_VAR struct PJ_UNITS
+C_NAMESPACE_VAR const struct PJ_UNITS
 pj_units[] = {
     {"km",      "1000.",                "Kilometer",                    1000.0},
     {"m",       "1.",                   "Meter",                        1.0},
@@ -31,7 +35,11 @@ pj_units[] = {
 };
 
 struct PJ_UNITS *pj_get_units_ref()
+{
+    return (struct PJ_UNITS *)pj_units;
+}
 
+const PJ_UNITS *proj_list_units()
 {
     return pj_units;
 }

--- a/src/pj_zpoly1.c
+++ b/src/pj_zpoly1.c
@@ -5,7 +5,7 @@
 **	n should always be >= 1 though no checks are made
 */
 	COMPLEX
-pj_zpoly1(COMPLEX z, COMPLEX *C, int n) {
+pj_zpoly1(COMPLEX z, const COMPLEX *C, int n) {
 	COMPLEX a;
 	double t;
 
@@ -20,7 +20,7 @@ pj_zpoly1(COMPLEX z, COMPLEX *C, int n) {
 }
 /* evaluate complex polynomial and derivative */
 	COMPLEX
-pj_zpolyd1(COMPLEX z, COMPLEX *C, int n, COMPLEX *der) {
+pj_zpolyd1(COMPLEX z, const COMPLEX *C, int n, COMPLEX *der) {
 	COMPLEX a, b;
 	double t;
 	int first = 1;

--- a/src/proj.c
+++ b/src/proj.c
@@ -45,7 +45,9 @@ static int
 
 static char
     *cheby_str,         /* string controlling Chebychev evaluation */
-    *oform = (char *)0, /* output format for x-y or decimal degrees */
+    *oform = (char *)0; /* output format for x-y or decimal degrees */
+
+static const char
     *oterr = "*\t*",    /* output line for unprojectable input */
     *usage = "%s\nusage: %s [ -beEfiIlormsStTvVwW [args] ] [ +opts[=arg] ] [ files ]\n";
 
@@ -356,11 +358,11 @@ int main(int argc, char **argv) {
               case 'l': /* list projections, ellipses or units */
                 if (!arg[1] || arg[1] == 'p' || arg[1] == 'P') {
                     /* list projections */
-                    struct PJ_LIST *lp;
+                    const struct PJ_LIST *lp;
                     int do_long = arg[1] == 'P', c;
                     char *str;
 
-                    for (lp = pj_get_list_ref() ; lp->id ; ++lp) {
+                    for (lp = proj_list_operations() ; lp->id ; ++lp) {
                         if( strcmp(lp->id,"latlong") == 0
                             || strcmp(lp->id,"longlat") == 0
                             || strcmp(lp->id,"geocent") == 0 )
@@ -377,28 +379,28 @@ int main(int argc, char **argv) {
                         }
                     }
                 } else if (arg[1] == '=') { /* list projection 'descr' */
-                    struct PJ_LIST *lp;
+                    const struct PJ_LIST *lp;
 
                     arg += 2;
-                    for (lp = pj_get_list_ref(); lp->id ; ++lp)
+                    for (lp = proj_list_operations(); lp->id ; ++lp)
                         if (!strcmp(lp->id, arg)) {
                             (void)printf("%9s : %s\n", lp->id, *lp->descr);
                             break;
                         }
                 } else if (arg[1] == 'e') { /* list ellipses */
-                    struct PJ_ELLPS *le;
+                    const struct PJ_ELLPS *le;
 
-                    for (le = pj_get_ellps_ref(); le->id ; ++le)
+                    for (le = proj_list_ellps(); le->id ; ++le)
                         (void)printf("%9s %-16s %-16s %s\n",
                                      le->id, le->major, le->ell, le->name);
                 } else if (arg[1] == 'u') { /* list units */
-                    struct PJ_UNITS *lu;
+                    const struct PJ_UNITS *lu;
 
-                    for (lu = pj_get_units_ref(); lu->id ; ++lu)
+                    for (lu = proj_list_units(); lu->id ; ++lu)
                         (void)printf("%12s %-20s %s\n",
                                      lu->id, lu->to_meter, lu->name);
                 } else if (arg[1] == 'd') { /* list datums */
-                    struct PJ_DATUMS *ld;
+                    const struct PJ_DATUMS *ld;
 
                     printf("__datum_id__ __ellipse___ __definition/comments______________________________\n" );
                     for (ld = pj_get_datums_ref(); ld->id ; ++ld)

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -597,7 +597,7 @@ PJ_INFO proj_info(void) {
 
 ******************************************************************************/
     PJ_INFO info;
-    const char **paths;
+    const char * const *paths;
     char *tmpstr;
     int i, n;
     size_t len = 0;
@@ -845,22 +845,5 @@ PJ_FACTORS proj_factors(PJ *P, LP lp) {
     factors.tissot_semiminor  =  f.b;
 
     return factors;
-}
-
-
-const PJ_ELLPS *proj_list_ellps(void) {
-    return pj_get_ellps_ref();
-}
-
-const PJ_UNITS *proj_list_units(void) {
-    return pj_get_units_ref();
-}
-
-const PJ_OPERATIONS *proj_list_operations(void) {
-    return pj_get_list_ref();
-}
-
-const PJ_PRIME_MERIDIANS *proj_list_prime_meridians(void) {
-    return pj_get_prime_meridians_ref();
 }
 

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -119,7 +119,7 @@ char  *pj_make_args (size_t argc, char **argv);
 /* Lowest level: Minimum support for fileapi */
 void proj_fileapi_set (PJ *P, void *fileapi);
 
-const char **proj_get_searchpath(void);
+const char * const *proj_get_searchpath(void);
 int    proj_get_path_count(void);
 
 size_t pj_strlcpy(char *dst, const char *src, size_t siz);

--- a/src/proj_mdist.c
+++ b/src/proj_mdist.c
@@ -88,7 +88,7 @@ proj_mdist_ini(double es) {
 }
 	double
 proj_mdist(double phi, double sphi, double cphi, const void *data) {
-	struct MDIST *b = (struct MDIST *)data;
+	const struct MDIST *b = (const struct MDIST *)data;
 	double sc, sum, sphi2, D;
 	int i;
 
@@ -101,7 +101,7 @@ proj_mdist(double phi, double sphi, double cphi, const void *data) {
 }
 	double
 proj_inv_mdist(projCtx ctx, double dist, const void *data) {
-	struct MDIST *b = (struct MDIST *)data;
+	const struct MDIST *b = (const struct MDIST *)data;
 	double s, t, phi, k;
 	int i;
 

--- a/src/projects.h
+++ b/src/projects.h
@@ -713,8 +713,8 @@ double  pj_qsfn_(double, PJ *);
 double *pj_authset(double);
 double  pj_authlat(double, double *);
 
-COMPLEX pj_zpoly1(COMPLEX, COMPLEX *, int);
-COMPLEX pj_zpolyd1(COMPLEX, COMPLEX *, int, COMPLEX *);
+COMPLEX pj_zpoly1(COMPLEX, const COMPLEX *, int);
+COMPLEX pj_zpolyd1(COMPLEX, const COMPLEX *, int, COMPLEX *);
 
 int pj_deriv(LP, double, const PJ *, struct DERIVS *);
 int pj_factors(LP, const PJ *, double, struct FACTORS *);

--- a/src/test228.c
+++ b/src/test228.c
@@ -17,8 +17,8 @@ int main(int argc, char* argv[])
 #include <assert.h>
 #include <unistd.h>
 
-volatile int run = 0;
-volatile int started = 0;
+static volatile int run = 0;
+static volatile int started = 0;
 
 static void* thread_main(void* unused)
 {


### PR DESCRIPTION
Having non-const variables of static lifetime or even global scope is usually a bad idea. These variables are inherently constants, and this should be enforced.

This required marking some functions as not modifying input parameters and marking some pointers as pointers to const.

One advantage is that the compiler usually puts const static variables in a read-only code segment, so they can't be modified physically. This can be verified with `nm` (on POSIX systems).