### PR TITLE
Rename PACKAGE_NAME: PROJ.4 Projections -> PROJ

### DIFF
--- a/cmake/Proj4Config.cmake
+++ b/cmake/Proj4Config.cmake
@@ -31,8 +31,8 @@ check_library_exists(m ceil "" HAVE_LIBM)
 
 set(PACKAGE "proj")
 set(PACKAGE_BUGREPORT "https://github.com/OSGeo/proj.4/issues")
-set(PACKAGE_NAME "PROJ.4 Projections")
-set(PACKAGE_STRING "PROJ.4 Projections ${${PROJECT_INTERN_NAME}_VERSION}")
+set(PACKAGE_NAME "PROJ")
+set(PACKAGE_STRING "PROJ ${${PROJECT_INTERN_NAME}_VERSION}")
 set(PACKAGE_TARNAME "proj")
 set(PACKAGE_VERSION "${${PROJECT_INTERN_NAME}_VERSION}")
 

--- a/cmake/Proj4Config.cmake
+++ b/cmake/Proj4Config.cmake
@@ -34,6 +34,7 @@ set(PACKAGE_BUGREPORT "https://github.com/OSGeo/proj.4/issues")
 set(PACKAGE_NAME "PROJ")
 set(PACKAGE_STRING "PROJ ${${PROJECT_INTERN_NAME}_VERSION}")
 set(PACKAGE_TARNAME "proj")
+set(PACKAGE_URL "http://proj4.org")
 set(PACKAGE_VERSION "${${PROJECT_INTERN_NAME}_VERSION}")
 
 configure_file(cmake/proj_config.cmake.in src/proj_config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
 AC_INIT([PROJ], [5.0.0],
-        [https://github.com/OSGeo/proj.4/issues], proj)
+        [https://github.com/OSGeo/proj.4/issues], proj, [http://proj4.org])
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([PROJ.4 Projections], 5.0.0, [https://github.com/OSGeo/proj.4/issues], proj)
+AC_INIT([PROJ], [5.0.0],
+        [https://github.com/OSGeo/proj.4/issues], proj)
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C)
 


### PR DESCRIPTION
Both autoconf and CMake defined PACKAGE_NAME as "PROJ.4 Projections", which I've modified to simply "PROJ". I'm not sure if there are any possible consequences for this change. The ones that I've noted are some defines in src/proj_config.h, and a few improved messages from "make check". I suspect the file name src/org_proj4_Projections.h is derived from the former PACKAGE_NAME.

I've left PACKAGE_NAME in proj.spec as "proj", as it was previously already "PROJ" in 2004-05-17 (see ChangeLog). Is file even used? It's a metadata file for "FreeGIS CD".