### PR TITLE
Avoid shadowed declaration errors with old gcc

### DIFF
--- a/src/PJ_cart.c
+++ b/src/PJ_cart.c
@@ -131,39 +131,39 @@ static double geocentric_radius (double a, double b, double phi) {
 
 
 /*********************************************************************/
-static XYZ cartesian (LPZ geodetic,  PJ *P) {
+static XYZ cartesian (LPZ geod,  PJ *P) {
 /*********************************************************************/
-    double N, cosphi = cos(geodetic.phi);
+    double N, cosphi = cos(geod.phi);
     XYZ xyz;
 
-    N   =  normal_radius_of_curvature(P->a, P->es, geodetic.phi);
+    N   =  normal_radius_of_curvature(P->a, P->es, geod.phi);
 
     /* HM formula 5-27 (z formula follows WP) */
-    xyz.x = (N + geodetic.z) * cosphi      * cos(geodetic.lam);
-    xyz.y = (N + geodetic.z) * cosphi      * sin(geodetic.lam);
-    xyz.z = (N * (1 - P->es) + geodetic.z) * sin(geodetic.phi);
+    xyz.x = (N + geod.z) * cosphi      * cos(geod.lam);
+    xyz.y = (N + geod.z) * cosphi      * sin(geod.lam);
+    xyz.z = (N * (1 - P->es) + geod.z) * sin(geod.phi);
 
     return xyz;
 }
 
 
 /*********************************************************************/
-static LPZ geodetic (XYZ cartesian,  PJ *P) {
+static LPZ geodetic (XYZ cart,  PJ *P) {
 /*********************************************************************/
     double N, p, theta, c, s;
     LPZ lpz;
 
     /* Perpendicular distance from point to Z-axis (HM eq. 5-28) */
-    p = hypot (cartesian.x, cartesian.y);
+    p = hypot (cart.x, cart.y);
 
     /* HM eq. (5-37) */
-    theta  =  atan2 (cartesian.z * P->a,  p * P->b);
+    theta  =  atan2 (cart.z * P->a,  p * P->b);
 
     /* HM eq. (5-36) (from BB, 1976) */
     c  =  cos(theta);
     s  =  sin(theta);
-    lpz.phi  =  atan2 (cartesian.z + P->e2s*P->b*s*s*s,  p - P->es*P->a*c*c*c);
-    lpz.lam  =  atan2 (cartesian.y, cartesian.x);
+    lpz.phi  =  atan2 (cart.z + P->e2s*P->b*s*s*s,  p - P->es*P->a*c*c*c);
+    lpz.lam  =  atan2 (cart.y, cart.x);
     N        =  normal_radius_of_curvature (P->a, P->es, lpz.phi);
 
 
@@ -174,7 +174,7 @@ static LPZ geodetic (XYZ cartesian,  PJ *P) {
         /* minus the geocentric radius of the Earth at the given */
         /* latitude                                              */
         double r = geocentric_radius (P->a, P->b, lpz.phi);
-        lpz.z = fabs (cartesian.z) - r;
+        lpz.z = fabs (cart.z) - r;
     }
     else
         lpz.z =  p / c  -  N;

--- a/src/PJ_horner.c
+++ b/src/PJ_horner.c
@@ -436,7 +436,7 @@ static int parse_coefs (PJ *P, double *coefs, char *param, int ncoefs) {
 /*********************************************************************/
 PJ *PROJECTION(horner) {
 /*********************************************************************/
-    int   degree = 0, n, complex_horner = 0;
+    int   degree = 0, n, complex_polynomia = 0;
     HORNER *Q;
     P->fwd4d  = horner_forward_4d;
     P->inv4d  = horner_reverse_4d;
@@ -456,14 +456,14 @@ PJ *PROJECTION(horner) {
     }
 
     if (pj_param (P->ctx, P->params, "tfwd_c").i || pj_param (P->ctx, P->params, "tinv_c").i) /* complex polynomium? */
-		complex_horner = 1;
+		complex_polynomia = 1;
 
-    Q = horner_alloc (degree, complex_horner);
+    Q = horner_alloc (degree, complex_polynomia);
     if (Q == 0)
         return horner_freeup (P, ENOMEM);
     P->opaque = (void *) Q;
 
-    if (complex_horner) {
+    if (complex_polynomia) {
         /* Westings and/or southings? */
         Q->uneg = pj_param_exists (P->params, "uneg") ? 1 : 0;
         Q->vneg = pj_param_exists (P->params, "vneg") ? 1 : 0;

--- a/src/pj_gauss.c
+++ b/src/pj_gauss.c
@@ -36,8 +36,8 @@ struct GAUSS {
 };
 #define DEL_TOL 1e-14
 
-static double srat(double esinp, double exp) {
-    return(pow((1.-esinp)/(1.+esinp), exp));
+static double srat(double esinp, double ratexp) {
+    return(pow((1.-esinp)/(1.+esinp), ratexp));
 }
 
 void *pj_gauss_ini(double e, double phi0, double *chi, double *rc) {

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -430,7 +430,7 @@ void proj_log_trace (PJ *P, const char *fmt, ...) {
 
 
 /*****************************************************************************/
-void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION log) {
+void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf) {
 /******************************************************************************
     Put a new logging function into P's context. The opaque object app_data is
     passed as first arg at each call to the logger
@@ -440,6 +440,6 @@ void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION log) {
     if (0==ctx)
         return;
     ctx->app_data = app_data;
-    if (0!=log)
-        ctx->logger = log;
+    if (0!=logf)
+        ctx->logger = logf;
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -111,7 +111,7 @@ typedef void (*PJ_LOG_FUNCTION)(void *, int, const char *);
 void proj_log_error (PJ *P, const char *fmt, ...);
 void proj_log_debug (PJ *P, const char *fmt, ...);
 void proj_log_trace (PJ *P, const char *fmt, ...);
-void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION log);
+void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf);
 
 int pj_ellipsoid (PJ *);
 void pj_inherit_ellipsoid_def (const PJ *src, PJ *dst);


### PR DESCRIPTION
On an old CentOS with gcc 4.4.7, building with CMake has errors compiling a few files due to the `-Wshadow` flag. (The build with autotools does not complain since it doesn't enable this flag, but that's possibly a different issue with whatever `AX_CFLAGS_WARN_ALL(C_WFLAGS)` is doing).

I suspect `-Wshadow` is more strict with older gcc releases, which is why this not the normal behaviour.

The modifications rename some function variable names, so that they are different than other function names used globally (e.g. `log`) or elsewhere (e.g. `geodetic`). If other variable names are preferred, I can swap these.