### PR TITLE
Allow mingw32 travis tests to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,8 @@ matrix:
       env:
         - BUILD_NAME=mingw32
         - DETAILS="mingw32"
-
   allow_failures:
-      - env: BUILD_NAME=mingw32
+      - env: BUILD_NAME=mingw32 DETAILS="mingw32"
 
 before_install: ./travis/${BUILD_NAME}/before_install.sh
 


### PR DESCRIPTION
The previous attempt at allowing mingw32 tests to fail was not
sucessfull. It seems that all environment variables need to be matched
completely before the allowed failure setting is picket up. This commit
attempts to do that.