### PR TITLE
Remove final \n from pj_log messages.

### DIFF
--- a/src/nad_init.c
+++ b/src/nad_init.c
@@ -87,7 +87,7 @@ int nad_ctable_load( projCtx ctx, struct CTABLE *ct, PAFile fid )
         ct->cvs = NULL;
 
         pj_log( ctx, PJ_LOG_ERROR, 
-                "ctable loading failed on fread() - binary incompatible?\n" );
+                "ctable loading failed on fread() - binary incompatible?" );
         pj_ctx_set_errno( ctx, -38 );
         return 0;
     }

--- a/src/pj_gridinfo.c
+++ b/src/pj_gridinfo.c
@@ -536,7 +536,7 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
         ct->lim.phi = (pj_int32) (fabs(ur.phi-ct->ll.phi)/ct->del.phi + 0.5) + 1;
 
         pj_log( ctx, PJ_LOG_DEBUG_MINOR,
-                "NTv2 %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)\n",
+                "NTv2 %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)",
                 ct->id,
                 ct->lim.lam, ct->lim.phi,
                 ct->ll.lam/3600.0, ct->ll.phi/3600.0,
@@ -551,7 +551,7 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
         if( gs_count != ct->lim.lam * ct->lim.phi )
         {
             pj_log( ctx, PJ_LOG_ERROR,
-                    "GS_COUNT(%d) does not match expected cells (%dx%d=%d)\n",
+                    "GS_COUNT(%d) does not match expected cells (%dx%d=%d)",
                     gs_count, ct->lim.lam, ct->lim.phi,
                     ct->lim.lam * ct->lim.phi );
             pj_dalloc(ct);
@@ -618,7 +618,7 @@ static int pj_gridinfo_init_ntv2( projCtx ctx, PAFile fid, PJ_GRIDINFO *gilist )
             {
                 pj_log( ctx, PJ_LOG_ERROR,
                         "pj_gridinfo_init_ntv2(): "
-                        "failed to find parent %8.8s for %s.\n",
+                        "failed to find parent %8.8s for %s.",
                         (const char *) header+24, gi->ct->id );
 
                 for( lnk = gilist; lnk->next != NULL; lnk = lnk->next ) {}
@@ -943,7 +943,7 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
         gilist->ct = ct;
 
         pj_log( ctx, PJ_LOG_DEBUG_MAJOR,
-                "Ctable2 %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)\n",
+                "Ctable2 %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)",
                 ct->id,
                 ct->lim.lam, ct->lim.phi,
                 ct->ll.lam * RAD_TO_DEG, ct->ll.phi * RAD_TO_DEG,
@@ -964,7 +964,7 @@ PJ_GRIDINFO *pj_gridinfo_init( projCtx ctx, const char *gridname )
             gilist->ct = ct;
 
             pj_log( ctx, PJ_LOG_DEBUG_MAJOR,
-                    "Ctable %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)\n",
+                    "Ctable %s %dx%d: LL=(%.9g,%.9g) UR=(%.9g,%.9g)",
                     ct->id,
                     ct->lim.lam, ct->lim.phi,
                     ct->ll.lam * RAD_TO_DEG, ct->ll.phi * RAD_TO_DEG,

--- a/src/pj_init.c
+++ b/src/pj_init.c
@@ -126,7 +126,7 @@ static char *get_init_string (PJ_CONTEXT *ctx, char *name) {
     *section = 0;
     section++;
     n = strlen (section);
-    pj_log (ctx, 3, "get_init_string: searching for section [%s] in init file [%s]\n", section, fname);
+    pj_log (ctx, 3, "get_init_string: searching for section [%s] in init file [%s]", section, fname);
 
     fid = pj_open_lib (ctx, fname, "rt");
     if (0==fid) {
@@ -216,7 +216,7 @@ static char *get_init_string (PJ_CONTEXT *ctx, char *name) {
     if (0==buffer)
         return 0;
     pj_shrink (buffer);
-    pj_log (ctx, 3, "key=%s, value: [%s]\n", key, buffer);
+    pj_log (ctx, 3, "key=%s, value: [%s]", key, buffer);
     return buffer;
 }
 
@@ -236,7 +236,7 @@ Expand key from buffer or (if not in buffer) from init file
         xkey = key;
     else
         xkey += 5;
-    pj_log (ctx, 3, "get_init: searching cache for key: [%s]\n", xkey);
+    pj_log (ctx, 3, "get_init: searching cache for key: [%s]", xkey);
 
     /* Is file/key pair already in cache? */
     init_items = pj_search_initcache (xkey);
@@ -244,13 +244,13 @@ Expand key from buffer or (if not in buffer) from init file
         return init_items;
 
     /* If not, we must read it from file */
-    pj_log (ctx, 3, "get_init: searching on in init files for [%s]\n", xkey);
+    pj_log (ctx, 3, "get_init: searching on in init files for [%s]", xkey);
     definition = get_init_string (ctx, xkey);
     if (0==definition)
         return 0;
     init_items = string_to_paralist (ctx, definition);
     if (init_items)
-        pj_log (ctx, 3, "get_init: got [%s], paralist[0,1]: [%s,%s]\n", definition, init_items->param, init_items->next? init_items->next->param: "(empty)");
+        pj_log (ctx, 3, "get_init: got [%s], paralist[0,1]: [%s,%s]", definition, init_items->param, init_items->next? init_items->next->param: "(empty)");
     pj_dealloc (definition);
     if (0==init_items)
         return 0;

--- a/src/pj_open_lib.c
+++ b/src/pj_open_lib.c
@@ -198,7 +198,7 @@ pj_open_lib_ex(projCtx ctx, const char *name, const char *mode,
         pj_ctx_set_errno( ctx, errno );
 
     pj_log( ctx, PJ_LOG_DEBUG_MAJOR, 
-            "pj_open_lib(%s): call fopen(%s) - %s\n",
+            "pj_open_lib(%s): call fopen(%s) - %s",
             name, sysname,
             fid == NULL ? "failed" : "succeeded" );
 


### PR DESCRIPTION
There was a mix of pj_log calls with and without a trailing newline.
pj_stderr_logger already adds a newline to the end of each msg, so
pj_log calls don't need their own.