### PR TITLE
Enable selective debug printout through negative PROJ_DEBUG values

### DIFF
--- a/src/pj_ctx.c
+++ b/src/pj_ctx.c
@@ -84,7 +84,7 @@ projCtx pj_get_default_ctx()
 
         if( getenv("PROJ_DEBUG") != NULL )
         {
-            if( atoi(getenv("PROJ_DEBUG")) > 0 )
+            if( atoi(getenv("PROJ_DEBUG")) >= -PJ_LOG_DEBUG_MINOR )
                 default_context.debug_level = atoi(getenv("PROJ_DEBUG"));
             else
                 default_context.debug_level = PJ_LOG_DEBUG_MINOR;

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -187,7 +187,7 @@ enum proj_log_level proj_log_level (PJ_CONTEXT *ctx, enum proj_log_level log_lev
     if (PJ_LOG_TELL==log_level)
         return previous;
     ctx->debug_level = log_level;
-    return previous;
+    return abs(previous);
 }
 
 

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -183,11 +183,11 @@ enum proj_log_level proj_log_level (PJ_CONTEXT *ctx, enum proj_log_level log_lev
         ctx = pj_get_default_ctx();
     if (0==ctx)
         return PJ_LOG_TELL;
-    previous = ctx->debug_level;
+    previous = abs (ctx->debug_level);
     if (PJ_LOG_TELL==log_level)
         return previous;
     ctx->debug_level = log_level;
-    return abs(previous);
+    return previous;
 }
 
 

--- a/src/pj_log.c
+++ b/src/pj_log.c
@@ -51,8 +51,17 @@ void pj_vlog( projCtx ctx, int level, const char *fmt, va_list args )
 
 {
     char *msg_buf;
+    int debug_level = ctx->debug_level;
+    int shutup_unless_errno_set = debug_level < 0;
 
-    if( level > ctx->debug_level )
+    /* For negative debug levels, we first start logging when errno is set */
+    if (ctx->last_errno==0 && shutup_unless_errno_set)
+        return;
+
+    if (debug_level < 0)
+        debug_level = -debug_level;
+
+    if( level > debug_level )
         return;
 
     msg_buf = (char *) malloc(100000);

--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -72,14 +72,15 @@ extern "C" {
 #ifndef PROJ_H
 extern char const pj_release[]; /* global release id string */
 extern int pj_errno;    /* global error return code */
+#endif
 
-/* In proj.h these macros are replaced by the enumeration pj_log_level */
+#ifndef PROJ_INTERNAL_H
+/* replaced by enum proj_log_level in proj_internal.h */
 #define PJ_LOG_NONE        0
 #define PJ_LOG_ERROR       1
 #define PJ_LOG_DEBUG_MAJOR 2
 #define PJ_LOG_DEBUG_MINOR 3
 #endif
-
 
 #ifdef PROJ_API_H_NOT_INVOKED_AS_PRIMARY_API
     /* These make the function declarations below conform with classic proj */


### PR DESCRIPTION
Setting PROJ_DEBUG=3 is quite helpful for debugging PROJ and applications using PROJ, although the amount of information printed can be quite a jungle to navigate in.

This PR simplifies the navigation by introducing negative debug levels, which provide same level of debug output as their positive counterparts *but first when an error has occurred (i.e. errno has been set)*.

While one may need information about what happened *before* the error materialized, and hence must re-run with the equivalent positive PROJ_DEBUG level, at least the negative debug level helps pinpoint where things began to go wrong.