### PR TITLE
Download BETA2007 grid from proj-datumgrid package in CI scripts.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,7 @@ test_script:
   - cd %PROJ_LIB%
   - curl -O http://download.osgeo.org/proj/proj-datumgrid-1.6.zip
   - curl -O http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx
+  - curl -O -k https://raw.githubusercontent.com/OSGeo/proj-datumgrid/master/BETA2007.gsb
   - 7z e -aoa -y proj-datumgrid-1.6.zip
   - dir
   - cd ..
@@ -75,4 +76,3 @@ test_script:
   - gie.exe ..\test\gie\*.gie ..\test\gigs\*.gie
 
 deploy: off
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ proj_add_gie_test("Deformation" "gie/deformation.gie")
 proj_add_gie_test("Ellipsoid" "gie/ellipsoid.gie")
 proj_add_gie_test("GDA" "gie/GDA.gie")
 proj_add_gie_test("4D-API-cs2cs-style" "gie/4D-API_cs2cs-style.gie")
+proj_add_gie_test("DHDN_ETRS89" "gie/DHDN_ETRS89.gie")
 
 # GIGS tests. Uncommented tests are expected to fail due to issues with
 # various projections. Should be investigated further and fixed.

--- a/test/gie/Makefile.am
+++ b/test/gie/Makefile.am
@@ -8,7 +8,8 @@ EXTRA_DIST = 4D-API_cs2cs-style.gie \
 	deformation.gie \
 	ellipsoid.gie \
 	more_builtins.gie \
-	unitconvert.gie
+	unitconvert.gie \
+	DHDN_ETRS89.gie
 
 PROJ_LIB ?= $(top_srcdir)/nad
 
@@ -36,4 +37,7 @@ more_builtins: more_builtins.gie
 unitconvert: unitconvert.gie
 	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
 
-check-local: 4D-API-cs2cs-style GDA axisswap builtins deformation ellipsoid more_builtins unitconvert
+DHDN_ETRS89:
+	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<
+
+check-local: 4D-API-cs2cs-style GDA axisswap builtins deformation ellipsoid more_builtins unitconvert DHDN_ETRS89

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -7,6 +7,7 @@ wget http://download.osgeo.org/proj/proj-datumgrid-1.6.zip
 cd nad
 unzip -o ../proj-datumgrid-1.6.zip
 wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx
+wget https://raw.githubusercontent.com/OSGeo/proj-datumgrid/master/BETA2007.gsb
 GRIDDIR=`pwd`
 echo $GRIDDIR
 cd ..


### PR DESCRIPTION
Following PR #806 which removed various grids from nad/, we now have
to download the BETA2007 grid before that DHDN_ETRS89 test can pass
successfully.

I am downloading the BETA2007 grid individually instead of downloading the datumgrids package because I don't want to download ~100 MB every time the CI systems are invoked.