### PR TITLE
Enable wildcard globbing for MSVC builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,12 +60,7 @@ test_script:
   - dir
   - echo "Contents of ..\test\gie:"
   - dir ..\test\gie
-  - gie.exe ..\test\gie\builtins.gie
-  - gie.exe ..\test\gie\deformation.gie
-  - gie.exe ..\test\gie\axisswap.gie
-  - gie.exe ..\test\gie\ellipsoid.gie
-  - gie.exe -vvvvv ..\test\gie\more_builtins.gie
-  - gie.exe ..\test\gie\GDA.gie
+  - gie.exe ..\test\gie\*.gie
 
 deploy: off
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BUILD_NAD2BIN "Build nad2bin (format conversion tool)" ON)
 option(BUILD_PROJ    "Build proj (cartographic projection tool : latlong <-> projected coordinates)" ON)
 
 if(NOT MSVC)
+
   if (NOT APPLE)
     # Use relative path so that package is relocatable
     set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${LIBDIR}")
@@ -22,6 +23,14 @@ if(NOT MSVC)
     # (2) setting the INSTALL_RPATH property on the executables to
     # "@loader_path/../${LIBDIR}"
   endif ()
+
+else ()
+
+    # Linking to setargv.obj enables wildcard globbing for the
+    # command line utilities, when compiling with MSVC
+    # https://docs.microsoft.com/da-dk/cpp/c-language/expanding-wildcard-arguments
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} setargv.obj")
+
 endif ()
 
 if(BUILD_CCT)

--- a/src/makefile.vc
+++ b/src/makefile.vc
@@ -102,27 +102,27 @@ proj_i.lib:	$(LIBOBJ)
 	if exist $(PROJ_DLL).manifest mt -manifest $(PROJ_DLL).manifest -outputresource:$(PROJ_DLL);2
 
 $(PROJ_EXE):	$(PROJEXE_OBJ) $(EXE_PROJ)
-	cl $(PROJEXE_OBJ) $(EXE_PROJ)
+	cl $(PROJEXE_OBJ) $(EXE_PROJ) /link setargv.obj
 	if exist $(PROJ_EXE).manifest mt -manifest $(PROJ_EXE).manifest -outputresource:$(PROJ_EXE);1
 
 $(CS2CS_EXE):	$(CS2CSEXE_OBJ) $(EXE_PROJ)
-	cl $(CS2CSEXE_OBJ) $(EXE_PROJ)
+	cl $(CS2CSEXE_OBJ) $(EXE_PROJ) /link setargv.obj
 	if exist $(CS2CS_EXE).manifest mt -manifest $(CS2CS_EXE).manifest -outputresource:$(CS2CS_EXE);1
 
 $(GEOD_EXE):	$(GEODEXE_OBJ) $(EXE_PROJ)
-	cl $(GEODEXE_OBJ) $(EXE_PROJ)
+	cl $(GEODEXE_OBJ) $(EXE_PROJ) /link setargv.obj
 	if exist $(GEOD_EXE).manifest mt -manifest $(GEOD_EXE).manifest -outputresource:$(GEOD_EXE);1
 
 $(CCT_EXE):	$(CCTEXE_OBJ) $(EXE_PROJ)
-	cl $(CCTEXE_OBJ) $(EXE_PROJ)
+	cl $(CCTEXE_OBJ) $(EXE_PROJ) /link setargv.obj
 	if exist $(CCT_EXE).manifest mt -manifest $(CCT_EXE).manifest -outputresource:$(CCT_EXE);1
 
 $(GIE_EXE):	$(GIEEXE_OBJ) $(EXE_PROJ)
-	cl $(GIEEXE_OBJ) $(EXE_PROJ)
+	cl $(GIEEXE_OBJ) $(EXE_PROJ) /link setargv.obj
 	if exist $(GIE_EXE).manifest mt -manifest $(GIE_EXE).manifest -outputresource:$(GIE_EXE);1
 
 $(NAD2BIN_EXE):	nad2bin.obj emess.obj $(EXE_PROJ)
-	cl nad2bin.obj emess.obj $(EXE_PROJ)
+	cl nad2bin.obj emess.obj $(EXE_PROJ) /link setargv.obj
 
 $(MULTISTRESSTEST_EXE): $(MULTISTRESSTEST_OBJ)
 	cl $(MULTISTRESSTEST_OBJ) $(EXE_PROJ)

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -80,12 +80,7 @@ if [ $TRAVIS_OS_NAME == "osx" ]; then
     fi
 make -j3
 make check
-PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/builtins.gie
-PROJ_LIB=$GRIDDIR ./src/gie -vvvvv ./test/gie/more_builtins.gie
-PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/deformation.gie
-PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/axisswap.gie
-PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/ellipsoid.gie
-PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/GDA.gie
+PROJ_LIB=$GRIDDIR ./src/gie ./test/gie/*.gie
 
 # install & run the working GIGS test
   # create locations that pyproj understands


### PR DESCRIPTION
Make MSVC builds expand (glob) wildcards in command line arguments so, e.g.,

    gie tests\gie\*.gie

work properly