### PR TITLE
Use consistent names for PJ_COORD's in declarations

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -419,7 +419,7 @@ Various
     :returns: :c:type:`PJ_COORD`
 
 
-.. c:function:: double proj_roundtrip(PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coo)
+.. c:function:: double proj_roundtrip(PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coord)
 
     Measure internal consistency of a given transformation. The function
     performs :c:data:`n` round trip transformations starting in either
@@ -432,7 +432,7 @@ Various
     :param `direction`: Starting direction of transformation
     :type `direction`: PJ_DIRECTION
     :param int n: Number of roundtrip transformations
-    :param PJ_OBS obs: Input coordinate
+    :param PJ_COORD coord: Input coordinate
     :returns: :c:type:`double` Distance between original coordinate and the \
               resulting coordinate after :c:data:`n` transformation iterations.
 
@@ -487,7 +487,7 @@ Various
     :returns: :c:type:`char*` Pointer to output buffer (same as :c:data:`s`)
 
 
-.. c:function:: PJ_COORD proj_geocentric_latitude(const PJ *P, PJ_DIRECTION direction, PJ_COORD coo)
+.. c:function:: PJ_COORD proj_geocentric_latitude(const PJ *P, PJ_DIRECTION direction, PJ_COORD coord)
 
     Convert from geographical latitude to geocentric latitude.
 
@@ -495,8 +495,8 @@ Various
     :type `P`: const PJ*
     :param `direction`: Starting direction of transformation
     :type `direction`: PJ_DIRECTION
-    :param `coo`: Coordinate
-    :type `coo`: PJ_COORD
+    :param `coord`: Coordinate
+    :type `coord`: PJ_COORD
     :returns: :c:type:`PJ_COORD` Converted coordinate
 
 

--- a/src/proj.h
+++ b/src/proj.h
@@ -324,7 +324,7 @@ size_t proj_trans_generic (
 PJ_COORD proj_coord (double x, double y, double z, double t);
 
 /* Measure internal consistency - in forward or inverse direction */
-double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coo);
+double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coord);
 
 /* Geodesic distance between two points with angular 2D coordinates */
 double proj_lp_dist (const PJ *P, PJ_COORD a, PJ_COORD b);
@@ -373,7 +373,7 @@ double proj_torad (double angle_in_degrees);
 double proj_todeg (double angle_in_radians);
 
 /* Geographical to geocentric latitude - another of the "simple, but useful" */
-PJ_COORD proj_geocentric_latitude (const PJ *P, PJ_DIRECTION direction, PJ_COORD coo);
+PJ_COORD proj_geocentric_latitude (const PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
 
 double proj_dmstor(const char *is, char **rs);
 char*  proj_rtodms(char *s, double r, int pos, int neg);

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -113,7 +113,7 @@ double proj_xyz_dist (PJ_COORD a, PJ_COORD b) {
 
 
 /* Measure numerical deviation after n roundtrips fwd-inv (or inv-fwd) */
-double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coo) {
+double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coord) {
     int i;
     PJ_COORD t, org;
 
@@ -126,9 +126,9 @@ double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coo) {
     }
 
     /* in the first half-step, we generate the output value */
-    org  = *coo;
-    *coo = proj_trans (P, direction, org);
-    t = *coo;
+    org  = *coord;
+    *coord = proj_trans (P, direction, org);
+    t = *coord;
 
     /* now we take n-1 full steps in inverse direction: We are */
     /* out of phase due to the half step already taken */
@@ -148,26 +148,26 @@ double proj_roundtrip (PJ *P, PJ_DIRECTION direction, int n, PJ_COORD *coo) {
 
 
 /**************************************************************************************/
-PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
+PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord) {
 /***************************************************************************************
-Apply the transformation P to the coordinate coo, preferring the 4D interfaces if
+Apply the transformation P to the coordinate coord, preferring the 4D interfaces if
 available.
 
 See also pj_approx_2D_trans and pj_approx_3D_trans in pj_internal.c, which work
 similarly, but prefers the 2D resp. 3D interfaces if available.
 ***************************************************************************************/
     if (0==P)
-        return coo;
+        return coord;
     if (P->inverted)
         direction = -direction;
 
     switch (direction) {
         case PJ_FWD:
-            return pj_fwd4d (coo, P);
+            return pj_fwd4d (coord, P);
         case PJ_INV:
-            return  pj_inv4d (coo, P);
+            return  pj_inv4d (coord, P);
         case PJ_IDENT:
-            return coo;
+            return coord;
         default:
             break;
     }
@@ -357,7 +357,7 @@ size_t proj_trans_generic (
 
 
 /*************************************************************************************/
-PJ_COORD proj_geocentric_latitude (const PJ *P, PJ_DIRECTION direction, PJ_COORD coo) {
+PJ_COORD proj_geocentric_latitude (const PJ *P, PJ_DIRECTION direction, PJ_COORD coord) {
 /**************************************************************************************
     Convert geographical latitude to geocentric (or the other way round if
     direction = PJ_INV)
@@ -373,13 +373,13 @@ PJ_COORD proj_geocentric_latitude (const PJ *P, PJ_DIRECTION direction, PJ_COORD
     consequently, the input is copied directly to the output.
 **************************************************************************************/
     const double limit = M_HALFPI - 1e-9;
-    PJ_COORD res = coo;
-    if ((coo.lp.phi > limit) || (coo.lp.phi < -limit) || (P->es==0))
+    PJ_COORD res = coord;
+    if ((coord.lp.phi > limit) || (coord.lp.phi < -limit) || (P->es==0))
         return res;
     if (direction==PJ_FWD)
-        res.lp.phi = atan (P->one_es * tan (coo.lp.phi) );
+        res.lp.phi = atan (P->one_es * tan (coord.lp.phi) );
     else
-        res.lp.phi = atan (P->rone_es * tan (coo.lp.phi) );
+        res.lp.phi = atan (P->rone_es * tan (coord.lp.phi) );
 
     return res;
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -73,8 +73,6 @@ enum pj_io_units {
 enum pj_io_units pj_left (PJ *P);
 enum pj_io_units pj_right (PJ *P);
 
-PJ_COORD   proj_trans   (PJ *P, PJ_DIRECTION direction, PJ_COORD obs);
-
 PJ_COORD proj_coord_error (void);
 
 void proj_context_errno_set (PJ_CONTEXT *ctx, int err);


### PR DESCRIPTION
Changes use of 'PJ_COORD coo' to 'PJ_COORD coord' so that variable names in
public function prototypes are consistent.

Closes #842.

Does changing variable names in prototypes pose a problem with regards to ABI compatibility?