### PR TITLE
Don't set -std=c89 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,19 +18,21 @@ set(PROJECT_INTERN_NAME PROJ)
 if (NOT CMAKE_VERSION VERSION_LESS 3.1)
   cmake_policy(SET CMP0054 NEW)
 endif ()
+
 # Set warnings
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  # Suppress warning 4706 about assignment within conditional expression
   # Suppress warning 4996 about sprintf, etc., being unsafe
-  set(CMAKE_C_FLAGS "/wd4996 /WX ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /wd4706 /wd4996 \
+    /D_CRT_SECURE_NO_WARNINGS")
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror \
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wswitch -Wshadow \
     -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat \
-    -Werror=format-security -Wshadow ${CMAKE_C_FLAGS}")
+    -Wformat-security")
 elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-  set(CMAKE_C_FLAGS "-std=c89 -Wall -Wextra -Wswitch -Werror \
-    -Wc99-extensions -Wc11-extensions -Wunused-parameter -Wmissing-prototypes \
-    -Wmissing-declarations -Wformat -Werror=format-security -Wshadow \
-    -Wfloat-conversion ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wswitch -Wshadow \
+    -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat \
+    -Wformat-security -Wfloat-conversion -Wc99-extensions -Wc11-extensions")
 endif()
 
 # Tell Intel compiler to do arithmetic accurately.  This is needed to

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,7 @@ build_script:
   - if "%BUILD_TYPE%" == "cmake" if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%BUILD_TYPE%" == "cmake" if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
   - if "%BUILD_TYPE%" == "cmake" echo "%VS_FULL%"
-# warning C4706: assignment within conditional expression
-  - if "%BUILD_TYPE%" == "cmake" cmake -G "%VS_FULL%" . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=../bin -DBUILD_LIBPROJ_SHARED=ON -DCMAKE_C_FLAGS="/W4 /wd4706 /WX /D_CRT_SECURE_NO_WARNINGS"
+  - if "%BUILD_TYPE%" == "cmake" cmake -G "%VS_FULL%" . -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=../bin -DBUILD_LIBPROJ_SHARED=ON -DCMAKE_C_FLAGS="/WX"
   - if "%BUILD_TYPE%" == "cmake" cmake --build . --config Release
 
 test_script:

--- a/travis/linux_clang/install.sh
+++ b/travis/linux_clang/install.sh
@@ -4,4 +4,4 @@ set -e
 
 export CCACHE_CPP2=yes
 
-CC="ccache clang" CFLAGS="-std=c89 -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -Wfloat-conversion -fsanitize=address -O2" ./travis/install.sh
+CC="ccache clang" CFLAGS="-std=c89 -Werror -fsanitize=address" ./travis/install.sh

--- a/travis/linux_gcc/install.sh
+++ b/travis/linux_gcc/install.sh
@@ -4,5 +4,4 @@ set -e
 
 export CCACHE_CPP2=yes
 
-#  -Wfloat-conversion not available for gcc 4.8
-CC="ccache gcc" CFLAGS="-std=c89 -g -Wall -Wextra -Werror -Wunused-parameter -Wmissing-prototypes -Wmissing-declarations -Wformat -Werror=format-security -Wshadow -O2" ./travis/install.sh
+CC="ccache gcc" CFLAGS="-std=c89 -Werror" ./travis/install.sh


### PR DESCRIPTION
This allows us to take advantage of newer features when they are available. However, builds on Travis still use `-std=c89` to ensure C89 compatibility. Locally this can be achieved with either

* cmake -DCMAKE_C_STANDARD=90 ..
* cmake -DCMAKE_C_FLAGS='-std=c89' ..
* C_FLAGS='-std=c89' cmake ..

We also reorder the warning flags: they are all part of the standard build now, but `-Werror` is only applied on Travis.

Fixes #892.