### PR TITLE
Modify project bugreport (autoconf)

### DIFF
--- a/cmake/Proj4Config.cmake
+++ b/cmake/Proj4Config.cmake
@@ -30,7 +30,7 @@ CHECK_FUNCTION_EXISTS(localeconv HAVE_LOCALECONV)
 check_library_exists(m ceil "" HAVE_LIBM) 
 
 set(PACKAGE "proj")
-set(PACKAGE_BUGREPORT "warmerdam@pobox.com")
+set(PACKAGE_BUGREPORT "https://github.com/OSGeo/proj.4/issues")
 set(PACKAGE_NAME "PROJ.4 Projections")
 set(PACKAGE_STRING "PROJ.4 Projections ${${PROJECT_INTERN_NAME}_VERSION}")
 set(PACKAGE_TARNAME "proj")

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([PROJ.4 Projections], 5.0.0, [warmerdam@pobox.com], proj)
+AC_INIT([PROJ.4 Projections], 5.0.0, [https://github.com/OSGeo/proj.4/issues], proj)
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C)
 


### PR DESCRIPTION
See autoconf documentation for [AC_INIT](http://www.gnu.org/software/autoconf/manual/html_node/Initializing-configure.html) where the third parameter `AC_PACKAGE_BUGREPORT` is "Typically an email address, or URL to a bug management web page."

This parameter is visible at the end of a `make check` failure (via autotools build method), e.g. see the "report to" line the output in #826

With this PR (and re-`autogen.sh`) this is modified to:
```
...
=======================================================
1 of 1 test failed
Please report to https://github.com/OSGeo/proj.4/issues
=======================================================
...
```
which is the preferred place to submit bug reports.