### PR TITLE
proj.h: update PROJ_VERSION_MAJOR.PROJ_VERSION_MINOR to 5.1

### DIFF
--- a/src/proj.h
+++ b/src/proj.h
@@ -131,7 +131,7 @@ extern "C" {
 
 /* The version numbers should be updated with every release! **/
 #define PROJ_VERSION_MAJOR 5
-#define PROJ_VERSION_MINOR 0
+#define PROJ_VERSION_MINOR 1
 #define PROJ_VERSION_PATCH 0
 
 extern char const pj_release[]; /* global release id string */


### PR DESCRIPTION
This will help avoiding issues for people tracking proj master and GDAL
See https://lists.osgeo.org/pipermail/gdal-dev/2018-March/048285.html