### PR TITLE
Ensure cs2cs emulation gets correct ellipsoid defn

### DIFF
--- a/src/pj_geocent.c
+++ b/src/pj_geocent.c
@@ -48,7 +48,7 @@ static LP inverse(XY xy, PJ *P) {
     return lp;
 }
 
-PJ *PROJECTION(geocent) {
+PJ *CONVERSION (geocent, 0) {
     P->is_geocent = 1;
     P->x0 = 0.0;
     P->y0 = 0.0;

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -414,6 +414,8 @@ static int pj_cs2cs_emulation_setup (PJ *P) {
 If any cs2cs style modifiers are given (axis=..., towgs84=..., ) create the 4D API
 equivalent operations, so the preparation and finalization steps in the pj_inv/pj_fwd
 invocators can emulate the behaviour of pj_transform and the cs2cs app.
+
+Returns 1 on success, 0 on failure
 **************************************************************************************/
     PJ *Q;
     paralist *p;
@@ -502,12 +504,11 @@ invocators can emulate the behaviour of pj_transform and the cs2cs app.
     /* We also need cartesian/geographical transformations if we are working in */
     /* geocentric/cartesian space or we need to do a Helmert transform.         */
     if (P->is_geocent || P->helmert) {
-        char def[100];
-        sprintf (def, "break_cs2cs_recursion     proj=cart");
+        char def[150];
+        sprintf (def, "break_cs2cs_recursion     proj=cart   a=%40.20g  f=%40.20g", P->a, P->f);
         Q = proj_create (P->ctx, def);
         if (0==Q)
             return 0;
-        pj_inherit_ellipsoid_def (P, Q);
         P->cart = skip_prep_fin (Q);
 
         sprintf (def, "break_cs2cs_recursion     proj=cart  ellps=WGS84");
@@ -519,6 +520,7 @@ invocators can emulate the behaviour of pj_transform and the cs2cs app.
 
     return 1;
 }
+
 
 
 /*************************************************************************************/

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -22,7 +22,7 @@ Test the handling of the +towgs84 parameter.
 This example is from Lotti Jivall: "Simplified transformations from
 ITRF2008/IGS08 to ETRS89 for maritime applications" (see also more_builtins.gie)
 -------------------------------------------------------------------------------
-operation  proj=geocent ellps=WGS84
+operation  proj=geocent
            towgs84 = 0.676780, 0.654950, -0.528270,
                     -0.022742, 0.012667,  0.022704,
                     -0.01070
@@ -34,7 +34,6 @@ direction inverse
 accept     3565285.00000000  855949.00000000  5201383.00000000
 expect     3565285.41342351  855948.67986759  5201382.72939791
 -------------------------------------------------------------------------------
-
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Copy ellipsoid definition for proj=cart directly into the
proj_create call, rather than calling pj_inherit_ellipsoid_def
afterwards.

Previously, the ellipsoid definition was left out from the call.

pj_init_ctx would then pick up WGS84 from proj_def.dat, and the
init would succeed (and the possibly wrong ellipsoid definition
would later on be overwritten with the correct values by
pj_inherit_ellipsoid_def.

But if PROJ_LIB was not set or proj_def.dat was inaccessible for
other reasons, things went wrong.