### PR TITLE
Fix Debian package name

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -56,7 +56,7 @@ Debian
 
 On Debian and similar systems (e.g. Ubuntu) the APT package manager is used::
 
-    sudo apt-get install proj
+    sudo apt-get install proj-bin
 
 Red Hat
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
On Debian/Ubuntu the `proj-bin` package provides the commandline utilities, and `libproj-dev` the library headers and `.so` symlinks, the `-dev` required to build software that links to libproj.