### PR TITLE
Add plate motion model parameters to ITRF init-files.

### DIFF
--- a/nad/ITRF2008
+++ b/nad/ITRF2008
@@ -22,3 +22,40 @@
 <ITRF89> +proj=helmert +x=0.0278 +y=0.0386 +z=-0.1012 +s=0.00731 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +t_epoch=2000.0 +transpose
 
 <ITRF88> +proj=helmert +x=0.0228 +y=0.0026 +z=-0.1252 +s=0.01041 +rz=0.00006 +dx=0.0001 +dy=-0.0005 +dz=-0.0032 +ds=0.00009 +drz=0.00002 +t_epoch=2000.0 +transpose
+
+
+# ITRF2008 Plate Motion Model parameters
+#
+# As described in
+#
+# Altamimi, Z., L. Métivier, and X. Collilieux (2012), ITRF2008 plate motion model,
+# J. Geophys. Res., 117, B07402, doi:10.1029/2011JB008930.
+
+
+<AMUR> +proj=helmert +drx=-0.000190 +dry=-0.000442 +drz=0.000915
+
+<ANTA> +proj=helmert +drx=-0.000252 +dry=-0.000302 +drz=0.000643
+
+<ARAB> +proj=helmert +drx=0.001202 +dry=-0.000054 +drz=0.001485
+
+<AUST> +proj=helmert +drx=0.001504 +dry=0.001172 +drz=0.001228
+
+<CARB> +proj=helmert +drx=0.000049 +dry=-0.001088 +drz=0.000664
+
+<EURA> +proj=helmert +drx=-0.000083 +dry=0.000534 +drz=0.000750
+
+<INDI> +proj=helmert +drx=0.001232 +dry=0.000303 +drz=0.001540
+
+<NAZC> +proj=helmert +drx=-0.000330 +dry=-0.001551 +drz=0.001625
+
+<NOAM> +proj=helmert +drx=0.000035 +dry=-0.000662 +drz=0.0001
+
+<NUBI> +proj=helmert +drx=0.000095 +dry=-0.000598 +drz=0.000723
+
+<PCFC> +proj=helmert +drx=0.000411 +dry=0.001036 +drz=-0.002166
+
+<SOAM> +proj=helmert +drx=-0.000243 +dry=-0.000311 +drz=-0.000154
+
+<SOMA> +proj=helmert +drx=-0.000080 +dry=-0.000745 +drz=0.000897
+
+<SUND> +proj=helmert +drx=0.000047 +dry=-0.001 +drz=0.000975

--- a/nad/ITRF2014
+++ b/nad/ITRF2014
@@ -24,3 +24,32 @@
 <ITRF89> +proj=helmert +x=0.0304 +y=0.0355 +z=-0.1308 +s=0.00819 +rz=0.00026 +dx=0.0001 +dy=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +transpose
 
 <ITRF88> +proj=helmert +x=0.0254 +y=-0.0005 +z=-0.1548 +s=0.01129 +rx=0.0001 +rz= +dx=0.00026 +dy=0.0001 +dx=-0.0005 +dz=-0.0033 +ds=0.00012 +drz=0.00002 +t_epoch=2010.0 +transpose
+
+# ITRF2014 Plate Motion Model parameters
+#
+# As described in
+#
+# Z. Altamimi et al, 2017, ITRF2014 plate motion model,
+# doi: 10.1093/gji/ggx136
+
+<ANTA> +proj=helmert +drx=−0.000248 +dry=−0.000324 +drz=0.000675
+
+<ARAB> +proj=helmert +drx=0.001154 +dry=−0.000136 +drz=0.001444
+
+<AUST> +proj=helmert +drx=0.001510 +dry=0.001182 +drz=0.001215
+
+<EURA> +proj=helmert +drx=−0.000085 +dry=−0.000531 +drz=0.000770
+
+<INDI> +proj=helmert +drx=0.001154 +dry=−0.000005 +drz=0.001454
+
+<NAZC> +proj=helmert +drx=−0.000333 +dry=−0.001544 +drz=0.001623
+
+<NOAM> +proj=helmert +drx=0.000024 +dry=-0.000694 +drz=-0.000063
+
+<NUBI> +proj=helmert +drx=0.000099 +dry=−0.000614 +drz=0.000733
+
+<PCFC> +proj=helmert +drx=−0.000409 +dry=0.001047 +drz=-0.002169
+
+<SOAM> +proj=helmert +drx=−0.000270 +dry=−0.000301 +drz=−0.000140
+
+<SOMA> +proj=helmert +drx=−0.000121 +dry=−0.000794 +drz=0.000884


### PR DESCRIPTION
Parameters for the plate motion models (PMM) for ITRF2008 and ITRF2014
are added to the ITRF2008/2014 init-files. The PMMs allow coordinates
to be moved back and forward in time in plate fixed reference frames
such as GR96 in Greenland which is defined as ITRF94@1996.623.
Transforming an ITRF2014-coordinate to GR96 is done with:

```
+proj=pipeline +step +init=ITRF2014:NOAM   +t_epoch=1996.623 +t_obs=2017.584
               +step +init=ITRF2014:ITRF94 +t_obs=1996.623
```` 

where the first step transforms the coordinate back in time to
ITRF2014@1996.632 by using the ITRF2014 PMM. The second step transforms
the ITRF2014 coordinate to ITRF94.

The PMM parameters are simply rotation rates that can be used with the Helmert transform.
Each plate, and it's corresponding parameters, have been added as a separate entry point in
both ITRF init-files.