### PR TITLE
Shrink PJ_XXX_INFO structs, but keep same syntax.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,8 @@ test_script:
   - dir
   - echo "Contents of ..\test\gie:"
   - dir ..\test\gie
+  - echo "Contents of PROJ_LIB " %PROJ_LIB%
+  - dir %PROJ_LIB%
   - gie.exe ..\test\gie\*.gie
 
 deploy: off

--- a/src/gie.c
+++ b/src/gie.c
@@ -1682,6 +1682,7 @@ static int pj_cart_selftest (void) {
     /* proj_info()                                                            */
     /* this one is difficult to test, since the output changes with the setup */
     info = proj_info();
+printf ("gie - info.searchpath=[%s]\n", info.searchpath);
 
     if (info.version[0] != '\0' ) {
         char tmpstr[64];
@@ -1689,6 +1690,7 @@ static int pj_cart_selftest (void) {
         if (strcmp(info.version, tmpstr)) return 55;
     }
     if (info.release[0] == '\0')    return 56;
+printf ("gie - info.searchpath=[%s]\n", info.searchpath);
     if (getenv ("HOME") || getenv ("PROJ_LIB"))
         if (info.searchpath[0] == '\0') return 57;
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -1458,7 +1458,7 @@ static int pj_cart_selftest (void) {
     size_t n, sz;
     double dist, h, t;
     char *args[3] = {"proj=utm", "zone=32", "ellps=GRS80"};
-    const char *arg = {"+proj=utm +zone=32 +ellps=GRS80"};
+    char arg[50] = {"+proj=utm; +zone=32; +ellps=GRS80"};
     char buf[40];
 
     /* An utm projection on the GRS80 ellipsoid */
@@ -1699,6 +1699,7 @@ static int pj_cart_selftest (void) {
     P = proj_create(PJ_DEFAULT_CTX, arg);
     pj_info = proj_pj_info(P);
     if ( !pj_info.has_inverse )            {  proj_destroy(P); return 61; }
+    pj_shrink (arg);
     if ( strcmp(pj_info.definition, arg) ) {  proj_destroy(P); return 62; }
     if ( strcmp(pj_info.id, "utm") )       {  proj_destroy(P); return 63; }
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -1682,7 +1682,6 @@ static int pj_cart_selftest (void) {
     /* proj_info()                                                            */
     /* this one is difficult to test, since the output changes with the setup */
     info = proj_info();
-printf ("gie - info.searchpath=[%s]\n", info.searchpath);
 
     if (info.version[0] != '\0' ) {
         char tmpstr[64];
@@ -1690,7 +1689,6 @@ printf ("gie - info.searchpath=[%s]\n", info.searchpath);
         if (strcmp(info.version, tmpstr)) return 55;
     }
     if (info.release[0] == '\0')    return 56;
-printf ("gie - info.searchpath=[%s]\n", info.searchpath);
     if (getenv ("HOME") || getenv ("PROJ_LIB"))
         if (info.searchpath[0] == '\0') return 57;
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -1689,7 +1689,8 @@ static int pj_cart_selftest (void) {
         if (strcmp(info.version, tmpstr)) return 55;
     }
     if (info.release[0] == '\0')    return 56;
-    if (info.searchpath[0] == '\0') return 57;
+    if (getenv ("HOME") || getenv ("PROJ_LIB"))
+        if (info.searchpath[0] == '\0') return 57;
 
     /* proj_pj_info() */
     P = proj_create(PJ_DEFAULT_CTX, "+proj=august"); /* august has no inverse */

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -261,7 +261,9 @@ consuming their surrounding whitespace.
 
         /* Eliminate prefix '+', only if preceeded by whitespace */
         /* (i.e. keep it in 1.23e+08) */
-        if ((i > 0) && ('+'==c[j]) && isspace (c[i]))
+        if ((i > 0) && ('+'==c[j]) && ws)
+            c[j] = ' ';
+        if ((i==0) && ('+'==c[j]))
             c[j] = ' ';
 
         if (isspace (c[j]) || ';'==c[j]) {

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -148,56 +148,6 @@ void proj_context_inherit (PJ *parent, PJ *child) {
 
 
 
-/**************************************************************************************/
-size_t pj_strlcpy(char *dst, const char *src, size_t dsize) {
-/***************************************************************************************
-   Copy src to string dst of size siz.  At most siz-1 characters
-   will be copied.  Always NUL terminates (unless siz == 0).
-   Returns strlen(src); if retval >= siz, truncation occurred.
-
- *
- * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
-
-  Source: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/string/strlcpy.c
-
-***************************************************************************************/
-    const char *osrc = src;
-    size_t nleft = dsize;
-
-    /* Copy as many bytes as will fit. */
-    if (nleft != 0) {
-        while (--nleft != 0) {
-            if ((*dst++ = *src++) == '\0')
-                break;
-        }
-    }
-
-    /* Not enough room in dst, add NUL and traverse rest of src. */
-    if (nleft == 0) {
-        if (dsize != 0)
-            *dst = '\0';		/* NUL-terminate dst */
-        while (*src++)
-            ;
-    }
-
-    return(src - osrc - 1);	/* count does not include NUL */
-}
-
-
-
 /*****************************************************************************/
 char *pj_chomp (char *c) {
 /******************************************************************************

--- a/src/pj_malloc.c
+++ b/src/pj_malloc.c
@@ -221,6 +221,7 @@ void *pj_default_destructor (PJ *P, int errlev) {   /* Destructor */
 
     /* free parameter list elements */
     pj_dealloc_params (pj_get_ctx(P), P->params, errlev);
+    pj_dealloc (P->def_full);
 
     /* free the cs2cs emulation elements */
     pj_free (P->axisswap);

--- a/src/proj.h
+++ b/src/proj.h
@@ -247,6 +247,8 @@ struct PJ_INFO {
     const char  *searchpath;        /* Paths where init and grid files are  */
                                     /* looked for. Paths are separated by   */
                                     /* semi-colons.                         */
+    const char * const *paths;
+    size_t path_count;
 };
 
 struct PJ_PROJ_INFO {

--- a/src/proj.h
+++ b/src/proj.h
@@ -239,20 +239,20 @@ union PJ_COORD {
 
 
 struct PJ_INFO {
-    char        release[64];        /* Release info. Version + date         */
-    char        version[64];        /* Full version number                  */
     int         major;              /* Major release number                 */
     int         minor;              /* Minor release number                 */
     int         patch;              /* Patch level                          */
-    char        searchpath[512];    /* Paths where init and grid files are  */
+    const char  *release;           /* Release info. Version + date         */
+    const char  *version;           /* Full version number                  */
+    const char  *searchpath;        /* Paths where init and grid files are  */
                                     /* looked for. Paths are separated by   */
                                     /* semi-colons.                         */
 };
 
 struct PJ_PROJ_INFO {
-    char        id[16];             /* Name of the projection in question                       */
-    char        description[128];   /* Description of the projection                            */
-    char        definition[512];    /* Projection definition                                    */
+    const char  *id;                /* Name of the projection in question                       */
+    const char  *description;       /* Description of the projection                            */
+    const char  *definition;        /* Projection definition                                    */
     int         has_inverse;        /* 1 if an inverse mapping exists, 0 otherwise              */
     double      accuracy;           /* Expected accuracy of the transformation. -1 if unknown.  */
 };
@@ -356,7 +356,7 @@ int  proj_errno_restore (const PJ *P, int err);
 PJ_FACTORS proj_factors(PJ *P, LP lp);
 
 /* Info functions - get information about various PROJ.4 entities */
-PJ_INFO      proj_info(void);
+PJ_INFO proj_info(void);
 PJ_PROJ_INFO proj_pj_info(PJ *P);
 PJ_GRID_INFO proj_grid_info(const char *gridname);
 PJ_INIT_INFO proj_init_info(const char *initname);

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -758,7 +758,7 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
             pj_dealloc (buf);
             return 0;
         }
-        *buf_size = 2 * len;
+        *buf_size = 2 * len + 2;
         if (buf != 0)
             strcpy (p, buf);
         pj_dealloc (buf);

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -753,7 +753,7 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
 
     /* "pj_realloc", so to speak */
     if (*buf_size < len) {
-        p = pj_calloc (2 * len, sizeof (char));
+        p = pj_calloc (2 * len + 2, sizeof (char));
         if (0==p) {
             pj_dealloc (buf);
             return 0;
@@ -806,6 +806,7 @@ PJ_INFO proj_info (void) {
         info.searchpath = empty;
         info.version    = version;
         info.release    = pj_get_release ();
+printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
 
         /* build search path string */
         buf = path_append (buf, getenv ("HOME"), &buf_size);
@@ -821,11 +822,13 @@ PJ_INFO proj_info (void) {
 
         for (i = 0;  i < n;  i++) {
             buf = path_append (buf, paths[i], &buf_size);
+printf ("loop: buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
             if (0==buf)
                 break;
         }
+        if (0==buf)
+            break;
         info.searchpath = buf;
-printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
 printf ("buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
 
         info.paths = paths;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -769,6 +769,7 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
     if (0 != buflen)
         strcat (buf, ";");
     strcat (buf, app);
+printf ("buf_size=%3.3d,  buf=[%s]\n", (int) *buf_size, buf);
     return buf;
 }
 
@@ -824,6 +825,7 @@ PJ_INFO proj_info (void) {
                 break;
         }
         info.searchpath = buf;
+printf ("buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
 
         info.paths = paths;
         info.path_count = n;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -825,6 +825,7 @@ PJ_INFO proj_info (void) {
                 break;
         }
         info.searchpath = buf;
+printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
 printf ("buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
 
         info.paths = paths;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -781,8 +781,7 @@ PJ_INFO proj_info (void) {
 /******************************************************************************
     Basic info about the current instance of the PROJ.4 library.
 
-    Returns PJ_INFO struct. Searchpath member of the struct is truncated to 512
-    characters.
+    Returns PJ_INFO struct.
 ******************************************************************************/
     const char * const *paths;
     int i, n;
@@ -894,14 +893,17 @@ PJ_GRID_INFO proj_grid_info(const char *gridname) {
         return grinfo;
     }
 
+    /* The string copies below are automatically null-terminated due to */
+    /* the memset above, so strncpy is safe */
+
     /* name of grid */
-    pj_strlcpy(grinfo.gridname, gridname, sizeof(grinfo.gridname));
+    strncpy (grinfo.gridname, gridname, sizeof(grinfo.gridname) - 1);
 
     /* full path of grid */
-    pj_find_file(ctx, gridname, grinfo.filename, sizeof(grinfo.filename));
+    pj_find_file(ctx, gridname, grinfo.filename, sizeof(grinfo.filename) - 1);
 
     /* grid format */
-    pj_strlcpy(grinfo.format, gridinfo->format, sizeof(grinfo.format));
+    strncpy (grinfo.format, gridinfo->format, sizeof(grinfo.format) - 1);
 
     /* grid size */
     grinfo.n_lon = gridinfo->ct->lim.lam;
@@ -951,12 +953,14 @@ PJ_INIT_INFO proj_init_info(const char *initname){
         return ininfo;
     }
 
-    pj_strlcpy(ininfo.name, initname, sizeof(ininfo.name));
+    /* The initial memset (0) makes strncpy safe here */
+    strncpy (ininfo.name, initname, sizeof(ininfo.name) - 1);
     strcpy(ininfo.origin, "Unknown");
     strcpy(ininfo.version, "Unknown");
     strcpy(ininfo.lastupdate, "Unknown");
 
-    pj_strlcpy(key, initname, 64); /* make room for ":metadata\0" at the end */
+    strncpy (key, initname, 64); /* make room for ":metadata\0" at the end */
+    key[64] = 0;
     strncat(key, ":metadata", 9);
     strcpy(param, "+init=");
     strncat(param, key, 73);
@@ -964,17 +968,14 @@ PJ_INIT_INFO proj_init_info(const char *initname){
     start = pj_mkparam(param);
     pj_expand_init(ctx, start);
 
-    if (pj_param(ctx, start, "tversion").i) {
-        pj_strlcpy(ininfo.version, pj_param(ctx, start, "sversion").s, sizeof(ininfo.version));
-    }
+    if (pj_param(ctx, start, "tversion").i)
+        strncpy(ininfo.version, pj_param(ctx, start, "sversion").s, sizeof(ininfo.version) - 1);
 
-    if (pj_param(ctx, start, "torigin").i) {
-        pj_strlcpy(ininfo.origin, pj_param(ctx, start, "sorigin").s, sizeof(ininfo.origin));
-    }
+    if (pj_param(ctx, start, "torigin").i)
+        strncpy(ininfo.origin, pj_param(ctx, start, "sorigin").s, sizeof(ininfo.origin) - 1);
 
-    if (pj_param(ctx, start, "tlastupdate").i) {
-        pj_strlcpy(ininfo.lastupdate, pj_param(ctx, start, "slastupdate").s, sizeof(ininfo.lastupdate));
-    }
+    if (pj_param(ctx, start, "tlastupdate").i)
+        strncpy(ininfo.lastupdate, pj_param(ctx, start, "slastupdate").s, sizeof(ininfo.lastupdate) - 1);
 
     for ( ; start; start = next) {
         next = start->next;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -793,6 +793,8 @@ PJ_INFO proj_info (void) {
     if (0 != info.version)
         return info;
 
+    pj_acquire_lock();
+
     info.major = PROJ_VERSION_MAJOR;
     info.minor = PROJ_VERSION_MINOR;
     info.patch = PROJ_VERSION_PATCH;
@@ -823,8 +825,9 @@ PJ_INFO proj_info (void) {
         if (0==buf)
             return info;
     }
-
     info.searchpath = buf;
+
+    pj_release_lock();
     return info;
 }
 

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -738,6 +738,11 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
 ******************************************************************************/
     char *p;
     size_t len, applen = 0, buflen = 0;
+#ifdef _WIN32
+    char *delim = ";";
+#else
+    char *delim = ":";
+#endif
 
     /* Nothing to do? */
     if (0 == app)
@@ -749,16 +754,16 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
     /* Start checking whether buf is long enough */
     if (0 != buf)
         buflen = strlen (buf);
-    len = buflen+applen+2;
+    len = buflen+applen+strlen (delim) + 1;
 
     /* "pj_realloc", so to speak */
     if (*buf_size < len) {
-        p = pj_calloc (2 * len + 2, sizeof (char));
+        p = pj_calloc (2 * len, sizeof (char));
         if (0==p) {
             pj_dealloc (buf);
             return 0;
         }
-        *buf_size = 2 * len + 2;
+        *buf_size = 2 * len;
         if (buf != 0)
             strcpy (p, buf);
         pj_dealloc (buf);
@@ -769,7 +774,6 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
     if (0 != buflen)
         strcat (buf, ";");
     strcat (buf, app);
-printf ("buf_size=%3.3d,  buf=[%s]\n", (int) *buf_size, buf);
     return buf;
 }
 
@@ -798,7 +802,6 @@ PJ_INFO proj_info (void) {
         return info;
     }
 
-    info_initialized = 1;
     info.major = PROJ_VERSION_MAJOR;
     info.minor = PROJ_VERSION_MINOR;
     info.patch = PROJ_VERSION_PATCH;
@@ -812,8 +815,6 @@ PJ_INFO proj_info (void) {
     info.version    = version;
     info.release    = pj_get_release ();
 
-printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
-
     /* build search path string */
     buf = path_append (buf, getenv ("HOME"), &buf_size);
     buf = path_append (buf, getenv ("PROJ_LIB"), &buf_size);
@@ -824,8 +825,6 @@ printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
     for (i = 0;  i < n;  i++)
         buf = path_append (buf, paths[i], &buf_size);
     info.searchpath = buf ? buf : empty;
-
-printf ("buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
 
     info.paths = paths;
     info.path_count = n;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -724,22 +724,74 @@ PJ_CONTEXT *proj_context_destroy (PJ_CONTEXT *ctx) {
 }
 
 
+
+
+
+
 /*****************************************************************************/
-PJ_INFO proj_info(void) {
+static char *path_append (char *buf, const char *app, size_t *buf_size) {
+/******************************************************************************
+    Helper for proj_info() below. Append app to buf, separated by a
+    semicolon. Also handle allocation of longer buffer if needed.
+
+    Returns buffer and adjusts *buf_size through provided pointer arg.
+******************************************************************************/
+    char *p;
+    size_t len, applen = 0, buflen = 0;
+
+    /* Nothing to do? */
+    if (0 == app)
+        return buf;
+    applen = strlen (app);
+    if (0 == applen)
+        return buf;
+
+    /* Start checking whether buf is long enough */
+    if (0 != buf)
+        buflen = strlen (buf);
+    len = buflen+applen+2;
+
+    /* "pj_realloc", so to speak */
+    if (*buf_size < len) {
+        p = pj_calloc (2 * len, sizeof (char));
+        if (0==p) {
+            pj_dealloc (buf);
+            return 0;
+        }
+        *buf_size = 2 * len;
+        if (buf != 0)
+            strcpy (p, buf);
+        buf = p;
+    }
+
+    /* Only append a semicolon if something's already there */
+    if (0 != buflen)
+        strcat (buf, ";");
+    strcat (buf, app);
+    return buf;
+}
+
+static const char *empty = {""};
+static char version[64]  = {""};
+static PJ_INFO info = {0, 0, 0, 0, 0, 0};
+
+
+/*****************************************************************************/
+PJ_INFO proj_info (void) {
 /******************************************************************************
     Basic info about the current instance of the PROJ.4 library.
 
     Returns PJ_INFO struct. Searchpath member of the struct is truncated to 512
     characters.
-
 ******************************************************************************/
-    PJ_INFO info;
     const char * const *paths;
-    char *tmpstr;
     int i, n;
-    size_t len = 0;
 
-    memset(&info, 0, sizeof(PJ_INFO));
+    size_t  buf_size = 0;
+    char   *buf = 0;
+
+    if (0 != info.version)
+        return info;
 
     info.major = PROJ_VERSION_MAJOR;
     info.minor = PROJ_VERSION_MINOR;
@@ -748,46 +800,31 @@ PJ_INFO proj_info(void) {
     /* This is a controlled environment, so no risk of sprintf buffer
        overflow. A normal version string is xx.yy.zz which is 8 characters
        long and there is room for 64 bytes in the version string. */
-    sprintf(info.version, "%d.%d.%d", info.major, info.minor, info.patch);
+    sprintf(version, "%d.%d.%d", info.major, info.minor, info.patch);
 
-    pj_strlcpy(info.release, pj_get_release(), sizeof(info.release));
-
+    info.searchpath = empty;
+    info.version    = version;
+    info.release    = pj_get_release();
 
     /* build search path string */
-    tmpstr = getenv("HOME");
-    if (tmpstr != NULL) {
-        pj_strlcpy(info.searchpath, tmpstr, sizeof(info.searchpath));
-    }
+    buf = path_append (buf, getenv("HOME"), &buf_size);
+    if (0==buf)
+        return info;
 
-    tmpstr = getenv("PROJ_LIB");
-    if (tmpstr != NULL) {
-        if (strlen(info.searchpath) != 0) {
-            /* $HOME already in path */
-            strcat(info.searchpath, ";");
-            len = strlen(tmpstr);
-            strncat(info.searchpath, tmpstr, sizeof(info.searchpath)-len-1);
-        } else {
-            /* path is empty */
-            pj_strlcpy(info.searchpath, tmpstr, sizeof(info.searchpath));
-        }
-    }
+    buf = path_append (buf, getenv("PROJ_LIB"), &buf_size);
+    if (0==buf)
+        return info;
 
     paths = proj_get_searchpath();
     n = proj_get_path_count();
 
-    for (i=0; i<n; i++) {
-        if (strlen(info.searchpath)+strlen(paths[i]) >= 511)
-            continue;
-
-        if (strlen(info.searchpath) != 0) {
-            strcat(info.searchpath, ";");
-            len = strlen(paths[i]);
-            strncat(info.searchpath, paths[i], sizeof(info.searchpath)-len-1);
-        } else {
-            pj_strlcpy(info.searchpath, paths[i], sizeof(info.searchpath));
-        }
+    for (i = 0;  i < n;  i++) {
+        buf = path_append (buf, paths[i], &buf_size);
+        if (0==buf)
+            return info;
     }
 
+    info.searchpath = buf;
     return info;
 }
 
@@ -798,37 +835,41 @@ PJ_PROJ_INFO proj_pj_info(PJ *P) {
     Basic info about a particular instance of a projection object.
 
     Returns PJ_PROJ_INFO struct.
-
 ******************************************************************************/
-    PJ_PROJ_INFO info;
+    PJ_PROJ_INFO pjinfo;
     char *def;
 
-    memset(&info, 0, sizeof(PJ_PROJ_INFO));
+    memset(&pjinfo, 0, sizeof(PJ_PROJ_INFO));
 
     /* Expected accuracy of the transformation. Hardcoded for now, will be improved */
     /* later. Most likely to be used when a transformation is set up with           */
     /* proj_create_crs_to_crs in a future version that leverages the EPSG database. */
-    info.accuracy = -1.0;
+    pjinfo.accuracy = -1.0;
 
-    if (!P) {
-        return info;
-    }
+    if (0==P)
+        return pjinfo;
 
     /* projection id */
     if (pj_param(P->ctx, P->params, "tproj").i)
-        pj_strlcpy(info.id, pj_param(P->ctx, P->params, "sproj").s, sizeof(info.id));
+        pjinfo.id = pj_param(P->ctx, P->params, "sproj").s;
 
     /* projection description */
-    pj_strlcpy(info.description, P->descr, sizeof(info.description));
+    pjinfo.description = P->descr;
 
     /* projection definition */
-    def = pj_get_def(P, 0); /* pj_get_def takes a non-const PJ pointer */
-    pj_strlcpy(info.definition, &def[1], sizeof(info.definition)); /* def includes a leading space */
-    pj_dealloc(def);
+    if (P->def_full)
+        def = P->def_full;
+    else
+        def = pj_get_def(P, 0); /* pj_get_def takes a non-const PJ pointer */
+    if (0==def)
+        pjinfo.definition = empty;
+    else
+        pjinfo.definition = pj_shrink (def);
+    /* Make pj_free clean this up eventually */
+    P->def_full = def;
 
-    info.has_inverse = pj_has_inverse(P);
-
-    return info;
+    pjinfo.has_inverse = pj_has_inverse(P);
+    return pjinfo;
 }
 
 
@@ -838,47 +879,46 @@ PJ_GRID_INFO proj_grid_info(const char *gridname) {
     Information about a named datum grid.
 
     Returns PJ_GRID_INFO struct.
-
 ******************************************************************************/
-    PJ_GRID_INFO info;
+    PJ_GRID_INFO grinfo;
 
     /*PJ_CONTEXT *ctx = proj_context_create(); */
     PJ_CONTEXT *ctx = pj_get_default_ctx();
     PJ_GRIDINFO *gridinfo = pj_gridinfo_init(ctx, gridname);
-    memset(&info, 0, sizeof(PJ_GRID_INFO));
+    memset(&grinfo, 0, sizeof(PJ_GRID_INFO));
 
     /* in case the grid wasn't found */
     if (gridinfo->filename == NULL) {
         pj_gridinfo_free(ctx, gridinfo);
-        strcpy(info.format, "missing");
-        return info;
+        strcpy(grinfo.format, "missing");
+        return grinfo;
     }
 
     /* name of grid */
-    pj_strlcpy(info.gridname, gridname, sizeof(info.gridname));
+    pj_strlcpy(grinfo.gridname, gridname, sizeof(grinfo.gridname));
 
     /* full path of grid */
-    pj_find_file(ctx, gridname, info.filename, sizeof(info.filename));
+    pj_find_file(ctx, gridname, grinfo.filename, sizeof(grinfo.filename));
 
     /* grid format */
-    pj_strlcpy(info.format, gridinfo->format, sizeof(info.format));
+    pj_strlcpy(grinfo.format, gridinfo->format, sizeof(grinfo.format));
 
     /* grid size */
-    info.n_lon = gridinfo->ct->lim.lam;
-    info.n_lat = gridinfo->ct->lim.phi;
+    grinfo.n_lon = gridinfo->ct->lim.lam;
+    grinfo.n_lat = gridinfo->ct->lim.phi;
 
     /* cell size */
-    info.cs_lon = gridinfo->ct->del.lam;
-    info.cs_lat = gridinfo->ct->del.phi;
+    grinfo.cs_lon = gridinfo->ct->del.lam;
+    grinfo.cs_lat = gridinfo->ct->del.phi;
 
     /* bounds of grid */
-    info.lowerleft  = gridinfo->ct->ll;
-    info.upperright.lam = info.lowerleft.lam + info.n_lon*info.cs_lon;
-    info.upperright.phi = info.lowerleft.phi + info.n_lat*info.cs_lat;
+    grinfo.lowerleft  = gridinfo->ct->ll;
+    grinfo.upperright.lam = grinfo.lowerleft.lam + grinfo.n_lon*grinfo.cs_lon;
+    grinfo.upperright.phi = grinfo.lowerleft.phi + grinfo.n_lat*grinfo.cs_lat;
 
     pj_gridinfo_free(ctx, gridinfo);
 
-    return info;
+    return grinfo;
 }
 
 
@@ -897,25 +937,24 @@ PJ_INIT_INFO proj_init_info(const char *initname){
 
     If the init file is found, but the metadata is missing, the value is
     set to "Unknown".
-
 ******************************************************************************/
     int file_found;
     char param[80], key[74];
     paralist *start, *next;
-    PJ_INIT_INFO info;
+    PJ_INIT_INFO ininfo;
     PJ_CONTEXT *ctx = pj_get_default_ctx();
 
-    memset(&info, 0, sizeof(PJ_INIT_INFO));
+    memset(&ininfo, 0, sizeof(PJ_INIT_INFO));
 
-    file_found = pj_find_file(ctx, initname, info.filename, sizeof(info.filename));
+    file_found = pj_find_file(ctx, initname, ininfo.filename, sizeof(ininfo.filename));
     if (!file_found || strlen(initname) > 64) {
-        return info;
+        return ininfo;
     }
 
-    pj_strlcpy(info.name, initname, sizeof(info.name));
-    strcpy(info.origin, "Unknown");
-    strcpy(info.version, "Unknown");
-    strcpy(info.lastupdate, "Unknown");
+    pj_strlcpy(ininfo.name, initname, sizeof(ininfo.name));
+    strcpy(ininfo.origin, "Unknown");
+    strcpy(ininfo.version, "Unknown");
+    strcpy(ininfo.lastupdate, "Unknown");
 
     pj_strlcpy(key, initname, 64); /* make room for ":metadata\0" at the end */
     strncat(key, ":metadata", 9);
@@ -926,15 +965,15 @@ PJ_INIT_INFO proj_init_info(const char *initname){
     pj_expand_init(ctx, start);
 
     if (pj_param(ctx, start, "tversion").i) {
-        pj_strlcpy(info.version, pj_param(ctx, start, "sversion").s, sizeof(info.version));
+        pj_strlcpy(ininfo.version, pj_param(ctx, start, "sversion").s, sizeof(ininfo.version));
     }
 
     if (pj_param(ctx, start, "torigin").i) {
-        pj_strlcpy(info.origin, pj_param(ctx, start, "sorigin").s, sizeof(info.origin));
+        pj_strlcpy(ininfo.origin, pj_param(ctx, start, "sorigin").s, sizeof(ininfo.origin));
     }
 
     if (pj_param(ctx, start, "tlastupdate").i) {
-        pj_strlcpy(info.lastupdate, pj_param(ctx, start, "slastupdate").s, sizeof(info.lastupdate));
+        pj_strlcpy(ininfo.lastupdate, pj_param(ctx, start, "slastupdate").s, sizeof(ininfo.lastupdate));
     }
 
     for ( ; start; start = next) {
@@ -942,7 +981,7 @@ PJ_INIT_INFO proj_init_info(const char *initname){
         pj_dalloc(start);
     }
 
-   return info;
+   return ininfo;
 }
 
 
@@ -957,7 +996,6 @@ PJ_FACTORS proj_factors(PJ *P, LP lp) {
 
     returns PJ_FACTORS. If unsuccessfull, error number is set and the
     struct returned contains NULL data.
-
 ******************************************************************************/
     PJ_FACTORS factors = {0,0,0,  0,0,0,  0,0,  0,0,0,0};
     struct FACTORS f;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -810,22 +810,13 @@ printf ("HOME=[%s],  PROJ_LIB=[%s]\n", getenv("HOME"), getenv("PROJ_LIB"));
 
         /* build search path string */
         buf = path_append (buf, getenv ("HOME"), &buf_size);
-        if (0==buf)
-            break;
-
         buf = path_append (buf, getenv ("PROJ_LIB"), &buf_size);
-        if (0==buf)
-            break;
 
         paths = proj_get_searchpath ();
         n = (size_t) proj_get_path_count ();
 
-        for (i = 0;  i < n;  i++) {
+        for (i = 0;  i < n;  i++)
             buf = path_append (buf, paths[i], &buf_size);
-printf ("loop: buf_size=%3.3d,  info.searchpath=[%s]\n", (int) buf_size, info.searchpath);
-            if (0==buf)
-                break;
-        }
         if (0==buf)
             break;
         info.searchpath = buf;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -792,6 +792,7 @@ PJ_INFO proj_info (void) {
 
     pj_acquire_lock ();
     while (0==info_initialized) {
+        info_initialized = 1;
         info.major = PROJ_VERSION_MAJOR;
         info.minor = PROJ_VERSION_MINOR;
         info.patch = PROJ_VERSION_PATCH;
@@ -827,7 +828,6 @@ PJ_INFO proj_info (void) {
         info.paths = paths;
         info.path_count = n;
 
-        info_initialized = 1;
     }
     pj_release_lock ();
     return info;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -761,6 +761,7 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
         *buf_size = 2 * len;
         if (buf != 0)
             strcpy (p, buf);
+        pj_dealloc (buf);
         buf = p;
     }
 

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -132,8 +132,6 @@ void proj_fileapi_set (PJ *P, void *fileapi);
 const char * const *proj_get_searchpath(void);
 int    proj_get_path_count(void);
 
-size_t pj_strlcpy(char *dst, const char *src, size_t siz);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/projects.h
+++ b/src/projects.h
@@ -231,6 +231,7 @@ struct PJconsts {
     projCtx_t *ctx;
     const char *descr;             /* From pj_list.h or individual PJ_*.c file */
     paralist *params;              /* Parameter list */
+    char *def_full;                /* Full textual definition (usually 0 - set by proj_pj_info) */
     char *def_size;                /* Shape and size parameters extracted from params */
     char *def_shape;
     char *def_spherification;


### PR DESCRIPTION
A number of the fixed length strings in the INFO structs are simply
reflections of material that already exists as static or preallocated strings at a
number of places in the library (or in the case of PJ_INFO, really
*should* exist, and is now implemented).

This PR replaces these cases of constant length strings with const
char pointers. The usage syntax is unchanged, and so is the nice
property of having the return value allocated on the stack, and
hence not requiring explicit memory management by the caller.

proj_info now only does setup once - and the searchpath entry of
PJ_INFO is not arbitrarily truncated at 512 bytes. Repeated calls
simply returns a copy of already prepared material.

The id, description and definition entries of PJ_PROJ_INFO are now
also guaranteed to hold the entire text of the corresponding static or preallocated
string, by being represented by a const char pointer to that actual
string.

PJ_GRID_INFO and PJ_INIT_INFO (i.e. the two smallest INFO structs)
are unchanged.

As part of the work, the remaining calls to pj_strlcpy were also eliminated, so pj_strlcpy is removed.