### PR TITLE
Make proj_pj_info work correctly for pipelines

### DIFF
--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -240,11 +240,13 @@ static PJ *pj_create_pipeline (PJ *P, size_t steps) {
 
 
 
-/* count the number of args in pipeline definition */
+/* count the number of args in pipeline definition, and mark all args as used */
 static size_t argc_params (paralist *params) {
     size_t argc = 0;
-    for (; params != 0; params = params->next)
+    for (; params != 0; params = params->next) {
         argc++;
+        params->used = 1;
+    }
     return ++argc;  /* one extra for the sentinel */
 }
 
@@ -414,7 +416,7 @@ PJ *OPERATION(pipeline,0) {
         err = proj_errno_reset (P);
 
         next_step = proj_create_argv (P->ctx, current_argc, current_argv);
-        proj_log_trace (P, "Pipeline: Step %d at %p", i, next_step);
+        proj_log_trace (P, "Pipeline: Step %d (%s) at %p", i, current_argv[0], next_step);
 
         if (0==next_step) {
             /* The step init failed, but possibly without setting errno. If so, we say "malformed" */
@@ -436,7 +438,7 @@ PJ *OPERATION(pipeline,0) {
 
         P->opaque->pipeline[i+1] = next_step;
 
-        proj_log_trace (P, "Pipeline at [%p]:    step at [%p] done", P, next_step);
+        proj_log_trace (P, "Pipeline at [%p]:    step at [%p] (%s) done", P, next_step, current_argv[0]);
     }
 
     /* Require a forward path through the pipeline */

--- a/src/cct.c
+++ b/src/cct.c
@@ -151,6 +151,7 @@ static const char usage[] = {
 int main(int argc, char **argv) {
     PJ *P;
     PJ_COORD point;
+    PJ_PROJ_INFO info;
     OPTARGS *o;
     FILE *fout = stdout;
     char *buf;
@@ -220,6 +221,11 @@ int main(int argc, char **argv) {
         if (stdout != fout)
             fclose (fout);
         return 1;
+    }
+
+    if (verbose > 4) {
+        info = proj_pj_info (P);
+        fprintf (stdout, "Final: %s argc=%d pargc=%d\n", info.definition, argc, o->pargc);
     }
 
     if (direction==-1) {


### PR DESCRIPTION
Due to the slightly involved way a pipeline is set up, only a small
subset of the definition parameters are directly read by the pj_init
code. The remaining parameters will not get their "used" flag set,
and for that reason will not be included in the projection definition
element of a PJ_PROJ_INFO, returned by proj_pj_info.

For now, we force the "used" flag of all elements of a pipeline to be
set. The code is tested by introducing cct functionality for printing
the projection definition used.