### PR TITLE
Allow failure of ming32 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ matrix:
         - BUILD_NAME=mingw32
         - DETAILS="mingw32"
 
-#  allow_failures:
-#    - os: osx
+  allow_failures:
+      - env: BUILD_NAME=mingw32
 
 before_install: ./travis/${BUILD_NAME}/before_install.sh
 


### PR DESCRIPTION
The Travis ming32 tests fail sporadically due to connection issues (or whatever...). With this change it is allowed to fail.