### PR TITLE
Let gie use init-file syntax

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -781,7 +781,7 @@ static int dispatch (char *cmnd, char *args) {
     int last_errno = proj_errno_reset (T.P);
 
     if  (0==level%2) {
-        if (0==strcmp (cmnd, "BEGIN"))
+        if (0==strcmp (cmnd, "BEGIN") || 0==strcmp (cmnd, "<begin>"))
            level++;
         return 0;
     }
@@ -807,6 +807,7 @@ static int dispatch (char *cmnd, char *args) {
     if  (0==strcmp (cmnd, "ECHO"))      return  echo      (args);
     if  (0==strcmp (cmnd, "echo"))      return  echo      (args);
     if  (0==strcmp  (cmnd, "END"))      return          finish_previous_operation (args), level++, 0;
+    if  (0==strcmp  (cmnd, "<end>"))    return          finish_previous_operation (args), level++, 0;
     if  ('#'==cmnd[0])                  return  comment   (args);
 
     if (proj_errno(T.P))


### PR DESCRIPTION
Currently one may write `gie` tests in an init-syntax file (e.g. epsg, IGNF) by surrounding them with BEGIN and END.

But since the PROJ.4 init file reader keeps on reading setup material until it reaches a "<", the test material will also end up in the proj init string.

With this PR, we let `gie` use `<begin>` and `<end>` as synonyms for BEGIN and END, hence making the init material automatically end where the test material begins, and facilitates a total integration between system definitions and validation data.