### PR TITLE
Fix issue #715

### DIFF
--- a/src/geodesic.h
+++ b/src/geodesic.h
@@ -132,7 +132,7 @@
  * The patch level of the geodesic library.  (This tracks the version of
  * GeographicLib.)
  **********************************************************************/
-#define GEODESIC_VERSION_PATCH 0
+#define GEODESIC_VERSION_PATCH 1
 
 /**
  * Pack the version components into a single integer.  Users should not rely on

--- a/src/geodtest.c
+++ b/src/geodtest.c
@@ -505,7 +505,7 @@ static int GeodSolve59() {
   geod_inverse(&g, 5, 0.00000000000001, 10, 180, &s12, &azi1, &azi2);
   result += assertEquals(azi1, 0.000000000000035, 1.5e-14);
   result += assertEquals(azi2, 179.99999999999996, 1.5e-14);
-  result += assertEquals(s12, 18345191.174332713, 2.5e-9);
+  result += assertEquals(s12, 18345191.174332713, 5e-9);
   return result;
 }
 


### PR DESCRIPTION
Merge 1.49.1 of geodesic library (tagged as v1.49.1-c in GeographicLib).
This fixes issue #715. Details:

Workaround bugs in handling of -0.0 in fmod and sin in Visual Studio 10,
11, and 12.

Relax unrealistically strict delta for GeodSolve59 in geodtest.