### PR TITLE
proj_errno_reset: Also reset pj_errno

### DIFF
--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -734,6 +734,7 @@ int proj_errno_reset (const PJ *P) {
 
     pj_ctx_set_errno (pj_get_ctx ((PJ *) P), 0);
     errno = 0;
+    pj_errno = 0;
     return last_errno;
 }
 


### PR DESCRIPTION
Related to [this PostGIS ticket](https://trac.osgeo.org/postgis/ticket/4016). It has been temporarily solve by setting it manually after an [error](https://github.com/postgis/postgis/blob/f58c2049c3dfa9704ed3445d17cc4e9c94241646/liblwgeom/lwgeom_transform.c#L151) but I understand it was an unintended behaviour change and it should be handled here.

I've removed the postgis patch and applied this PR and the behaviour remains the same as with 4.9.3.