### PR TITLE
Rerun tests without grids not included in proj-datumgrid.

### DIFF
--- a/travis/install.sh
+++ b/travis/install.sh
@@ -82,4 +82,8 @@ if [ $TRAVIS_OS_NAME == "osx" ]; then
 make -j3
 PROJ_LIB=$GRIDDIR make check
 
+# Rerun tests without grids not included in proj-datumgrid
+rm -v ${GRIDDIR}/egm96_15.gtx
+PROJ_LIB=$GRIDDIR make check
+
 mv src/.libs/*.gc* src


### PR DESCRIPTION
To catch regressions like #819 the tests should also be run with only the grids included in proj-datumgrid.

Rebased #821