### PR TITLE
Improve API

### DIFF
--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -187,7 +187,7 @@ static LPZ geodetic (XYZ cartesian,  PJ *P) {
 
 /* In effect, 2 cartesian coordinates of a point on the ellipsoid. Rather pointless, but... */
 static XY cart_forward (LP lp, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point;
     point.lp = lp;
     point.lpz.z = 0;
 
@@ -197,7 +197,7 @@ static XY cart_forward (LP lp, PJ *P) {
 
 /* And the other way round. Still rather pointless, but... */
 static LP cart_reverse (XY xy, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point;
     point.xy = xy;
     point.xyz.z = 0;
 

--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -310,7 +310,7 @@ static void build_rot_matrix(PJ *P) {
 static XY helmert_forward (LP lp, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     double x, y, cr, sr;
     point.lp = lp;
 
@@ -330,7 +330,7 @@ static XY helmert_forward (LP lp, PJ *P) {
 static LP helmert_reverse (XY xy, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     double x, y, sr, cr;
     point.xy = xy;
 
@@ -350,7 +350,7 @@ static LP helmert_reverse (XY xy, PJ *P) {
 static XYZ helmert_forward_3d (LPZ lpz, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     double X, Y, Z, scale;
 
     point.lpz = lpz;
@@ -390,7 +390,7 @@ static XYZ helmert_forward_3d (LPZ lpz, PJ *P) {
 static LPZ helmert_reverse_3d (XYZ xyz, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     double X, Y, Z, scale;
 
     point.xyz = xyz;

--- a/src/PJ_hgridshift.c
+++ b/src/PJ_hgridshift.c
@@ -5,7 +5,7 @@
 PROJ_HEAD(hgridshift, "Horizontal grid shift");
 
 static XYZ forward_3d(LPZ lpz, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
 
     if (P->gridlist != NULL) {
@@ -19,7 +19,7 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 
 
 static LPZ reverse_3d(XYZ xyz, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
 
     if (P->gridlist != NULL) {

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -193,7 +193,7 @@ static LPZ calc_abridged_params(LPZ lpz, PJ *P) {
 
 
 static XY forward_2d(LP lp, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
 
     point.lp = lp;
     point.xyz = forward_3d(point.lpz, P);
@@ -203,7 +203,7 @@ static XY forward_2d(LP lp, PJ *P) {
 
 
 static LP reverse_2d(XY xy, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
 
     point.xy = xy;
     point.xyz.z = 0;
@@ -215,7 +215,7 @@ static LP reverse_2d(XY xy, PJ *P) {
 
 static XYZ forward_3d(LPZ lpz, PJ *P) {
     struct pj_opaque_molodensky *Q = (struct pj_opaque_molodensky *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
 
     point.lpz = lpz;
 
@@ -243,7 +243,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
 
 static LPZ reverse_3d(XYZ xyz, PJ *P) {
     struct pj_opaque_molodensky *Q = (struct pj_opaque_molodensky *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     LPZ lpz;
 
     /* calculate parameters depending on the mode we are in */

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -204,7 +204,7 @@ static XY forward_2d(LP lp, PJ *P) {
     Forward unit conversions in the plane
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.lp = lp;
 
     point.xy.x *= pj_units[Q->xy_in_id].factor / pj_units[Q->xy_out_id].factor;
@@ -220,7 +220,7 @@ static LP reverse_2d(XY xy, PJ *P) {
     Reverse unit conversions in the plane
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.xy = xy;
 
     point.xy.x *= pj_units[Q->xy_out_id].factor / pj_units[Q->xy_in_id].factor;
@@ -236,7 +236,7 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
     Forward unit conversions the vertical component
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
 
     /* take care of the horizontal components in the 2D function */
@@ -253,7 +253,7 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
     Reverse unit conversions the vertical component
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
 
     /* take care of the horizontal components in the 2D function */
@@ -271,7 +271,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     Forward conversion of time units
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_COORD out;
+    PJ_COORD out = {{0,0,0,0}};
 
     /* delegate unit conversion of physical dimensions to the 3D function */
     out.xyz = forward_3d(obs.lpz, P);
@@ -291,7 +291,7 @@ static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
     Reverse conversion of time units
 ************************************************************************/
     struct pj_opaque_unitconvert *Q = (struct pj_opaque_unitconvert *) P->opaque;
-    PJ_COORD out;
+    PJ_COORD out = {{0,0,0,0}};
 
     /* delegate unit conversion of physical dimensions to the 3D function */
     out.lpz = reverse_3d(obs.xyz, P);

--- a/src/PJ_vgridshift.c
+++ b/src/PJ_vgridshift.c
@@ -6,7 +6,7 @@ PROJ_HEAD(vgridshift, "Vertical grid shift");
 
 
 static XYZ forward_3d(LPZ lpz, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
 
     if (P->vgridlist_geoid != NULL) {
@@ -20,7 +20,7 @@ static XYZ forward_3d(LPZ lpz, PJ *P) {
 
 
 static LPZ reverse_3d(XYZ xyz, PJ *P) {
-    PJ_TRIPLET point;
+    PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
 
     if (P->vgridlist_geoid != NULL) {
@@ -34,7 +34,7 @@ static LPZ reverse_3d(XYZ xyz, PJ *P) {
 
 
 static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
-    PJ_COORD point;
+    PJ_COORD point = {{0,0,0,0}};
     point.xyz = forward_3d (obs.lpz, P);
     return point;
 }

--- a/src/gie.c
+++ b/src/gie.c
@@ -1040,7 +1040,6 @@ static int pj_cart_selftest (void) {
     PJ_GRID_INFO grid_info;
     PJ_INIT_INFO init_info;
 
-    PJ_DERIVS derivs;
     PJ_FACTORS factors;
 
     const PJ_OPERATIONS *oper_list;
@@ -1335,25 +1334,14 @@ static int pj_cart_selftest (void) {
     a.lp.lam = PJ_TORAD(12);
     a.lp.phi = PJ_TORAD(55);
 
-    derivs = proj_derivatives(P, a.lp);
-    if (proj_errno(P))
-        return 80; /* derivs not created correctly */
-
-    if ( fabs(derivs.x_l - 1.0)     > 1e-5 )   return 81;
-    if ( fabs(derivs.x_p - 0.0)     > 1e-5 )   return 82;
-    if ( fabs(derivs.y_l - 0.0)     > 1e-5 )   return 83;
-    if ( fabs(derivs.y_p - 1.73959) > 1e-5 )   return 84;
-
-
     factors = proj_factors(P, a.lp);
     if (proj_errno(P))
         return 85; /* factors not created correctly */
 
     /* check a few key characteristics of the Mercator projection */
-    if (factors.omega != 0.0)       return 86; /* angular distortion should be 0 */
-    if (factors.thetap != M_PI_2)   return 87; /* Meridian/parallel angle should be 90 deg */
-    if (factors.conv != 0.0)        return 88; /* meridian convergence should be 0 */
-
+    if (factors.angular_distortion != 0.0)  return 86; /* angular distortion should be 0 */
+    if (factors.meridian_parallel_angle != M_PI_2)  return 87; /* Meridian/parallel angle should be 90 deg */
+    if (factors.meridian_convergence != 0.0)  return 88; /* meridian convergence should be 0 */
 
     proj_destroy(P);
 
@@ -1474,8 +1462,8 @@ static int test_time(char* args, double tol, double t_in, double t_exp) {
     return ret;
 }
 
-static int test_xyz(char* args, double tol, PJ_TRIPLET in, PJ_TRIPLET exp) {
-    PJ_COORD out, obs_in;
+static int test_xyz(char* args, double tol, PJ_COORD in, PJ_COORD exp) {
+    PJ_COORD out = {{0,0,0,0}}, obs_in = {{0,0,0,0}};
     PJ *P = proj_create(PJ_DEFAULT_CTX, args);
     int ret = 0;
 
@@ -1517,10 +1505,10 @@ static int pj_unitconvert_selftest (void) {
     double in4 = 1877.71428, exp4 = 2016.0;
 
     char args5[] = "+proj=unitconvert +xy_in=m +xy_out=dm +z_in=cm +z_out=mm";
-    PJ_TRIPLET in5 = {{55.25, 23.23, 45.5}}, exp5 = {{552.5, 232.3, 455.0}};
+    PJ_COORD in5 = {{55.25, 23.23, 45.5, 0}}, exp5 = {{552.5, 232.3, 455.0, 0}};
 
     char args6[] = "+proj=unitconvert +xy_in=m +xy_out=m +z_in=m +z_out=m";
-    PJ_TRIPLET in6 = {{12.3, 45.6, 7.89}};
+    PJ_COORD in6 = {{12.3, 45.6, 7.89, 0}};
 
     ret = test_time(args1, 1e-6, in1, in1);   if (ret) return ret + 10;
     ret = test_time(args2, 1e-6, in2, in2);   if (ret) return ret + 20;

--- a/src/pj_deriv.c
+++ b/src/pj_deriv.c
@@ -2,8 +2,10 @@
 #define PJ_LIB__
 #include "projects.h"
 
-int pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
+int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     XY t;
+    /* get rid of constness until we can do it for real */
+    PJ *Q = (PJ *) P;
 
     lp.lam += h;
     lp.phi += h;
@@ -11,7 +13,7 @@ int pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
         return 1;
 
     h += h;
-    t = (*P->fwd)(lp, P);
+    t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
         return 1;
 
@@ -23,7 +25,7 @@ int pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
     if (fabs(lp.phi) > M_HALFPI)
         return 1;
 
-    t = (*P->fwd)(lp, P);
+    t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
         return 1;
 
@@ -32,7 +34,7 @@ int pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
     der->x_p -= t.x;
     der->y_l += t.y;
     lp.lam -= h;
-    t = (*P->fwd)(lp, P);
+    t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
         return 1;
 
@@ -41,7 +43,7 @@ int pj_deriv(LP lp, double h, PJ *P, struct DERIVS *der) {
     der->x_p -= t.x;
     der->y_l -= t.y;
     lp.phi += h;
-    t = (*P->fwd)(lp, P);
+    t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
         return 1;
 

--- a/src/pj_deriv.c
+++ b/src/pj_deriv.c
@@ -6,6 +6,8 @@ int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     XY t;
     /* get rid of constness until we can do it for real */
     PJ *Q = (PJ *) P;
+    if (0==Q->fwd)
+        return 1;
 
     lp.lam += h;
     lp.phi += h;
@@ -21,6 +23,7 @@ int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     der->y_p = t.y;
     der->x_p = t.x;
     der->y_l = t.y;
+
     lp.phi -= h;
     if (fabs(lp.phi) > M_HALFPI)
         return 1;
@@ -33,6 +36,7 @@ int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     der->y_p -= t.y;
     der->x_p -= t.x;
     der->y_l += t.y;
+
     lp.lam -= h;
     t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
@@ -42,6 +46,7 @@ int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     der->y_p -= t.y;
     der->x_p -= t.x;
     der->y_l -= t.y;
+
     lp.phi += h;
     t = (*Q->fwd)(lp, Q);
     if (t.x == HUGE_VAL)
@@ -51,7 +56,9 @@ int pj_deriv(LP lp, double h, const PJ *P, struct DERIVS *der) {
     der->y_p += t.y;
     der->x_p += t.x;
     der->y_l -= t.y;
-    der->x_l /= (h += h);
+
+    h += h;
+    der->x_l /= h;
     der->y_p /= h;
     der->x_p /= h;
     der->y_l /= h;

--- a/src/pj_factors.c
+++ b/src/pj_factors.c
@@ -11,7 +11,7 @@
 
 #define EPS 1.0e-12
 
-int pj_factors(LP lp, PJ *P, double h, struct FACTORS *fac) {
+int pj_factors(LP lp, const PJ *P, double h, struct FACTORS *fac) {
     double cosphi, t, n, r;
     int err;
     PJ_COORD coo = {{0, 0, 0, 0}};

--- a/src/proj.def
+++ b/src/proj.def
@@ -137,16 +137,15 @@ EXPORTS
     proj_rtodms                    @125
     proj_dmstor                    @126
 
-    proj_derivatives               @127
-    proj_factors                   @128
+    proj_factors                   @127
 
-    proj_list_operations           @129
-    proj_list_ellps                @130
-    proj_list_units                @131
-    proj_list_prime_meridians      @132
+    proj_list_operations           @128
+    proj_list_ellps                @129
+    proj_list_units                @130
+    proj_list_prime_meridians      @131
 
-    proj_angular_input             @133
-    proj_angular_output            @134
+    proj_angular_input             @132
+    proj_angular_output            @133
 
-    pj_ellipsoid                   @135
-    pj_calc_ellipsoid_params       @136
+    pj_ellipsoid                   @134
+    pj_calc_ellipsoid_params       @135

--- a/src/projects.h
+++ b/src/projects.h
@@ -178,7 +178,6 @@ union  PJ_COORD;
 struct geod_geodesic;
 struct pj_opaque;
 struct ARG_list;
-struct FACTORS;
 struct PJ_REGION_S;
 typedef struct PJ_REGION_S  PJ_Region;
 typedef struct ARG_list paralist;   /* parameter list */
@@ -704,8 +703,8 @@ double  pj_authlat(double, double *);
 COMPLEX pj_zpoly1(COMPLEX, COMPLEX *, int);
 COMPLEX pj_zpolyd1(COMPLEX, COMPLEX *, int, COMPLEX *);
 
-int pj_deriv(LP, double, PJ *, struct DERIVS *);
-int pj_factors(LP, PJ *, double, struct FACTORS *);
+int pj_deriv(LP, double, const PJ *, struct DERIVS *);
+int pj_factors(LP, const PJ *, double, struct FACTORS *);
 
 struct PW_COEF {    /* row coefficient structure */
     int m;          /* number of c coefficients (=0 for none) */


### PR DESCRIPTION
* Increase the focus on **`PJ_COORD`** as primary datatype: Eliminate use of `PJ_TRIPLET` etc.

* Trim proj.h by removing material that has become unnecessary.

* Improve constness

* Make proj_factors work in `proj.h` space, by providing a trimmed down `PJ_FACTORS` with more meaningful field names (it used to need projects.h as well, for full definition of `PJ_FACTORS`).