### PR TITLE
Catch over range lam0 in proj_etmerc.c

### DIFF
--- a/src/proj_etmerc.c
+++ b/src/proj_etmerc.c
@@ -345,6 +345,10 @@ PJ *PROJECTION(utm) {
         proj_errno_set(P, PJD_ERR_ELLIPSOID_USE_REQUIRED);
         return pj_default_destructor(P, ENOMEM);
     }
+    if (P->lam0 < -1000.0 || P->lam0 > 1000.0) {
+        return pj_default_destructor(P, PJD_ERR_INVALID_UTM_ZONE);
+    }
+
     P->y0 = pj_param (P->ctx, P->params, "bsouth").i ? 10000000. : 0.;
     P->x0 = 500000.;
     if (pj_param (P->ctx, P->params, "tzone").i) /* zone input ? */


### PR DESCRIPTION
lam0 of inf caused a nan in the cast to int.
Picked +/-1000 for lam0 as a guess for what constitutes reduculously large values.

proj_etmerc.c:361:16: runtime error: nan is outside the range of representable values of type 'int'

Found with autofuzz: UndefinedBehaviorSanitizer: float-cast-overflow