### PR TITLE
If HAVE_C99_MATH, define pj_is_nan as isnan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ int main() {
   int q;
   return (int)(hypot(3.0, 4.0) + atanh(0.8) + cbrt(8.0) +
                remquo(100.0, 90.0, &q) +
-               remainder(100.0, 90.0) + copysign(1.0, -0.0));
+               remainder(100.0, 90.0) + copysign(1.0, -0.0)) +
+               isnan(0.0);
 }\n" C99_MATH)
 if (C99_MATH)
   add_definitions (-DHAVE_C99_MATH=1)

--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM(
         [int q;
          return (int)(hypot(3.0, 4.0) + atanh(0.8) + cbrt(8.0) +
                       remquo(100.0, 90.0, &q) +
-                      remainder(100.0, 90.0) + copysign(1.0, -0.0));])],
+                      remainder(100.0, 90.0) + copysign(1.0, -0.0)) +
+		      isnan(0.0);])],
         [AC_MSG_RESULT([yes]);C99_MATH="-DHAVE_C99_MATH=1"],
         [AC_MSG_RESULT([no]);C99_MATH="-DHAVE_C99_MATH=0"])
 CFLAGS="$save_CFLAGS $C99_MATH"

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -445,6 +445,9 @@ void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf) {
 }
 
 
+#if HAVE_C99_MATH
+/* proj_internal.h defines pj_is_nan as isnan */
+#else
 /*****************************************************************************/
 int pj_is_nan (double val) {
 /******************************************************************************
@@ -455,3 +458,4 @@ int pj_is_nan (double val) {
     /* cppcheck-suppress duplicateExpression */
     return val != val;
 }
+#endif

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -50,6 +50,10 @@ extern "C" {
 
 #define STATIC_ASSERT(COND) ((void)sizeof(char[(COND) ? 1 : -1]))
 
+#if !defined(HAVE_C99_MATH)
+#define HAVE_C99_MATH 0
+#endif
+
 #ifndef PJ_TODEG
 #define PJ_TODEG(rad)  ((rad)*180.0/M_PI)
 #endif
@@ -130,7 +134,11 @@ void proj_fileapi_set (PJ *P, void *fileapi);
 const char * const *proj_get_searchpath(void);
 int    proj_get_path_count(void);
 
+#if HAVE_C99_MATH
+#define pj_is_nan isnan
+#else
 int pj_is_nan (double val);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Extend HAVE_C99_MATH checks in CMakeLists.txt and configure.ac to
include test for C99 function isnan.

This addresses #890.