### PR TITLE
Add --version option to gie and cct.

### DIFF
--- a/src/cct.c
+++ b/src/cct.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
     int nfields = 4, direction = 1, verbose;
     double fixed_z = HUGE_VAL, fixed_time = HUGE_VAL;
     int columns_xyzt[] = {1, 2, 3, 4};
-    const char *longflags[]  = {"v=verbose", "h=help", "I=inverse", 0};
+    const char *longflags[]  = {"v=verbose", "h=help", "I=inverse", "version", 0};
     const char *longkeys[]   = {"o=output",  "c=columns", "z=height", "t=time", 0};
 
     o = opt_parse (argc, argv, "hvI", "cozt", longflags, longkeys);
@@ -172,6 +172,11 @@ int main(int argc, char **argv) {
 
     direction = opt_given (o, "I")? -1: 1;
     verbose   = opt_given (o, "v");
+
+    if (opt_given (o, "version")) {
+        fprintf (stdout, "%s: %s\n", o->progname, pj_get_release ());
+        return 0;
+    }
 
     if (opt_given (o, "o"))
         fout = fopen (opt_arg (o, "output"), "wt");

--- a/src/gie.c
+++ b/src/gie.c
@@ -133,8 +133,6 @@ typedef struct ffio {
     size_t level;
 }  ffio;
 
-FILE *test = 0;
-
 static int get_inp (ffio *F);
 static int skip_to_next_tag (ffio *F);
 static int step_into_gie_block (ffio *F);
@@ -231,7 +229,7 @@ static const char usage[] = {
 
 int main (int argc, char **argv) {
     int  i;
-    const char *longflags[]  = {"v=verbose", "q=quiet", "h=help", "l=list", 0};
+    const char *longflags[]  = {"v=verbose", "q=quiet", "h=help", "l=list", "version", 0};
     const char *longkeys[]   = {"o=output", 0};
     OPTARGS *o;
 
@@ -240,7 +238,6 @@ int main (int argc, char **argv) {
     T.verbosity = 1;
     T.tolerance = 5e-4;
 
-    test = fopen ("test.c", "wt");
     o = opt_parse (argc, argv, "hlvq", "o", longflags, longkeys);
     if (0==o)
         return 0;
@@ -249,6 +246,13 @@ int main (int argc, char **argv) {
         printf (usage, o->progname);
         return 0;
     }
+
+
+    if (opt_given (o, "version")) {
+        fprintf (stdout, "%s: %s\n", o->progname, pj_get_release ());
+        return 0;
+    }
+
 
     if (opt_given (o, "l"))
         return list_err_codes ();

--- a/src/optargpm.h
+++ b/src/optargpm.h
@@ -84,7 +84,7 @@ opt_eof_handler (o):
 
 Usage is probably easiest understood by a brief textbook style example:
 
-Consider a simple program taking the conventinal "-v, -h, -o" options
+Consider a simple program taking the conventional "-v, -h, -o" options
 indicating "verbose output", "help please", and "output file specification",
 respectively.
 


### PR DESCRIPTION
Additionally correct a spelling error in optargpm.h and
remove two lines of leftover cruft from gie.c

Resolves #764 