### PR TITLE
Remove 'pj_' prefix from static functions

### DIFF
--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -71,7 +71,7 @@ static const double rot[7][2][2] = ROT;
  * @param v the parameter whose sign is returned.
  * @return 1 for positive number, -1 for negative, and 0 for zero.
  **/
-static double pj_sign (double v) {
+static double sign (double v) {
     return v > 0 ? 1 : (v < 0 ? -1 : 0);
 }
 
@@ -236,7 +236,7 @@ static double auth_lat(PJ *P, double alpha, int inverse) {
 
         if (fabs(ratio) > 1) {
             /* Rounding error. */
-            ratio = pj_sign(ratio);
+            ratio = sign(ratio);
         }
         return asin(ratio);
     } else {
@@ -269,7 +269,7 @@ static XY healpix_sphere(LP lp) {
         }
         lamc = -3*M_FORTPI + M_HALFPI*cn;
         xy.x = lamc + (lam - lamc)*sigma;
-        xy.y = pj_sign(phi)*M_FORTPI*(2 - sigma);
+        xy.y = sign(phi)*M_FORTPI*(2 - sigma);
     }
     return xy;
 }
@@ -297,10 +297,10 @@ static LP healpix_sphere_inverse(XY xy) {
         xc = -3*M_FORTPI + M_HALFPI*cn;
         tau = 2.0 - 4*fabs(y)/M_PI;
         lp.lam = xc + (x - xc)/tau;
-        lp.phi = pj_sign(y)*asin(1.0 - pow(tau, 2)/3.0);
+        lp.phi = sign(y)*asin(1.0 - pow(tau, 2)/3.0);
     } else {
         lp.lam = -M_PI;
-        lp.phi = pj_sign(y)*M_HALFPI;
+        lp.phi = sign(y)*M_HALFPI;
     }
     return (lp);
 }

--- a/src/gie.c
+++ b/src/gie.c
@@ -579,9 +579,9 @@ either a conversion or a transformation)
 
 
 
-static int pj_unitconvert_selftest (void);
-static int pj_cart_selftest (void);
-static int pj_horner_selftest (void);
+static int unitconvert_selftest (void);
+static int cart_selftest (void);
+static int horner_selftest (void);
 
 /*****************************************************************************/
 static int builtins (const char *args) {
@@ -598,26 +598,26 @@ using the "builtins" command verb.
     T.op_ok = 0;
     T.op_ko = 0;
     T.op_skip = 0;
-    i = pj_unitconvert_selftest ();
+    i = unitconvert_selftest ();
     if (i!=0) {
-        fprintf (T.fout, "pj_unitconvert_selftest fails with %d\n", i);
+        fprintf (T.fout, "unitconvert_selftest fails with %d\n", i);
         another_failing_builtin();
     }
     else
         another_succeeding_builtin ();
 
 
-    i = pj_cart_selftest ();
+    i = cart_selftest ();
     if (i!=0) {
-        fprintf (T.fout, "pj_cart_selftest fails with %d\n", i);
+        fprintf (T.fout, "cart_selftest fails with %d\n", i);
         another_failing_builtin();
     }
     else
         another_succeeding_builtin ();
 
-    i = pj_horner_selftest ();
+    i = horner_selftest ();
     if (i!=0) {
-        fprintf (T.fout, "pj_horner_selftest fails with %d\n", i);
+        fprintf (T.fout, "horner_selftest fails with %d\n", i);
         another_failing_builtin();
     }
     else
@@ -1473,7 +1473,7 @@ static const char sb_utm32[] = {
     " +inv_c=6.13342118787027e+06,4.94690181709311e+05,9.99824464710368e-01,2.82279070814774e-02,7.66123542220864e-11,1.78425334628927e-09,-1.05584823306400e-14,-3.32554258683744e-15"
 };
 
-static int pj_horner_selftest (void) {
+static int horner_selftest (void) {
     PJ *P;
     PJ_COORD a, b, c;
     double dist;
@@ -1539,7 +1539,7 @@ static int pj_horner_selftest (void) {
 
 
 /* Testing quite a bit of the pj_obs_api as a side effect (inspired by pj_obs_api_test.c) */
-static int pj_cart_selftest (void) {
+static int cart_selftest (void) {
     PJ_CONTEXT *ctx;
     PJ *P;
     PJ_COORD a, b, obs[2];
@@ -1968,7 +1968,7 @@ static int test_time(const char* args, double tol, double t_in, double t_exp) {
     return ret;
 }
 
-static int pj_unitconvert_selftest (void) {
+static int unitconvert_selftest (void) {
     int ret = 0;
     char args1[] = "+proj=unitconvert +t_in=decimalyear +t_out=decimalyear";
     double in1 = 2004.25;

--- a/src/pj_apply_vgridshift.c
+++ b/src/pj_apply_vgridshift.c
@@ -33,7 +33,7 @@
 #include "proj_internal.h"
 #include "projects.h"
 
-static double pj_read_vgrid_value( PJ *defn, LP input, int *gridlist_count_p, PJ_GRIDINFO **tables, struct CTABLE *ct) {
+static double read_vgrid_value( PJ *defn, LP input, int *gridlist_count_p, PJ_GRIDINFO **tables, struct CTABLE *ct) {
     int  itable = 0;
     double value = HUGE_VAL;
     double grid_x, grid_y;
@@ -180,7 +180,7 @@ int pj_apply_vgridshift( PJ *defn, const char *listname,
         input.phi = y[io];
         input.lam = x[io];
 
-        value = pj_read_vgrid_value(defn, input, gridlist_count_p, tables, &ct);
+        value = read_vgrid_value(defn, input, gridlist_count_p, tables, &ct);
 
         if( inverse )
             z[io] -= value;
@@ -286,7 +286,7 @@ double proj_vgrid_value(PJ *P, LP lp){
     double value;
     memset(&used_grid, 0, sizeof(struct CTABLE));
 
-    value = pj_read_vgrid_value(P, lp, &(P->vgridlist_geoid_count), P->vgridlist_geoid, &used_grid);
+    value = read_vgrid_value(P, lp, &(P->vgridlist_geoid_count), P->vgridlist_geoid, &used_grid);
     proj_log_trace(P, "proj_vgrid_value: (%f, %f) = %f", lp.lam*RAD_TO_DEG, lp.phi*RAD_TO_DEG, value);
 
     return value;

--- a/src/pj_fileapi.c
+++ b/src/pj_fileapi.c
@@ -30,20 +30,20 @@
 #include "projects.h"
 #include <string.h>
 
-static PAFile pj_stdio_fopen(projCtx ctx, const char *filename, 
+static PAFile stdio_fopen(projCtx ctx, const char *filename, 
                              const char *access);
-static size_t pj_stdio_fread(void *buffer, size_t size, size_t nmemb, 
+static size_t stdio_fread(void *buffer, size_t size, size_t nmemb, 
                              PAFile file);
-static int pj_stdio_fseek(PAFile file, long offset, int whence);
-static long pj_stdio_ftell(PAFile file);
-static void pj_stdio_fclose(PAFile file);
+static int stdio_fseek(PAFile file, long offset, int whence);
+static long stdio_ftell(PAFile file);
+static void stdio_fclose(PAFile file);
 
 static projFileAPI default_fileapi = { 
-    pj_stdio_fopen, 
-    pj_stdio_fread,
-    pj_stdio_fseek,
-    pj_stdio_ftell,
-    pj_stdio_fclose
+    stdio_fopen, 
+    stdio_fread,
+    stdio_fseek,
+    stdio_ftell,
+    stdio_fclose
 };
 
 typedef struct {
@@ -61,10 +61,10 @@ projFileAPI *pj_get_default_fileapi(void)
 }
 
 /************************************************************************/
-/*                           pj_stdio_fopen()                           */
+/*                           stdio_fopen()                           */
 /************************************************************************/
 
-static PAFile pj_stdio_fopen(projCtx ctx, const char *filename, 
+static PAFile stdio_fopen(projCtx ctx, const char *filename, 
                              const char *access)
 {
     stdio_pafile *pafile;
@@ -90,10 +90,10 @@ static PAFile pj_stdio_fopen(projCtx ctx, const char *filename,
 }
 
 /************************************************************************/
-/*                           pj_stdio_fread()                           */
+/*                           stdio_fread()                           */
 /************************************************************************/
 
-static size_t pj_stdio_fread(void *buffer, size_t size, size_t nmemb, 
+static size_t stdio_fread(void *buffer, size_t size, size_t nmemb, 
                              PAFile file)
 {
     stdio_pafile *pafile = (stdio_pafile *) file;
@@ -101,27 +101,27 @@ static size_t pj_stdio_fread(void *buffer, size_t size, size_t nmemb,
 }
 
 /************************************************************************/
-/*                           pj_stdio_fseek()                           */
+/*                           stdio_fseek()                           */
 /************************************************************************/
-static int pj_stdio_fseek(PAFile file, long offset, int whence)
+static int stdio_fseek(PAFile file, long offset, int whence)
 {
     stdio_pafile *pafile = (stdio_pafile *) file;
     return fseek(pafile->fp, offset, whence);
 }
 
 /************************************************************************/
-/*                           pj_stdio_ftell()                           */
+/*                           stdio_ftell()                           */
 /************************************************************************/
-static long pj_stdio_ftell(PAFile file)
+static long stdio_ftell(PAFile file)
 {
     stdio_pafile *pafile = (stdio_pafile *) file;
     return ftell(pafile->fp);
 }
 
 /************************************************************************/
-/*                          pj_stdio_fclose()                           */
+/*                          stdio_fclose()                           */
 /************************************************************************/
-static void pj_stdio_fclose(PAFile file)
+static void stdio_fclose(PAFile file)
 {
     stdio_pafile *pafile = (stdio_pafile *) file;
     fclose(pafile->fp);

--- a/src/pj_fwd.c
+++ b/src/pj_fwd.c
@@ -36,7 +36,7 @@
 #define OUTPUT_UNITS P->right
 
 
-static PJ_COORD pj_fwd_prepare (PJ *P, PJ_COORD coo) {
+static PJ_COORD fwd_prepare (PJ *P, PJ_COORD coo) {
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ();
 
@@ -100,7 +100,7 @@ static PJ_COORD pj_fwd_prepare (PJ *P, PJ_COORD coo) {
 
 
 
-static PJ_COORD pj_fwd_finalize (PJ *P, PJ_COORD coo) {
+static PJ_COORD fwd_finalize (PJ *P, PJ_COORD coo) {
 
     switch (OUTPUT_UNITS) {
 
@@ -180,7 +180,7 @@ XY pj_fwd(LP lp, PJ *P) {
     coo.lp = lp;
 
     if (!P->skip_fwd_prepare)
-        coo = pj_fwd_prepare (P, coo);
+        coo = fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ().xy;
 
@@ -199,7 +199,7 @@ XY pj_fwd(LP lp, PJ *P) {
         return proj_coord_error ().xy;
 
     if (!P->skip_fwd_finalize)
-        coo = pj_fwd_finalize (P, coo);
+        coo = fwd_finalize (P, coo);
     return coo.xy;
 }
 
@@ -210,7 +210,7 @@ XYZ pj_fwd3d(LPZ lpz, PJ *P) {
     coo.lpz = lpz;
 
     if (!P->skip_fwd_prepare)
-        coo = pj_fwd_prepare (P, coo);
+        coo = fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ().xyz;
 
@@ -229,7 +229,7 @@ XYZ pj_fwd3d(LPZ lpz, PJ *P) {
         return proj_coord_error ().xyz;
 
     if (!P->skip_fwd_finalize)
-        coo = pj_fwd_finalize (P, coo);
+        coo = fwd_finalize (P, coo);
     return coo.xyz;
 }
 
@@ -237,7 +237,7 @@ XYZ pj_fwd3d(LPZ lpz, PJ *P) {
 
 PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
     if (!P->skip_fwd_prepare)
-        coo = pj_fwd_prepare (P, coo);
+        coo = fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ();
 
@@ -256,6 +256,6 @@ PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
         return proj_coord_error ();
 
     if (!P->skip_fwd_finalize)
-        coo = pj_fwd_finalize (P, coo);
+        coo = fwd_finalize (P, coo);
     return coo;
 }

--- a/src/pj_gc_reader.c
+++ b/src/pj_gc_reader.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <ctype.h>
 
-static int pj_gc_readentry(projCtx ctx, PAFile fid, PJ_GridCatalogEntry *entry);
+static int gc_readentry(projCtx ctx, PAFile fid, PJ_GridCatalogEntry *entry);
 
 /************************************************************************/
 /*                         pj_gc_readcatalog()                          */
@@ -81,7 +81,7 @@ PJ_GridCatalog *pj_gc_readcatalog( projCtx ctx, const char *catalog_name )
         return NULL;
     }
     
-    while( pj_gc_readentry( ctx, fid, 
+    while( gc_readentry( ctx, fid, 
                             catalog->entries+catalog->entry_count) == 0)
     {
         catalog->entry_count++;
@@ -114,13 +114,13 @@ PJ_GridCatalog *pj_gc_readcatalog( projCtx ctx, const char *catalog_name )
 }
 
 /************************************************************************/
-/*                        pj_gc_read_csv_line()                         */
+/*                        gc_read_csv_line()                         */
 /*                                                                      */
 /*      Simple csv line splitter with fixed maximum line size and       */
 /*      token count.                                                    */
 /************************************************************************/
 
-static int pj_gc_read_csv_line( projCtx ctx, PAFile fid, 
+static int gc_read_csv_line( projCtx ctx, PAFile fid, 
                                 char **tokens, int max_tokens ) 
 {
     char line[302];
@@ -197,7 +197,7 @@ double pj_gc_parsedate( projCtx ctx, const char *date_string )
 
 
 /************************************************************************/
-/*                          pj_gc_readentry()                           */
+/*                          gc_readentry()                           */
 /*                                                                      */
 /*      Read one catalog entry from the file                            */
 /*                                                                      */
@@ -205,7 +205,7 @@ double pj_gc_parsedate( projCtx ctx, const char *date_string )
 /*        gridname,ll_long,ll_lat,ur_long,ur_lat,priority,date          */
 /************************************************************************/
 
-static int pj_gc_readentry(projCtx ctx, PAFile fid, PJ_GridCatalogEntry *entry) 
+static int gc_readentry(projCtx ctx, PAFile fid, PJ_GridCatalogEntry *entry) 
 {
 #define MAX_TOKENS 30
     char *tokens[MAX_TOKENS];
@@ -214,7 +214,7 @@ static int pj_gc_readentry(projCtx ctx, PAFile fid, PJ_GridCatalogEntry *entry)
 
     memset( entry, 0, sizeof(PJ_GridCatalogEntry) );
     
-    token_count = pj_gc_read_csv_line( ctx, fid, tokens, MAX_TOKENS );
+    token_count = gc_read_csv_line( ctx, fid, tokens, MAX_TOKENS );
     if( token_count < 5 )
     {
         error = 1; /* TODO: need real error codes */

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -389,12 +389,12 @@ int pj_gridinfo_load( projCtx ctx, PJ_GRIDINFO *gi )
 }
 
 /************************************************************************/
-/*                        pj_gridinfo_parent()                          */
+/*                        gridinfo_parent()                          */
 /*                                                                      */
 /*      Seek a parent grid file by name from a grid list                */
 /************************************************************************/
 
-static PJ_GRIDINFO* pj_gridinfo_parent( PJ_GRIDINFO *gilist,
+static PJ_GRIDINFO* gridinfo_parent( PJ_GRIDINFO *gilist,
         const char *name, int length )
 {
     while( gilist )
@@ -402,7 +402,7 @@ static PJ_GRIDINFO* pj_gridinfo_parent( PJ_GRIDINFO *gilist,
         if( strncmp(gilist->ct->id,name,length) == 0 ) return gilist;
         if( gilist->child )
         {
-            PJ_GRIDINFO *parent=pj_gridinfo_parent( gilist->child, name, length );
+            PJ_GRIDINFO *parent=gridinfo_parent( gilist->child, name, length );
             if( parent ) return parent;
         }
         gilist=gilist->next;
@@ -596,7 +596,7 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
         else
         {
             PJ_GRIDINFO *lnk;
-            PJ_GRIDINFO *gp = pj_gridinfo_parent(gilist,
+            PJ_GRIDINFO *gp = gridinfo_parent(gilist,
                                                  (const char*)header+24,8);
 
             if( gp == NULL )

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -470,7 +470,7 @@ pj_init(int argc, char **argv) {
 }
 
 
-static PJ_CONSTRUCTOR pj_locate_constructor (const char *name) {
+static PJ_CONSTRUCTOR locate_constructor (const char *name) {
     int i;
     char *s;
     for (i = 0; (s = pj_list[i].id) && strcmp(name, s) ; ++i) ;
@@ -557,7 +557,7 @@ pj_init_ctx(projCtx ctx, int argc, char **argv) {
         return pj_dealloc_params (ctx, start, PJD_ERR_PROJ_NOT_NAMED);
     name += 5;
 
-    proj = pj_locate_constructor (name);
+    proj = locate_constructor (name);
     if (0==proj)
         return pj_dealloc_params (ctx, start, PJD_ERR_UNKNOWN_PROJECTION_ID);
 

--- a/src/pj_inv.c
+++ b/src/pj_inv.c
@@ -35,7 +35,7 @@
 #define INPUT_UNITS  P->right
 #define OUTPUT_UNITS P->left
 
-static PJ_COORD pj_inv_prepare (PJ *P, PJ_COORD coo) {
+static PJ_COORD inv_prepare (PJ *P, PJ_COORD coo) {
     if (coo.xyz.x == HUGE_VAL) {
         proj_errno_set (P, PJD_ERR_INVALID_X_OR_Y);
         return proj_coord_error ();
@@ -132,7 +132,7 @@ static PJ_COORD pj_inv_prepare (PJ *P, PJ_COORD coo) {
 
 
 
-static PJ_COORD pj_inv_finalize (PJ *P, PJ_COORD coo) {
+static PJ_COORD inv_finalize (PJ *P, PJ_COORD coo) {
     if (coo.xyz.x == HUGE_VAL) {
         proj_errno_set (P, PJD_ERR_INVALID_X_OR_Y);
         return proj_coord_error ();
@@ -178,7 +178,7 @@ LP pj_inv(XY xy, PJ *P) {
     coo.xy = xy;
 
     if (!P->skip_inv_prepare)
-        coo = pj_inv_prepare (P, coo);
+        coo = inv_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ().lp;
 
@@ -197,7 +197,7 @@ LP pj_inv(XY xy, PJ *P) {
         return proj_coord_error ().lp;
 
     if (!P->skip_inv_finalize)
-        coo = pj_inv_finalize (P, coo);
+        coo = inv_finalize (P, coo);
     return coo.lp;
 }
 
@@ -208,7 +208,7 @@ LPZ pj_inv3d (XYZ xyz, PJ *P) {
     coo.xyz = xyz;
 
     if (!P->skip_inv_prepare)
-        coo = pj_inv_prepare (P, coo);
+        coo = inv_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ().lpz;
 
@@ -227,7 +227,7 @@ LPZ pj_inv3d (XYZ xyz, PJ *P) {
         return proj_coord_error ().lpz;
 
     if (!P->skip_inv_finalize)
-        coo = pj_inv_finalize (P, coo);
+        coo = inv_finalize (P, coo);
     return coo.lpz;
 }
 
@@ -235,7 +235,7 @@ LPZ pj_inv3d (XYZ xyz, PJ *P) {
 
 PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
     if (!P->skip_inv_prepare)
-        coo = pj_inv_prepare (P, coo);
+        coo = inv_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ();
 
@@ -254,6 +254,6 @@ PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
         return proj_coord_error ();
 
     if (!P->skip_inv_finalize)
-        coo = pj_inv_finalize (P, coo);
+        coo = inv_finalize (P, coo);
     return coo;
 }

--- a/src/pj_mutex.c
+++ b/src/pj_mutex.c
@@ -100,9 +100,9 @@ void pj_cleanup_lock()
 
 #include "pthread.h"
 
-static pthread_mutex_t pj_precreated_lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t pj_core_lock;
-static int pj_core_lock_created = 0;
+static pthread_mutex_t precreated_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t core_lock;
+static int core_lock_created = 0;
 
 /************************************************************************/
 /*                          pj_acquire_lock()                           */
@@ -112,16 +112,16 @@ static int pj_core_lock_created = 0;
 
 void pj_acquire_lock()
 {
-    if (!pj_core_lock_created) {
+    if (!core_lock_created) {
         /*
         ** We need to ensure the core mutex is created in recursive mode
         ** and there is no portable way of doing that using automatic
-        ** initialization so we have pj_precreated_lock only for the purpose
+        ** initialization so we have precreated_lock only for the purpose
         ** of protecting the creation of the core lock.
         */
         pthread_mutexattr_t mutex_attr;
 
-        pthread_mutex_lock( &pj_precreated_lock);
+        pthread_mutex_lock( &precreated_lock);
 
         pthread_mutexattr_init(&mutex_attr);
 #ifdef HAVE_PTHREAD_MUTEX_RECURSIVE
@@ -129,13 +129,13 @@ void pj_acquire_lock()
 #else
         pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE_NP);
 #endif
-        pthread_mutex_init(&pj_core_lock, &mutex_attr);
-        pj_core_lock_created = 1;
+        pthread_mutex_init(&core_lock, &mutex_attr);
+        core_lock_created = 1;
 
-        pthread_mutex_unlock( &pj_precreated_lock );
+        pthread_mutex_unlock( &precreated_lock );
     }
 
-    pthread_mutex_lock( &pj_core_lock);
+    pthread_mutex_lock( &core_lock);
 }
 
 /************************************************************************/
@@ -146,7 +146,7 @@ void pj_acquire_lock()
 
 void pj_release_lock()
 {
-    pthread_mutex_unlock( &pj_core_lock );
+    pthread_mutex_unlock( &core_lock );
 }
 
 /************************************************************************/

--- a/src/pj_strtod.c
+++ b/src/pj_strtod.c
@@ -69,10 +69,10 @@ double pj_atof( const char* nptr )
 
 
 /************************************************************************/
-/*                     pj_replace_point_by_locale_point()               */
+/*                     replace_point_by_locale_point()               */
 /************************************************************************/
 
-static char* pj_replace_point_by_locale_point(const char* pszNumber, char point,
+static char* replace_point_by_locale_point(const char* pszNumber, char point,
                                               char* pszWorkBuffer)
 {
 #if !defined(HAVE_LOCALECONV)
@@ -179,7 +179,7 @@ double pj_strtod( const char *nptr, char **endptr )
     int         nError;
     char        szWorkBuffer[PJ_STRTOD_WORK_BUFFER_SIZE];
 
-    char*       pszNumber = pj_replace_point_by_locale_point(nptr, '.', szWorkBuffer);
+    char*       pszNumber = replace_point_by_locale_point(nptr, '.', szWorkBuffer);
 
     dfValue = strtod( pszNumber, endptr );
     nError = errno;

--- a/src/pj_transform.c
+++ b/src/pj_transform.c
@@ -44,7 +44,7 @@ typedef enum PJ_DIRECTION PJ_DIRECTION;
 
 
 
-static int pj_adjust_axis( projCtx ctx, const char *axis, int denormalize_flag,
+static int adjust_axis( projCtx ctx, const char *axis, int denormalize_flag,
                            long point_count, int point_offset,
                            double *x, double *y, double *z );
 
@@ -104,7 +104,7 @@ static int adjust_axes (PJ *P, PJ_DIRECTION dir, long n, int dist, double *x, do
     if (0==strcmp(P->axis,"enu"))
         return 0;
 
-    return pj_adjust_axis( P->ctx, P->axis,
+    return adjust_axis( P->ctx, P->axis,
                 dir==PJ_FWD ? 1: 0, n, dist, x, y, z );
 }
 
@@ -914,12 +914,12 @@ int pj_datum_transform( PJ *srcdefn, PJ *dstdefn,
 }
 
 /************************************************************************/
-/*                           pj_adjust_axis()                           */
+/*                           adjust_axis()                           */
 /*                                                                      */
 /*      Normalize or de-normalized the x/y/z axes.  The normal form     */
 /*      is "enu" (easting, northing, up).                               */
 /************************************************************************/
-static int pj_adjust_axis( projCtx ctx,
+static int adjust_axis( projCtx ctx,
                            const char *axis, int denormalize_flag,
                            long point_count, int point_offset,
                            double *x, double *y, double *z )

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -409,7 +409,7 @@ in cs2cs compatibility mode.
 }
 
 /*************************************************************************************/
-static int pj_cs2cs_emulation_setup (PJ *P) {
+static int cs2cs_emulation_setup (PJ *P) {
 /**************************************************************************************
 If any cs2cs style modifiers are given (axis=..., towgs84=..., ) create the 4D API
 equivalent operations, so the preparation and finalization steps in the pj_inv/pj_fwd
@@ -564,7 +564,7 @@ PJ *proj_create (PJ_CONTEXT *ctx, const char *definition) {
     pj_dealloc (args);
 
     /* Support cs2cs-style modifiers */
-    ret = pj_cs2cs_emulation_setup  (P);
+    ret = cs2cs_emulation_setup  (P);
     if (0==ret)
         return proj_destroy (P);
 


### PR DESCRIPTION
Functions should only be prefixed with 'pj_' when they can be used in
other parts of the code base and not just within a single file.

Takes care of the last step in #675.