### PR TITLE
Add -std=c89 to travis targets

### DIFF
--- a/src/multistresstest.c
+++ b/src/multistresstest.c
@@ -161,7 +161,7 @@ TestItem test_list[] = {
         0, 0
     },
     {
-        //Bad projection (invalid ellipsoid parameter +R_A=0)
+        /* Bad projection (invalid ellipsoid parameter +R_A=0) */
         "+proj=utm +zone=11 +datum=WGS84",
         "+proj=merc +datum=potsdam +R_A=0",
         150000.0, 3000000.0, 0.0,
@@ -201,7 +201,6 @@ static void TestThread()
 /* -------------------------------------------------------------------- */
     projPJ *src_pj_list, *dst_pj_list;
     projCtx ctx = pj_ctx_alloc();
-//    projCtx ctx = pj_get_default_ctx();
 
     src_pj_list = (projPJ *) calloc(test_count,sizeof(projPJ));
     dst_pj_list = (projPJ *) calloc(test_count,sizeof(projPJ));

--- a/src/multistresstest.c
+++ b/src/multistresstest.c
@@ -32,10 +32,10 @@
 #include "proj_api.h"
 
 #ifdef _WIN32
-	#include <windows.h>
+    #include <windows.h>
 #else
-	#include <pthread.h>
-	#include <unistd.h>
+    #include <pthread.h>
+    #include <unistd.h>
 #endif
 
 #define num_threads    10
@@ -49,10 +49,10 @@ typedef struct {
 
     double  src_x, src_y, src_z;
     double  dst_x, dst_y, dst_z;
-    
+
     int     dst_error;
     int     skip;
-} TestItem; 
+} TestItem;
 
 TestItem test_list[] = {
     {
@@ -192,7 +192,7 @@ static projPJ* custom_pj_init_plus_ctx(projCtx ctx, const char* def)
 static void TestThread()
 
 {
-    int i, test_count = sizeof(test_list) / sizeof(TestItem); 
+    int i, test_count = sizeof(test_list) / sizeof(TestItem);
     int repeat_count = num_iterations;
     int i_iter;
 
@@ -202,10 +202,10 @@ static void TestThread()
     projPJ *src_pj_list, *dst_pj_list;
     projCtx ctx = pj_ctx_alloc();
 //    projCtx ctx = pj_get_default_ctx();
-    
+
     src_pj_list = (projPJ *) calloc(test_count,sizeof(projPJ));
     dst_pj_list = (projPJ *) calloc(test_count,sizeof(projPJ));
-                                
+
     if(!reinit_every_iteration)
     {
         for( i = 0; i < test_count; i++ )
@@ -216,11 +216,11 @@ static void TestThread()
             dst_pj_list[i] = custom_pj_init_plus_ctx( ctx, test->dst_def );
         }
     }
-    
+
 /* -------------------------------------------------------------------- */
 /*      Perform tests - over and over.                                  */
 /* -------------------------------------------------------------------- */
-    
+
     for( i_iter = 0; i_iter < repeat_count; i_iter++ )
     {
         for( i = 0; i < test_count; i++ )
@@ -240,7 +240,7 @@ static void TestThread()
 
                 {
                     int skipTest = (src_pj_list[i] == NULL || dst_pj_list[i] == NULL);
-                            
+
                     if ( skipTest != test->skip )
                         fprintf( stderr, "Threaded projection initialization does not match unthreaded initialization\n" );
 
@@ -256,23 +256,23 @@ static void TestThread()
             if ( test->skip )
                 continue;
 
-            error = pj_transform( src_pj_list[i], dst_pj_list[i], 1, 0, 
+            error = pj_transform( src_pj_list[i], dst_pj_list[i], 1, 0,
                                   &x, &y, &z );
-            
+
 
             if( error != test->dst_error )
             {
-                fprintf( stderr, "Got error %d, expected %d\n", 
+                fprintf( stderr, "Got error %d, expected %d\n",
                          error, test->dst_error );
             }
 
             if( x != test->dst_x || y != test->dst_y || z != test->dst_z )
             {
-                fprintf( stderr, 
+                fprintf( stderr,
                          "Got %.15g,%.15g,%.15g\n"
                          "Expected %.15g,%.15g,%.15g\n"
                          "Diff %.15g,%.15g,%.15g\n",
-                         x, y, z, 
+                         x, y, z,
                          test->dst_x, test->dst_y, test->dst_z,
                          x-test->dst_x, y-test->dst_y, z-test->dst_z);
             }
@@ -296,13 +296,13 @@ static void TestThread()
             pj_free( dst_pj_list[i] );
         }
     }
-    
+
     free( src_pj_list );
     free( dst_pj_list );
 
     pj_ctx_free( ctx );
 
-    printf( "%d iterations of the %d tests complete in thread X\n", 
+    printf( "%d iterations of the %d tests complete in thread X\n",
             repeat_count, test_count );
 
     active_thread_count--;
@@ -348,7 +348,7 @@ static int do_main(void)
 /*      Our first pass is to establish the correct answers for all      */
 /*      the tests.                                                      */
 /* -------------------------------------------------------------------- */
-    int i, test_count = sizeof(test_list) / sizeof(TestItem); 
+    int i, test_count = sizeof(test_list) / sizeof(TestItem);
 
     for( i = 0; i < test_count; i++ )
     {
@@ -374,16 +374,16 @@ static int do_main(void)
             pj_free (src_pj);
             continue;
         }
-        
+
         test->dst_x = test->src_x;
         test->dst_y = test->src_y;
         test->dst_z = test->src_z;
 
-        test->dst_error = pj_transform( src_pj, dst_pj, 1, 0, 
-                                        &(test->dst_x), 
+        test->dst_error = pj_transform( src_pj, dst_pj, 1, 0,
+                                        &(test->dst_x),
                                         &(test->dst_y),
                                         &(test->dst_z) );
-     
+
         pj_free( src_pj );
         pj_free( dst_pj );
 
@@ -401,47 +401,47 @@ static int do_main(void)
 /* -------------------------------------------------------------------- */
 #ifdef _WIN32
 
-	{ //Scoped to workaround lack of c99 support in VS
-		HANDLE ahThread[num_threads];
+    { //Scoped to workaround lack of c99 support in VS
+        HANDLE ahThread[num_threads];
 
-		for( i = 0; i < num_threads; i++ )
-		{
-			active_thread_count++;
+        for( i = 0; i < num_threads; i++ )
+        {
+            active_thread_count++;
 
-			ahThread[i] = CreateThread(NULL, 0, WinTestThread, NULL, 0, NULL);
-			
-			if (ahThread[i] == 0)
-			{
-				printf( "Thread creation failed.");
-				return 1;
-			}
-		}
+            ahThread[i] = CreateThread(NULL, 0, WinTestThread, NULL, 0, NULL);
 
-		printf( "%d test threads launched.\n", num_threads );
+            if (ahThread[i] == 0)
+            {
+                printf( "Thread creation failed.");
+                return 1;
+            }
+        }
 
-		WaitForMultipleObjects(num_threads, ahThread, TRUE, INFINITE);
-	}
+        printf( "%d test threads launched.\n", num_threads );
+
+        WaitForMultipleObjects(num_threads, ahThread, TRUE, INFINITE);
+    }
 
 #else
     {
-	pthread_t ahThread[num_threads];
-	pthread_attr_t hThreadAttr;
+    pthread_t ahThread[num_threads];
+    pthread_attr_t hThreadAttr;
 
-	pthread_attr_init( &hThreadAttr );
-	pthread_attr_setdetachstate( &hThreadAttr, PTHREAD_CREATE_DETACHED );
+    pthread_attr_init( &hThreadAttr );
+    pthread_attr_setdetachstate( &hThreadAttr, PTHREAD_CREATE_DETACHED );
 
-	for( i = 0; i < num_threads; i++ )
-	{
-		active_thread_count++;
+    for( i = 0; i < num_threads; i++ )
+    {
+        active_thread_count++;
 
-		pthread_create( &(ahThread[i]), &hThreadAttr, 
-			PosixTestThread, NULL );
-	}
+        pthread_create( &(ahThread[i]), &hThreadAttr,
+            PosixTestThread, NULL );
+    }
 
-	printf( "%d test threads launched.\n", num_threads );
+    printf( "%d test threads launched.\n", num_threads );
 
-	while( active_thread_count > 0 )				       
-		sleep( 1 );
+    while( active_thread_count > 0 )
+        sleep( 1 );
     }
 #endif
 

--- a/travis/linux_clang/install.sh
+++ b/travis/linux_clang/install.sh
@@ -4,4 +4,4 @@ set -e
 
 export CCACHE_CPP2=yes
 
-CC="ccache clang" CFLAGS="-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -fsanitize=address -O2" ./travis/install.sh
+CC="ccache clang" CFLAGS="-std=c89 -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -fsanitize=address -O2" ./travis/install.sh

--- a/travis/linux_gcc/install.sh
+++ b/travis/linux_gcc/install.sh
@@ -5,4 +5,4 @@ set -e
 export CCACHE_CPP2=yes
 
 #  -Wfloat-conversion not available for gcc 4.8
-CC="ccache gcc" CFLAGS="-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2" ./travis/install.sh
+CC="ccache gcc" CFLAGS="-std=c89 -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2" ./travis/install.sh

--- a/travis/osx/install.sh
+++ b/travis/osx/install.sh
@@ -4,4 +4,4 @@ set -e
 
 export CCACHE_CPP2=yes
 
-CC="ccache clang" CFLAGS="-g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -O2" ./travis/install.sh
+CC="ccache clang" CFLAGS="-std=c89 -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -O2" ./travis/install.sh


### PR DESCRIPTION
As suggested by @schwehr  in https://github.com/OSGeo/proj.4/issues/710 this adds `-std=c89` to the linux and os x travis targets.