### PR TITLE
Let gie skip tests when specific errors are returned.

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -1739,9 +1739,9 @@ static int pj_cart_selftest (void) {
     proj_destroy(P);
 
     /* proj_grid_info() */
-    grid_info = proj_grid_info("egm96_15.gtx");
+    grid_info = proj_grid_info("null");
     if ( strlen(grid_info.filename) == 0 )            return 64;
-    if ( strcmp(grid_info.gridname, "egm96_15.gtx") ) return 65;
+    if ( strcmp(grid_info.gridname, "null") ) return 65;
     grid_info = proj_grid_info("nonexistinggrid");
     if ( strlen(grid_info.filename) > 0 )             return 66;
 

--- a/src/pj_malloc.c
+++ b/src/pj_malloc.c
@@ -182,7 +182,7 @@ void pj_free(PJ *P) {
     /* to be called as the last step of the local destructor     */
     /* pointed to by P->destructor. In most cases,               */
     /* pj_default_destructor actually *is* what is pointed to    */
-    P->destructor (P, 0);
+    P->destructor (P, proj_errno(P));
 }
 
 

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -74,6 +74,7 @@ operation proj=latlong ellps=intl
 operation  proj=latlong nadgrids=nzgd2kgrid0005.gsb  ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 1 nm
+ignore    pjd_err_failed_to_load_grid
 accept    173                 -45                  0 0
 expect    172.999892181021551 -45.001620431954613  0 0
 direction inverse
@@ -87,6 +88,7 @@ expect    173                 -45                  0 0
 operation  proj=latlong geoidgrids=egm96_15.gtx  ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 15 cm      # lax tolerance due to widespread bad egm96 file
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5   0
 expect    12.5 55.5 -36.0213
 direction inverse
@@ -96,6 +98,7 @@ expect    12.5 55.5  0
 operation  proj=merc geoidgrids=egm96_15.gtx  ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 0.1 mm
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5 0
 expect    1391493.63492   7424275.19462  -36.0213
 direction inverse
@@ -111,6 +114,7 @@ Same as the two above, but also do axis swapping.
 operation  proj=latlong geoidgrids=egm96_15.gtx  axis=neu ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 15 cm      # lax tolerance due to widely distributed, bad egm96 file
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5  0
 expect    55.5 12.5 -36.0213
 direction inverse
@@ -120,6 +124,7 @@ expect    12.5 55.5  0
 operation  proj=latlong geoidgrids=egm96_15.gtx  axis=dne ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 15 cm      # lax tolerance due to widely distributed, bad egm96 file
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5  0
 expect    36.0213 55.5 12.5
 direction inverse
@@ -129,6 +134,7 @@ expect    12.5 55.5  0
 operation  proj=merc geoidgrids=egm96_15.gtx  ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 0.1 mm
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5 0
 expect    1391493.63492   7424275.19462  -36.0213
 direction inverse
@@ -143,6 +149,7 @@ Some more complex axis swapping.
 operation  proj=latlong geoidgrids=egm96_15.gtx  axis=nue ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 15 cm      # lax tolerance due to widely distributed, bad egm96 file
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5 0
 expect    55.5 -36.0213 12.5
 direction inverse
@@ -152,6 +159,7 @@ expect    12.5 55.5 0
 operation  proj=merc geoidgrids=egm96_15.gtx axis=sue ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 15 cm
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5 0
 expect    -7424275.1946 -36.0213  1391493.6349 0.0000
 direction inverse

--- a/test/gie/Makefile.am
+++ b/test/gie/Makefile.am
@@ -10,28 +10,30 @@ EXTRA_DIST = 4D-API_cs2cs-style.gie \
 	more_builtins.gie \
 	unitconvert.gie
 
+PROJ_LIB ?= $(top_srcdir)/nad
+
 4D-API-cs2cs-style: 4D-API_cs2cs-style.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 GDA: GDA.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 axisswap: axisswap.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 builtins: builtins.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 deformation: deformation.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 ellipsoid: ellipsoid.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 more_builtins: more_builtins.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 unitconvert: unitconvert.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 check-local: 4D-API-cs2cs-style GDA axisswap builtins deformation ellipsoid more_builtins unitconvert

--- a/test/gie/deformation.gie
+++ b/test/gie/deformation.gie
@@ -18,6 +18,7 @@ operation   +proj=deformation +xy_grids=alaska +z_grids=egm96_15.gtx
             +t_epoch=2016.0 +t_obs=2000.0 +ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance   0.1 mm
+ignore      pjd_err_failed_to_load_grid
 accept      -3004295.5882503074 -1093474.1690603832 5500477.1338251457
 expect      -3004295.7025       -1093474.2106       5500477.3444
 roundtrip   5
@@ -29,6 +30,7 @@ operation   +proj=deformation
             +xy_grids=alaska +z_grids=egm96_15.gtx +t_epoch=2016.0 +ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance   0.1 mm
+ignore      pjd_err_failed_to_load_grid
 accept      -3004295.5882503074 -1093474.1690603832 5500477.1338251457 2000.0
 expect      -3004295.7025       -1093474.2106       5500477.3444       2000.0
 roundtrip   5

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -190,6 +190,7 @@ This is annoying, but must be handled elsewhere. We jump through the hoop by
 setting a very lax tolerance.
 -------------------------------------------------------------------------------
 tolerance 15 cm
+ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5   0                  0
 expect    12.5 55.5 -36.021305084228516  0
 
@@ -214,6 +215,7 @@ Some tests from PJ_hgridshift.c
 operation  proj=hgridshift +grids=nzgd2kgrid0005.gsb  ellps=GRS80
 -------------------------------------------------------------------------------
 tolerance 1 nm
+ignore    pjd_err_failed_to_load_grid
 accept    173 -45 0 0
 roundtrip 100
 -------------------------------------------------------------------------------

--- a/test/gigs/Makefile.am
+++ b/test/gigs/Makefile.am
@@ -20,57 +20,57 @@ EXTRA_DIST = \
 	5201.gie \
 	5208.gie
 
+PROJ_LIB ?= $(top_srcdir)/nad
 
 5101.1: 5101.1-jhs.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5101.2: 5101.2-jhs.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5101.3: 5101.3-jhs.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5101.4: 5101.4-jhs-etmerc.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5102.1: 5102.1.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5103.1: 5103.1.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5103.2: 5103.2.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5103.3: 5103.3.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5105.2: 5105.2.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5106: 5106.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5107: 5107.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5109: 5109.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5111.1: 5111.1.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5112: 5112.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5113: 5113.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5201: 5201.gie
-	$(GIEEXE) $<
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 5208: 5208.gie
-	$(GIEEXE) $<
-
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
 check-local: 5101.1 5101.2 5101.3 5101.4 5102.1 5103.1 5103.2 5103.3 5105.2 5106 5107 5109 5111.1 5112 5113 5201 5208


### PR DESCRIPTION
Closes #774.

Implemented more or less as specified in the above issue. I've chosen to use `ignore` instead of the suggested `skip_on_error` keyword. 

I still need to adjust the test material in `test/gie` and `test/gigs`.

Below is a test file and the returned output when run by gie:

```
<gie>

-------------------------------------------------------------------------------
operation  proj=hgridshift +grids=nzgd2kgrid0005.gsb  ellps=GRS80
-------------------------------------------------------------------------------
tolerance 1 nm
ignore    pjd_err_failed_to_load_grid
accept    173 -45 0 0
roundtrip 100
-------------------------------------------------------------------------------
expect    172.999892181021551 -45.001620431954613  0 0
direction inverse
accept    172.999892181021551 -45.001620431954613  0 0
expect    173 -45 0 0
-------------------------------------------------------------------------------

-------------------------------------------------------------------------------
operation  proj=hgridshift +grids=nzgd2kgrid0003.gsb  ellps=GRS80
-------------------------------------------------------------------------------
tolerance 1 nm
ignore    pjd_err_failed_to_load_grid
accept    173 -45 0 0
roundtrip 100
-------------------------------------------------------------------------------
expect    172.999892181021551 -45.001620431954613  0 0
direction inverse
accept    172.999892181021551 -45.001620431954613  0 0
expect    173 -45 0 0
-------------------------------------------------------------------------------

-------------------------------------------------------------------------------
operation  proj=hgridshift +grids=nzgd2kgrid0004.gsb  ellps=GRS80
-------------------------------------------------------------------------------
tolerance 1 nm
accept    173 -45 0 0
roundtrip 100
-------------------------------------------------------------------------------
expect    172.999892181021551 -45.001620431954613  0 0
direction inverse
accept    172.999892181021551 -45.001620431954613  0 0
expect    173 -45 0 0
-------------------------------------------------------------------------------

</gie>
```

```
λ bin\gie.exe test.gie
-------------------------------------------------------------------------------
Reading file 'test.gie'
-------------------------------------------------------------------------------
proj=hgridshift +grids=nzgd2kgrid0004.gsb ellps=GRS80
-------------------------------------------------------------------------------
Invalid operation definition in line no. 32: failed to load datum shift file
-------------------------------------------------------------------------------
proj=hgridshift +grids=nzgd2kgrid0004.gsb ellps=GRS80
-------------------------------------------------------------------------------
Invalid operation definition in line no. 32: failed to load datum shift file
-------------------------------------------------------------------------------
total:  3 tests succeeded,  3 tests skipped,  3 tests FAILED!
-------------------------------------------------------------------------------
```
