### PR TITLE
Add 'exact' flag to Helmert operation when doing cs2cs emulation.

### DIFF
--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -490,7 +490,7 @@ Returns 1 on success, 0 on failure
         def = malloc (100+n);
         if (0==def)
             return 0;
-        sprintf (def, "break_cs2cs_recursion     proj=helmert %s transpose", s);
+        sprintf (def, "break_cs2cs_recursion     proj=helmert exact %s transpose", s);
         Q = proj_create (P->ctx, def);
         pj_inherit_ellipsoid_def (P, Q);
         free (def);


### PR DESCRIPTION
fixes #871.