### PR TITLE
Reykjavik (1900) datum, prerequisites

### DIFF
--- a/src/pj_datums.c
+++ b/src/pj_datums.c
@@ -30,10 +30,10 @@
 #define PJ_DATUMS__
 #include <projects.h>
 
-/* 
+/*
  * The ellipse code must match one from pj_ellps.c.  The datum id should
- * be kept to 12 characters or less if possible.  Use the official OGC 
- * datum name for the comments if available. 
+ * be kept to 12 characters or less if possible.  Use the official OGC
+ * datum name for the comments if available.
  */
 
 C_NAMESPACE_VAR const struct PJ_DATUMS pj_datums[] = {
@@ -86,6 +86,7 @@ C_NAMESPACE_VAR const struct PJ_PRIME_MERIDIANS pj_prime_meridians[] = {
     {"stockholm", "18d3'29.8\"E"},
     {"athens",    "23d42'58.815\"E"},
     {"oslo",      "10d43'22.5\"E"},
+    {"copenhagen","12d34'40.35\"E"},
     {NULL,        NULL}
 };
 

--- a/src/pj_ellps.c
+++ b/src/pj_ellps.c
@@ -16,6 +16,7 @@ pj_ellps[] = {
 {"NWL9D",	"a=6378145.0.",		"rf=298.25",		"Naval Weapons Lab., 1965"},
 {"mod_airy",	"a=6377340.189",	"b=6356034.446",	"Modified Airy"},
 {"andrae",	"a=6377104.43",		"rf=300.0",		"Andrae 1876 (Den., Iclnd.)"},
+{"danish",	"a=6377019.2563",	"rf=300.0",		"Andrae 1876 (Denmark, Iceland)"},
 {"aust_SA",	"a=6378160.0",		"rf=298.25",		"Australian Natl & S. Amer. 1969"},
 {"GRS67",	"a=6378160.0",		"rf=298.2471674270",	"GRS 67(IUGG 1967)"},
 {"GSK2011",	"a=6378136.5",		"rf=298.2564151",	"GSK-2011"},


### PR DESCRIPTION
Danish (Andræ) ellipsoid, and Copenhagen meridian introduced in support of the Reykjavik 1900 datum (Iceland).

The magnitude of the Danish (1876) ellipsoid was originally given in French toise (fathoms) - the Andræ ellipsoid already in PROJ seems to have been transformed to meters using a conversion factor for German fathoms.

This version, based on a French conversion factor of 1.94903631 m/toise, corresponds to the official value for the semimajor axis used by the Icelandic NMA, Landmælingar Íslands, LMI (Guðmundur Valsson, LMI, pers. comm. 2017-12-15).

This value deviates by approximately one centimeter, compared to the truncated value of 6377019.27 m, given in the EPSG:7051 record.
