### PR TITLE
A few repairs in and around pj_init.c

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -1836,12 +1836,12 @@ static int pj_cart_selftest (void) {
 
     /* linear in and out */
     P = proj_create(PJ_DEFAULT_CTX,
-        " +proj=helmert +ellps=GRS80"
+        " +proj=helmert"
         " +x=0.0127 +y=0.0065 +z=-0.0209 +s=0.00195"
         " +rx=-0.00039 +ry=0.00080 +rz=-0.00114"
         " +dx=-0.0029 +dy=-0.0002 +dz=-0.0006 +ds=0.00001"
         " +drx=-0.00011 +dry=-0.00019 +drz=0.00007"
-        " +t_epoch=1988.0 +transpose"
+        " +t_epoch=1988.0 +transpose +no_defs"
     );
     if (0==P) return 0;
     if (proj_angular_input (P, PJ_FWD))  return 116;
@@ -1853,14 +1853,15 @@ static int pj_cart_selftest (void) {
     if (proj_angular_input (P, PJ_INV))  return 121;
     if (proj_angular_output (P, PJ_FWD)) return 122;
     if (proj_angular_output (P, PJ_INV)) return 123;
-    proj_destroy(P);
 
+    /* We specified "no_defs" but didn't give any ellipsoid info */
+    /* pj_init_ctx should defualt to WGS84 */
+    if (P->a != 6378137.0) return 124;
+    if (P->f != 1.0/298.257223563) return 125;
+    proj_destroy(P);
 
     return 0;
 }
-
-
-
 
 
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -470,22 +470,20 @@ pj_init(int argc, char **argv) {
 }
 
 
-typedef    PJ *(constructor)(PJ *);
-
-static constructor *pj_constructor (const char *name) {
+static PJ_CONSTRUCTOR pj_locate_constructor (const char *name) {
     int i;
     char *s;
     for (i = 0; (s = pj_list[i].id) && strcmp(name, s) ; ++i) ;
     if (0==s)
         return 0;
-    return (constructor *) pj_list[i].proj;
+    return (PJ_CONSTRUCTOR) pj_list[i].proj;
 }
 
 
 PJ *
 pj_init_ctx(projCtx ctx, int argc, char **argv) {
     char *s, *name;
-    constructor *proj;
+    PJ_CONSTRUCTOR proj;
     paralist *curr, *init, *start;
     int i;
     int err;
@@ -559,7 +557,7 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
         return pj_dealloc_params (ctx, start, PJD_ERR_PROJ_NOT_NAMED);
     name += 5;
 
-    proj = pj_constructor (name);
+    proj = pj_locate_constructor (name);
     if (0==proj)
         return pj_dealloc_params (ctx, start, PJD_ERR_UNKNOWN_PROJECTION_ID);
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -509,7 +509,7 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
             n_inits++;
     }
 
-    /* can't have nested pipeline directly */
+    /* can't have nested pipelines directly */
     if (n_pipelines > 1) {
         pj_ctx_set_errno (ctx, PJD_ERR_MALFORMED_PIPELINE);
         return 0;

--- a/src/projects.h
+++ b/src/projects.h
@@ -218,6 +218,37 @@ struct PJ_AREA {
 struct projCtx_t;
 typedef struct projCtx_t projCtx_t;
 
+/*****************************************************************************
+
+    Some function types that are especially useful when working with PJs
+
+******************************************************************************
+
+PJ_CONSTRUCTOR:
+
+    A function taking a pointer-to-PJ as arg, and returning a pointer-to-PJ.
+    Historically called twice: First with a 0 argument, to allocate memory,
+    second with the first return value as argument, for actual setup.
+
+PJ_DESTRUCTOR:
+
+    A function taking a pointer-to-PJ and an integer as args, then first
+    handling the deallocation of the PJ, afterwards handing the integer over
+    to the error reporting subsystem, and finally returning a null pointer in
+    support of the "return free (P)" (aka "get the hell out of here") idiom.
+
+PJ_OPERATOR:
+
+    A function taking a PJ_COORD and a pointer-to-PJ as args, applying the
+    PJ to the PJ_COORD, and returning the resulting PJ_COORD.
+
+*****************************************************************************/
+typedef    PJ       *(* PJ_CONSTRUCTOR) (PJ *);
+typedef    void     *(* PJ_DESTRUCTOR)  (PJ *, int);
+typedef    PJ_COORD  (* PJ_OPERATOR)    (PJ_COORD, PJ *);
+/****************************************************************************/
+
+
 
 /* base projection data structure */
 struct PJconsts {
@@ -267,10 +298,10 @@ struct PJconsts {
     LP  (*inv)(XY,    PJ *);
     XYZ (*fwd3d)(LPZ, PJ *);
     LPZ (*inv3d)(XYZ, PJ *);
-    PJ_COORD (*fwd4d)(PJ_COORD, PJ *);
-    PJ_COORD (*inv4d)(PJ_COORD, PJ *);
+    PJ_OPERATOR fwd4d;
+    PJ_OPERATOR inv4d;
 
-    void *(*destructor)(PJ *, int);
+    PJ_DESTRUCTOR destructor;
 
 
     /*************************************************************************************


### PR DESCRIPTION
* The defaulting-to-WGS84-ellipsoid handling introduced in 82cbab19db5ec8fd7b2fec7f6faf75993381f105 didn't work for `need_ellps=0` in connection with `no_defs` set.

* Some recurring function types (`PJ_CONSTRUCTOR`, `PJ_DESTRUCTOR` and `PJ_OPERATOR`) were typedeffed for clarity.