### PR TITLE
Don't reset errno when skipping tests.

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -332,7 +332,6 @@ static int another_failure (void) {
 static int another_skip (void) {
     T.op_skip++;
     T.total_skip++;
-    proj_errno_reset (T.P);
     return 0;
 }
 


### PR DESCRIPTION
The error number should not be reset until a new instance of "operation
..." is reached. The ignore-feature initially worked by accident since
pj_errno was not being reset when calling proj_errno_reset. This was
fixed in #808, which subsequently caused ignored tests to fail.

Closes #819 