### PR TITLE
Add proj_errno_string function

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -266,7 +266,15 @@ Change the error-state of :c:data:`P` to `err`.
     :param PJ* P: Transformation object.
     :param int err: Error code.
 
+.. c:function:: const char* proj_errno_string(int err)
 
+    Get a text representation of an error number.
+
+    :param int err: Error number.
+
+    :returns: :c:type:`const char*` String with description of error.
+
+    .. note:: Available from version 5.1.0.
 
 Info functions
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -1,10 +1,11 @@
 /* list of projection system pj_errno values */
-#include "projects.h"
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include "proj.h"
+#include "projects.h"
 
-    static const char * const
+static const char * const
 pj_err_list[] = {
     "no arguments in initialization list",                             /*  -1 */
     "no options found in 'init' file",                                 /*  -2 */
@@ -95,4 +96,8 @@ char *pj_strerrno(int err) {
 
     sprintf( note, "invalid projection system error (%d)", (err > -9999)? err: -9999);
     return note;
+}
+
+const char* proj_errno_string(int err) {
+    return pj_strerrno(err);
 }

--- a/src/proj.h
+++ b/src/proj.h
@@ -349,6 +349,7 @@ int  proj_errno (const PJ *P);
 int  proj_errno_set (const PJ *P, int err);
 int  proj_errno_reset (const PJ *P);
 int  proj_errno_restore (const PJ *P, int err);
+const char* proj_errno_string (int err);
 
 /* Scaling and angular distortion factors */
 PJ_FACTORS proj_factors(PJ *P, PJ_COORD lp);


### PR DESCRIPTION
The function allows users of the 4D API to get a textual representation of a returned error number.
Equivalent to pj_strerrno.

I am just returning whatever `pj_strerrno` returns. `pj_strerrno` returns a `char*` whereas `proj_errno_string` returns `const char*`. I am not sure if that is going to cause problems. Seems fine locally...