### PR TITLE
Fix bad typedef that surfaces when including proj.h and proj_api.h in the same file

### DIFF
--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -84,6 +84,7 @@ extern int pj_errno;    /* global error return code */
 #ifdef PROJ_API_H_NOT_INVOKED_AS_PRIMARY_API
     /* These make the function declarations below conform with classic proj */
     typedef PJ *projPJ;          /* projPJ is a pointer to PJ */
+    typedef struct projCtx_t projCtx_t;
     typedef projCtx_t *projCtx;  /* projCtx is a pointer to projCtx_t */
 #   define projXY        XY
 #   define projLP       LP

--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -84,8 +84,7 @@ extern int pj_errno;    /* global error return code */
 #ifdef PROJ_API_H_NOT_INVOKED_AS_PRIMARY_API
     /* These make the function declarations below conform with classic proj */
     typedef PJ *projPJ;          /* projPJ is a pointer to PJ */
-    typedef struct projCtx_t projCtx_t;
-    typedef projCtx_t *projCtx;  /* projCtx is a pointer to projCtx_t */
+    typedef struct projCtx_t *projCtx;  /* projCtx is a pointer to projCtx_t */
 #   define projXY        XY
 #   define projLP       LP
 #   define projXYZ      XYZ


### PR DESCRIPTION
This error appears when trying to include `proj.h` and `proj_api.h` in the same file. Fixed with this PR.

```
$ gcc -L../../build/proj4/lib -I../src -lproj projapitest.c -o test                                 
In file included from projapitest.c:3:                                                                
../src/proj_api.h:87:13: error: must use 'struct' tag to refer to type 'projCtx_t'
    typedef projCtx_t *projCtx;  /* projCtx is a pointer to projCtx_t */ 
            ^                                                                                         
            struct                                                                                    
1 error generated.
```