### PR TITLE
Remove angle brackets for proj headers

### DIFF
--- a/src/PJ_aea.c
+++ b/src/PJ_aea.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_aeqd.c
+++ b/src/PJ_aeqd.c
@@ -27,7 +27,7 @@
 
 #define PJ_LIB__
 #include "geodesic.h"
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_airy.c
+++ b/src/PJ_airy.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_aitoff.c
+++ b/src/PJ_aitoff.c
@@ -29,7 +29,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_bacon.c
+++ b/src/PJ_bacon.c
@@ -2,7 +2,7 @@
 # define EPS	1e-10
 #define PJ_LIB__
 #include	<errno.h>
-#include	<projects.h>
+#include	"projects.h"
 
 
 struct pj_opaque {

--- a/src/PJ_bipc.c
+++ b/src/PJ_bipc.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_boggs.c
+++ b/src/PJ_boggs.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 # include	<errno.h>
-# include	<projects.h>
+# include	"projects.h"
 PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl., no inv., Sph.";
 # define NITER	20
 # define EPS	1e-7

--- a/src/PJ_bonne.c
+++ b/src/PJ_bonne.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(bonne, "Bonne (Werner lat_1=90)")

--- a/src/PJ_calcofi.c
+++ b/src/PJ_calcofi.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(calcofi,
@@ -8,7 +8,7 @@ PROJ_HEAD(calcofi,
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
-#include <proj_api.h>
+#include "proj_api.h"
 #include <errno.h>
 
 /* Conversions for the California Cooperative Oceanic Fisheries Investigations

--- a/src/PJ_cc.c
+++ b/src/PJ_cc.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(cc, "Central Cylindrical") "\n\tCyl, Sph";

--- a/src/PJ_ccon.c
+++ b/src/PJ_ccon.c
@@ -22,7 +22,7 @@
 
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 #define EPS10   1e-10

--- a/src/PJ_cea.c
+++ b/src/PJ_cea.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 struct pj_opaque {

--- a/src/PJ_chamb.c
+++ b/src/PJ_chamb.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 typedef struct { double r, Az; } VECT;

--- a/src/PJ_collg.c
+++ b/src/PJ_collg.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(collg, "Collignon") "\n\tPCyl, Sph.";

--- a/src/PJ_comill.c
+++ b/src/PJ_comill.c
@@ -7,7 +7,7 @@ Port to PROJ.4 by Bojan Savric, 4 April 2016
 */
 
 #define PJ_LIB__
-#include    <projects.h>
+#include    "projects.h"
 
 PROJ_HEAD(comill, "Compact Miller") "\n\tCyl., Sph.";
 

--- a/src/PJ_crast.c
+++ b/src/PJ_crast.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-# include   <projects.h>
+# include   "projects.h"
 
 PROJ_HEAD(crast, "Craster Parabolic (Putnins P4)") "\n\tPCyl., Sph.";
 

--- a/src/PJ_deformation.c
+++ b/src/PJ_deformation.c
@@ -53,7 +53,7 @@ grid-values in units of mm/year in ENU-space.
 ***********************************************************************/
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/PJ_denoy.c
+++ b/src/PJ_denoy.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include    "projects.h"
 
 PROJ_HEAD(denoy, "Denoyer Semi-Elliptical") "\n\tPCyl., no inv., Sph.";
 

--- a/src/PJ_eck2.c
+++ b/src/PJ_eck2.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(eck2, "Eckert II") "\n\tPCyl. Sph.";

--- a/src/PJ_eck4.c
+++ b/src/PJ_eck4.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include    <projects.h>
+#include    "projects.h"
 
 PROJ_HEAD(eck4, "Eckert IV") "\n\tPCyl, Sph.";
 

--- a/src/PJ_eqc.c
+++ b/src/PJ_eqc.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 struct pj_opaque {

--- a/src/PJ_eqdc.c
+++ b/src/PJ_eqdc.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 struct pj_opaque {

--- a/src/PJ_fahey.c
+++ b/src/PJ_fahey.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(fahey, "Fahey") "\n\tPcyl, Sph.";
 

--- a/src/PJ_fouc_s.c
+++ b/src/PJ_fouc_s.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(fouc_s, "Foucaut Sinusoidal") "\n\tPCyl., Sph.";

--- a/src/PJ_gall.c
+++ b/src/PJ_gall.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(gall, "Gall (Gall Stereographic)") "\n\tCyl, Sph";
 

--- a/src/PJ_geoc.c
+++ b/src/PJ_geoc.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include <errno.h>
 #include "projects.h"
 

--- a/src/PJ_geos.c
+++ b/src/PJ_geos.c
@@ -29,7 +29,7 @@
 
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 struct pj_opaque {

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(gn_sinu, "General Sinusoidal Series") "\n\tPCyl, Sph.\n\tm= n=";

--- a/src/PJ_gnom.c
+++ b/src/PJ_gnom.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(gnom, "Gnomonic") "\n\tAzi, Sph.";

--- a/src/PJ_goode.c
+++ b/src/PJ_goode.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(goode, "Goode Homolosine") "\n\tPCyl, Sph.";

--- a/src/PJ_hammer.c
+++ b/src/PJ_hammer.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(hammer, "Hammer & Eckert-Greifendorff")

--- a/src/PJ_hatano.c
+++ b/src/PJ_hatano.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(hatano, "Hatano Asymmetrical Equal Area") "\n\tPCyl, Sph.";

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -31,7 +31,7 @@
 # define PJ_LIB__
 # include <errno.h>
 # include "proj_internal.h"
-# include <proj.h>
+# include "proj.h"
 # include "projects.h"
 
 PROJ_HEAD(healpix, "HEALPix") "\n\tSph., Ellps.";

--- a/src/PJ_imw_p.c
+++ b/src/PJ_imw_p.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(imw_p, "International Map of the World Polyconic")

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -1027,7 +1027,7 @@ isea_forward(struct isea_dgg *g, struct isea_geo *in)
 
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(isea, "Icosahedral Snyder Equal Area") "\n\tSph";

--- a/src/PJ_laea.c
+++ b/src/PJ_laea.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(laea, "Lambert Azimuthal Equal Area") "\n\tAzi, Sph&Ell";

--- a/src/PJ_lagrng.c
+++ b/src/PJ_lagrng.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(lagrng, "Lagrange") "\n\tMisc Sph, no inv.\n\tW=";

--- a/src/PJ_lcc.c
+++ b/src/PJ_lcc.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(lcc, "Lambert Conformal Conic")

--- a/src/PJ_lcca.c
+++ b/src/PJ_lcca.c
@@ -47,7 +47,7 @@
 
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(lcca, "Lambert Conformal Conic Alternative")

--- a/src/PJ_loxim.c
+++ b/src/PJ_loxim.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(loxim, "Loximuthal") "\n\tPCyl Sph";

--- a/src/PJ_lsat.c
+++ b/src/PJ_lsat.c
@@ -1,7 +1,7 @@
 /* based upon Snyder and Linck, USGS-NMD */
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(lsat, "Space oblique for LANDSAT")

--- a/src/PJ_mbtfpp.c
+++ b/src/PJ_mbtfpp.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(mbtfpp, "McBride-Thomas Flat-Polar Parabolic") "\n\tCyl., Sph.";

--- a/src/PJ_mbtfpq.c
+++ b/src/PJ_mbtfpq.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(mbtfpq, "McBryde-Thomas Flat-Polar Quartic") "\n\tCyl., Sph.";

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(merc, "Mercator") "\n\tCyl, Sph&Ell\n\tlat_ts=";

--- a/src/PJ_misrsom.c
+++ b/src/PJ_misrsom.c
@@ -22,7 +22,7 @@
 /* based upon Snyder and Linck, USGS-NMD */
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(misrsom, "Space oblique for MISR")

--- a/src/PJ_molodensky.c
+++ b/src/PJ_molodensky.c
@@ -44,7 +44,7 @@
 ***********************************************************************/
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/PJ_nsper.c
+++ b/src/PJ_nsper.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 enum Mode {

--- a/src/PJ_ob_tran.c
+++ b/src/PJ_ob_tran.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 #include <string.h>
 

--- a/src/PJ_ocea.c
+++ b/src/PJ_ocea.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(ocea, "Oblique Cylindrical Equal Area") "\n\tCyl, Sph"
     "lonc= alpha= or\n\tlat_1= lat_2= lon_1= lon_2=";

--- a/src/PJ_oea.c
+++ b/src/PJ_oea.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(oea, "Oblated Equal Area") "\n\tMisc Sph\n\tn= m= theta=";

--- a/src/PJ_omerc.c
+++ b/src/PJ_omerc.c
@@ -23,7 +23,7 @@
 */
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(omerc, "Oblique Mercator")

--- a/src/PJ_ortho.c
+++ b/src/PJ_ortho.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(ortho, "Orthographic") "\n\tAzi, Sph.";

--- a/src/PJ_patterson.c
+++ b/src/PJ_patterson.c
@@ -39,7 +39,7 @@
  */
 
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(patterson, "Patterson Cylindrical") "\n\tCyl.";
 

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -96,7 +96,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-20
 
 #define PJ_LIB__
 #include <geodesic.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -95,7 +95,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-20
 ********************************************************************************/
 
 #define PJ_LIB__
-#include <geodesic.h>
+#include "geodesic.h"
 #include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"

--- a/src/PJ_poly.c
+++ b/src/PJ_poly.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(poly, "Polyconic (American)")

--- a/src/PJ_putp3.c
+++ b/src/PJ_putp3.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 
 struct pj_opaque {
     double  A;

--- a/src/PJ_putp6.c
+++ b/src/PJ_putp6.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 
 struct pj_opaque {
     double C_x, C_y, A, B, D;

--- a/src/PJ_robin.c
+++ b/src/PJ_robin.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(robin, "Robinson") "\n\tPCyl., Sph.";

--- a/src/PJ_sch.c
+++ b/src/PJ_sch.c
@@ -32,7 +32,7 @@
 
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 #include "geocent.h"
 

--- a/src/PJ_sconics.c
+++ b/src/PJ_sconics.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 

--- a/src/PJ_somerc.c
+++ b/src/PJ_somerc.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(somerc, "Swiss. Obl. Mercator") "\n\tCyl, Ell\n\tFor CH1903";

--- a/src/PJ_stere.c
+++ b/src/PJ_stere.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(stere, "Stereographic") "\n\tAzi, Sph&Ell\n\tlat_ts=";

--- a/src/PJ_sterea.c
+++ b/src/PJ_sterea.c
@@ -25,7 +25,7 @@
 */
 #define PJ_LIB__
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 
 
 struct pj_opaque {

--- a/src/PJ_tcc.c
+++ b/src/PJ_tcc.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(tcc, "Transverse Central Cylindrical") "\n\tCyl, Sph, no inv.";

--- a/src/PJ_times.c
+++ b/src/PJ_times.c
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(times, "Times") "\n\tCyl, Sph";
 

--- a/src/PJ_tmerc.c
+++ b/src/PJ_tmerc.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(tmerc, "Transverse Mercator") "\n\tCyl, Sph&Ell";

--- a/src/PJ_tpeqd.c
+++ b/src/PJ_tpeqd.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 

--- a/src/PJ_urm5.c
+++ b/src/PJ_urm5.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(urm5, "Urmaev V") "\n\tPCyl., Sph., no inv.\n\tn= q= alpha=";

--- a/src/PJ_urmfps.c
+++ b/src/PJ_urmfps.c
@@ -1,6 +1,6 @@
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(urmfps, "Urmaev Flat-Polar Sinusoidal") "\n\tPCyl, Sph.\n\tn=";

--- a/src/PJ_vandg.c
+++ b/src/PJ_vandg.c
@@ -1,5 +1,5 @@
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 PROJ_HEAD(vandg, "van der Grinten (I)") "\n\tMisc Sph";

--- a/src/aasincos.c
+++ b/src/aasincos.c
@@ -1,5 +1,5 @@
 /* arc sin, cosine, tan2 and sqrt that will NOT fail */
-#include <projects.h>
+#include "projects.h"
 #define ONE_TOL	 1.00000000000001
 #define ATOL 1e-50
 

--- a/src/bch2bps.c
+++ b/src/bch2bps.c
@@ -1,5 +1,5 @@
 /* convert bivariate w Chebyshev series to w Power series */
-#include <projects.h>
+#include "projects.h"
 /* basic support procedures */
 	static void /* clear vector to zero */
 clear(projUV *p, int n) { static const projUV c = {0., 0.}; while (n--) *p++ = c; }

--- a/src/bchgen.c
+++ b/src/bchgen.c
@@ -1,5 +1,5 @@
 /* generate double bivariate Chebychev polynomial */
-#include <projects.h>
+#include "projects.h"
 	int
 bchgen(projUV a, projUV b, int nu, int nv, projUV **f, projUV(*func)(projUV)) {
 	int i, j, k;

--- a/src/biveval.c
+++ b/src/biveval.c
@@ -1,5 +1,5 @@
 /* procedures for evaluating Tseries */
-# include <projects.h>
+# include "projects.h"
 # define NEAR_ONE	1.00001
 static double ceval(struct PW_COEF *C, int n, projUV w, projUV w2) {
     double d=0, dd=0, vd, vdd, tmp, *c;

--- a/src/cct.c
+++ b/src/cct.c
@@ -77,7 +77,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 #include <stdlib.h>
 #include <string.h>
 
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 #include "optargpm.h"

--- a/src/dmstor.c
+++ b/src/dmstor.c
@@ -1,5 +1,5 @@
 /* Convert DMS string to radians */
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <ctype.h>
 

--- a/src/emess.c
+++ b/src/emess.c
@@ -14,7 +14,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <string.h>
-#include <proj_api.h>
+#include "proj_api.h"
 #define EMESS_ROUTINE
 #include "emess.h"
 	void

--- a/src/gie.c
+++ b/src/gie.c
@@ -112,7 +112,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2017-10-01/2017-10-08
 #include <stdlib.h>
 #include <string.h>
 
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/mk_cheby.c
+++ b/src/mk_cheby.c
@@ -1,4 +1,4 @@
-#include <projects.h>
+#include "projects.h"
 static void /* sum coefficients less than res */
 eval(projUV **w, int nu, int nv, double res, projUV *resid) {
     int i, j;

--- a/src/nad_init.c
+++ b/src/nad_init.c
@@ -27,7 +27,7 @@
 
 #define PJ_LIB__
 
-#include <projects.h>
+#include "projects.h"
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/src/nad_intr.c
+++ b/src/nad_intr.c
@@ -1,6 +1,6 @@
 /* Determine nad table correction value */
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 	LP
 nad_intr(LP t, struct CTABLE *ct) {
 	LP val, frct;

--- a/src/pj_auth.c
+++ b/src/pj_auth.c
@@ -1,5 +1,5 @@
 /* determine latitude from authalic latitude */
-#include <projects.h>
+#include "projects.h"
 # define P00 .33333333333333333333 /*   1 /     3 */
 # define P01 .17222222222222222222 /*  31 /   180 */
 # define P02 .10257936507936507937 /* 517 /  5040 */

--- a/src/pj_ctx.c
+++ b/src/pj_ctx.c
@@ -25,7 +25,7 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <errno.h>
 

--- a/src/pj_datum_set.c
+++ b/src/pj_datum_set.c
@@ -26,7 +26,7 @@
  *****************************************************************************/
 
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 
 /* SEC_TO_RAD = Pi/180/3600 */

--- a/src/pj_datums.c
+++ b/src/pj_datums.c
@@ -28,7 +28,7 @@
 #include "proj.h"
 
 #define PJ_DATUMS__
-#include <projects.h>
+#include "projects.h"
 
 /*
  * The ellipse code must match one from pj_ellps.c.  The datum id should

--- a/src/pj_ell_set.c
+++ b/src/pj_ell_set.c
@@ -1,7 +1,7 @@
 /* set ellipsoid parameters a and es */
 #include <string.h>
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/pj_errno.c
+++ b/src/pj_errno.c
@@ -1,6 +1,6 @@
 /* For full ANSI compliance of global variable */
 
-#include <projects.h>
+#include "projects.h"
 
 C_NAMESPACE_VAR int pj_errno = 0;
 

--- a/src/pj_factors.c
+++ b/src/pj_factors.c
@@ -1,6 +1,6 @@
 /* projection scale factors */
 #define PJ_LIB__
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 #include <errno.h>

--- a/src/pj_fileapi.c
+++ b/src/pj_fileapi.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 
 static PAFile pj_stdio_fopen(projCtx ctx, const char *filename, 

--- a/src/pj_gauss.c
+++ b/src/pj_gauss.c
@@ -24,7 +24,7 @@
 ** SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 #define MAX_ITER 20
 

--- a/src/pj_gc_reader.c
+++ b/src/pj_gc_reader.c
@@ -28,7 +28,7 @@
 #define PJ_LIB__
 
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <ctype.h>
 

--- a/src/pj_geocent.c
+++ b/src/pj_geocent.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 
 PROJ_HEAD(geocent, "Geocentric")  "\n\t";
 

--- a/src/pj_gridcatalog.c
+++ b/src/pj_gridcatalog.c
@@ -27,7 +27,7 @@
 
 #define PJ_LIB__
 
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <assert.h>
 

--- a/src/pj_gridlist.c
+++ b/src/pj_gridlist.c
@@ -29,7 +29,7 @@
 #define PJ_LIB__
 
 #include <errno.h>
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <math.h>
 

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -30,7 +30,7 @@
 
 
 #define PJ_LIB__
-#include <geodesic.h>
+#include "geodesic.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/pj_initcache.c
+++ b/src/pj_initcache.c
@@ -25,7 +25,7 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 
 static int cache_count = 0;

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -33,7 +33,7 @@
 #include <stdarg.h>
 #include <errno.h>
 
-#include <geodesic.h>
+#include "geodesic.h"
 #include "proj_internal.h"
 #include "projects.h"
 

--- a/src/pj_log.c
+++ b/src/pj_log.c
@@ -26,7 +26,7 @@
  *****************************************************************************/
 
 #include "proj.h"
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <stdarg.h>
 

--- a/src/pj_malloc.c
+++ b/src/pj_malloc.c
@@ -40,7 +40,7 @@
 ** projection system memory allocation/deallocation call with custom
 ** application procedures.  */
 
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 #include <errno.h>
 

--- a/src/pj_mlfn.c
+++ b/src/pj_mlfn.c
@@ -1,4 +1,4 @@
-#include <projects.h>
+#include "projects.h"
 /* meridional distance for ellipsoid and inverse
 **	8th degree - accurate to < 1e-5 meters when used in conjunction
 **		with typical major axis values.

--- a/src/pj_msfn.c
+++ b/src/pj_msfn.c
@@ -1,6 +1,6 @@
 /* determine constant small m */
 #include <math.h>
-#include <projects.h>
+#include "projects.h"
 	double
 pj_msfn(double sinphi, double cosphi, double es) {
 	return (cosphi / sqrt (1. - es * sinphi * sinphi));

--- a/src/pj_mutex.c
+++ b/src/pj_mutex.c
@@ -36,9 +36,9 @@
 
 #ifndef _WIN32
 #include "proj_config.h"
-#include <projects.h>
+#include "projects.h"
 #else
-#include <proj_api.h>
+#include "proj_api.h"
 #endif
 
 /* on win32 we always use win32 mutexes, even if pthreads are available */

--- a/src/pj_open_lib.c
+++ b/src/pj_open_lib.c
@@ -30,7 +30,7 @@
 
 #define PJ_LIB__
 #include "proj_internal.h"
-#include <projects.h>
+#include "projects.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,5 +1,5 @@
 /* determine latitude angle phi-2 */
-#include <projects.h>
+#include "projects.h"
 
 #define TOL 1.0e-10
 #define N_ITER 15

--- a/src/pj_pr_list.c
+++ b/src/pj_pr_list.c
@@ -1,5 +1,5 @@
 /* print projection's list of parameters */
-#include <projects.h>
+#include "projects.h"
 #include <stdio.h>
 #include <string.h>
 #define LINE_LEN 72

--- a/src/pj_qsfn.c
+++ b/src/pj_qsfn.c
@@ -1,6 +1,6 @@
 /* determine small q */
 #include <math.h>
-#include <projects.h>
+#include "projects.h"
 
 # define EPSILON 1.0e-7
 

--- a/src/pj_release.c
+++ b/src/pj_release.c
@@ -1,6 +1,6 @@
 /* <<< Release Notice for library >>> */
 
-#include <projects.h>
+#include "projects.h"
 
 char const pj_release[]="Rel. 5.0.0, March 1st, 2018";
 

--- a/src/pj_tsfn.c
+++ b/src/pj_tsfn.c
@@ -1,6 +1,6 @@
 /* determine small t */
 #include <math.h>
-#include <projects.h>
+#include "projects.h"
 
 double pj_tsfn(double phi, double sinphi, double e) {
     double denominator;

--- a/src/pj_units.c
+++ b/src/pj_units.c
@@ -3,7 +3,7 @@
 #include "proj.h"
 
 #define PJ_UNITS__
-#include <projects.h>
+#include "projects.h"
 
 /* Field 2 that contains the multiplier to convert named units to meters
 ** may be expressed by either a simple floating point constant or a

--- a/src/pj_utils.c
+++ b/src/pj_utils.c
@@ -28,7 +28,7 @@
 
 #define PJ_LIB__
 
-#include <projects.h>
+#include "projects.h"
 #include <string.h>
 #include <math.h>
 

--- a/src/pj_zpoly1.c
+++ b/src/pj_zpoly1.c
@@ -1,5 +1,5 @@
 /* evaluate complex polynomial */
-#include <projects.h>
+#include "projects.h"
 /* note: coefficients are always from C_1 to C_n
 **	i.e. C_0 == (0., 0)
 **	n should always be >= 1 though no checks are made

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 #include <stddef.h>
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "proj_internal.h"
 #include "projects.h"
 #include "geodesic.h"

--- a/src/proj_etmerc.c
+++ b/src/proj_etmerc.c
@@ -42,7 +42,7 @@
 #define PJ_LIB__
 
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 

--- a/src/proj_mdist.c
+++ b/src/proj_mdist.c
@@ -28,7 +28,7 @@
 ** Precision commensurate with double precision.
 */
 #define PJ_LIB__
-#include <projects.h>
+#include "projects.h"
 #define MAX_ITER 20
 #define TOL 1e-14
 

--- a/src/proj_rouss.c
+++ b/src/proj_rouss.c
@@ -25,7 +25,7 @@
 */
 #define PJ_LIB__
 #include <errno.h>
-#include <proj.h>
+#include "proj.h"
 #include "projects.h"
 
 struct pj_opaque {

--- a/src/rtodms.c
+++ b/src/rtodms.c
@@ -1,5 +1,5 @@
 /* Convert radian argument to DMS ascii format */
-#include <projects.h>
+#include "projects.h"
 #include <stdio.h>
 #include <string.h>
 /*

--- a/src/test228.c
+++ b/src/test228.c
@@ -1,4 +1,4 @@
-#include <proj_api.h>
+#include "proj_api.h"
 #include <stdio.h> /* for printf declaration */
 
 

--- a/src/vector1.c
+++ b/src/vector1.c
@@ -1,6 +1,6 @@
 /* make storage for one and two dimensional matricies */
 #include <stdlib.h>
-#include <projects.h>
+#include "projects.h"
 	void * /* one dimension array */
 vector1(int nvals, int size) { return((void *)pj_malloc(size * nvals)); }
 	void /* free 2D array */


### PR DESCRIPTION
Using angle brackets in include directives increases the risk of accidentally picking up an older system installed header file while building an updated version of PROJ.

This PR changes the angle brackets to "" for proj.h, projects.h, proj_api.h and geodesic.h

Resolves #841.