### PR TITLE
Fix SOVERSION for Automake build.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,7 @@ geodtest_LDADD = libproj.la
 
 lib_LTLIBRARIES = libproj.la
 
-libproj_la_LDFLAGS = -no-undefined -version-info 13:0:1
+libproj_la_LDFLAGS = -no-undefined -version-info 13:0:0
 
 libproj_la_SOURCES = \
 	pj_list.h proj_internal.h\


### PR DESCRIPTION
Because various symbols were added and removed the SONAME needs be bumped (as was done correctly for the CMake build).

See: [Libtool: Updating library version information](https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html)

Fixes: #763 