### PR TITLE
Pipeline and cct inverse fixes

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -320,6 +320,7 @@ PJ *OPERATION(pipeline,0) {
     int i, nsteps = 0, argc;
     int i_pipeline = -1, i_first_step = -1, i_current_step;
     char **argv, **current_argv;
+    PJ *Q;
 
     P->fwd4d  =  pipeline_forward_4d;
     P->inv4d  =  pipeline_reverse_4d;
@@ -429,12 +430,27 @@ PJ *OPERATION(pipeline,0) {
 
         /* Is this step inverted? */
         for (j = 0;  j < current_argc; j++)
-            if (0==strcmp("inv", current_argv[j]))
+            if (0==strcmp("inv", current_argv[j])) {
                 next_step->inverted = 1;
+            }
 
         P->opaque->pipeline[i+1] = next_step;
 
         proj_log_trace (P, "Pipeline at [%p]:    step at [%p] done", P, next_step);
+    }
+
+    /* determine if an inverse operation is possible */
+    for (i = 1; i <= nsteps; i++) {
+        Q = P->opaque->pipeline[i];
+        if ( ( Q->inverted && (Q->fwd || Q->fwd3d || Q->fwd4d) ) ||
+             ( Q->inv || Q->inv3d || Q->inv4d) ) {
+            continue;
+        } else {
+            P->inv   = 0;
+            P->inv3d = 0;
+            P->inv4d = 0;
+            break;
+        }
     }
 
     proj_log_trace (P, "Pipeline: %d steps built. Determining i/o characteristics", nsteps);

--- a/src/cct.c
+++ b/src/cct.c
@@ -217,9 +217,15 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    /* We have no API call for inverting an operation, so we brute force it. */
-    if (direction==-1)
+    if (direction==-1) {
+        /* fail if an inverse operation is not available */
+        if (!proj_pj_info(P).has_inverse) {
+            fprintf (stderr, "Inverse operation not available\n");
+            return 1;
+        }
+        /* We have no API call for inverting an operation, so we brute force it. */
         P->inverted = !(P->inverted);
+    }
     direction = 1;
 
     /* Allocate input buffer */

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -65,7 +65,7 @@ roundtrip 100    1 m
 -------------------------------------------------------------------------------
 Some tests from PJ_pipeline.c
 -------------------------------------------------------------------------------
-Forward-reverse geo->utm->geo
+Forward-reverse geo->utm->geo (4D functions)
 -------------------------------------------------------------------------------
 operation proj=pipeline zone=32 step
           proj=utm  ellps=GRS80 step
@@ -81,7 +81,7 @@ Now the inverse direction (still same result: the pipeline is symmetrical)
 direction inverse
 expect 12 55 0 0
 -------------------------------------------------------------------------------
-And now the back-to-back situation utm->geo->utm
+And now the back-to-back situation utm->geo->utm (4D functions)
 -------------------------------------------------------------------------------
 operation proj=pipeline zone=32 ellps=GRS80 step
           proj=utm inv                      step
@@ -91,6 +91,33 @@ accept 691875.63214  6098907.82501  0  0
 expect 691875.63214  6098907.82501  0  0
 direction inverse
 expect 691875.63214  6098907.82501  0  0
+-------------------------------------------------------------------------------
+Forward-reverse geo->utm->geo (3D functions)
+-------------------------------------------------------------------------------
+operation proj=pipeline zone=32 step
+          proj=utm  ellps=GRS80 step
+          proj=utm  ellps=GRS80 inv
+-------------------------------------------------------------------------------
+tolerance 0.1 mm
+
+accept 12 55 0
+expect 12 55 0
+
+Now the inverse direction (still same result: the pipeline is symmetrical)
+
+direction inverse
+expect 12 55 0
+-------------------------------------------------------------------------------
+And now the back-to-back situation utm->geo->utm (3D functions)
+-------------------------------------------------------------------------------
+operation proj=pipeline zone=32 ellps=GRS80 step
+          proj=utm inv                      step
+          proj=utm
+-------------------------------------------------------------------------------
+accept 691875.63214  6098907.82501  0
+expect 691875.63214  6098907.82501  0
+direction inverse
+expect 691875.63214  6098907.82501  0
 -------------------------------------------------------------------------------
 Test a corner case: A rather pointless one-step pipeline geo->utm
 -------------------------------------------------------------------------------
@@ -135,6 +162,20 @@ operation   proj=pipeline step
             proj=urm5 n=0.5
 accept      12 56
 expect      1215663.2814182492      5452209.5424045017
+-------------------------------------------------------------------------------
+Test various failing scenarios.
+-------------------------------------------------------------------------------
+operation   proj=pipeline   step
+            proj=pipeline   step
+            proj=merc
+expect      failure pjd_err_malformed_pipeline
+
+operation   step proj=pipeline step proj=merc
+expect      failure pjd_err_malformed_pipeline
+
+operation   proj=pipeline
+expect      failure pjd_err_malformed_pipeline
+
 
 -------------------------------------------------------------------------------
 Some tests from PJ_vgridshift.c

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -115,10 +115,26 @@ expect    691875.63214  6098907.82501  0  0
 direction inverse
 accept    12 55 0 0
 expect    12 55 0 0
+-------------------------------------------------------------------------------
+Test a few inversion scenarios (urm5 has no inverse operation)
+-------------------------------------------------------------------------------
+operation   proj=pipeline       step
+            proj=urm5 n=0.5 inv
+expect      failure pjd_err_malformed_pipeline
 
+operation   proj=pipeline   inv step
+            proj=urm5 n=0.5
+expect      failure pjd_err_malformed_pipeline
 
+operation   proj=pipeline   inv step
+            proj=urm5 n=0.5 inv
+accept      12 56
+expect      1215663.2814182492      5452209.5424045017
 
-
+operation   proj=pipeline step
+            proj=urm5 n=0.5
+accept      12 56
+expect      1215663.2814182492      5452209.5424045017
 
 -------------------------------------------------------------------------------
 Some tests from PJ_vgridshift.c


### PR DESCRIPTION
This PR makes two changes:

1.  Fail gracefully when invalid inverse operation is specified in cct.

Similar to proj and cs2cs, cct now returns immediately when trying to
do an inverse operation that is not possible, for example using
proj=urm5 which doesn't have an inverse:

```
	$ cct.exe -I  +proj=pipeline +step +proj=urm5 +n=0.5
	Inverse operation not available
```

2. Set inv*-functions to zero on pipeline PJ's where an inverse does not exist.

Some projections do not have an inverse mapping. If such a projection is used
as a (forward) step in a pipeline we won't be able to perform an inverse
operation using the pipeline. By setting the inv, inv3d and inv4d pointers to
zero we signal to the caller that an inverse mapping is not available.