### PR TITLE
Add pj_has_inverse().

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -454,8 +454,7 @@ PJ *OPERATION(pipeline,0) {
     /* determine if an inverse operation is possible */
     for (i = 1; i <= nsteps; i++) {
         PJ *Q = P->opaque->pipeline[i];
-        if ( ( Q->inverted && (Q->fwd || Q->fwd3d || Q->fwd4d) ) ||
-             ( Q->inv || Q->inv3d || Q->inv4d) ) {
+        if ( pj_has_inverse(Q) ) {
             continue;
         } else {
             P->inv   = 0;

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -119,7 +119,14 @@ chained calls starting out with a call to its 3D interface.
     return proj_coord_error ();
 }
 
-
+/**************************************************************************************/
+int pj_has_inverse(PJ *P) {
+/***************************************************************************************
+Check if a a PJ has an inverse.
+***************************************************************************************/
+    return ( (P->inverted && (P->fwd || P->fwd3d || P->fwd4d) ) ||
+             ( P->inv || P->inv3d || P->inv4d) );
+}
 
 
 /* Move P to a new context - or to the default context if 0 is specified */

--- a/src/proj.def
+++ b/src/proj.def
@@ -154,3 +154,4 @@ EXPORTS
 
     pj_approx_2D_trans             @138
     pj_approx_3D_trans             @139
+    pj_has_inverse                 @140

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -696,9 +696,7 @@ PJ_PROJ_INFO proj_pj_info(PJ *P) {
     pj_strlcpy(info.definition, &def[1], sizeof(info.definition)); /* def includes a leading space */
     pj_dealloc(def);
 
-    /* this does not take into account that a pipeline potentially does not */
-    /* have an inverse.                                                     */
-    info.has_inverse = (P->inv != 0 || P->inv3d != 0 || P->inv4d != 0);
+    info.has_inverse = pj_has_inverse(P);
 
     return info;
 }

--- a/src/proj_api.h
+++ b/src/proj_api.h
@@ -155,6 +155,7 @@ projPJ pj_init_ctx( projCtx, int, char ** );
 projPJ pj_init_plus_ctx( projCtx, const char * );
 char *pj_get_def(projPJ, int);
 projPJ pj_latlong_from_proj( projPJ );
+int pj_has_inverse(projPJ);
 
 
 void *pj_malloc(size_t);


### PR DESCRIPTION
With the introduction of the "inverted" flag on PJ objects
you can no longer rely on checking that the inv, inv3d and inv4d
functions are available on said PJ object. The function is used
internally a few places and otherwise exposed in proj_api.h to
ensure that users of the old programming interface can safely
check if an operation has an inverse.