### PR TITLE
gie.c: Initialize test_time other fields.

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -1950,7 +1950,7 @@ static int test_time(const char* args, double tol, double t_in, double t_exp) {
     if (P == 0)
         return 5;
 
-    in.xyzt.t = t_in;
+    in = proj_coord(0.0, 0.0, 0.0, t_in);
 
     out = proj_trans(P, PJ_FWD, in);
     if (fabs(out.xyzt.t - t_exp) > tol) {


### PR DESCRIPTION
Leaving x, y, z fields unset triggers an MSAN failure.

fwd_prepare pj_fwd.c:40:9
pj_fwd4d    pj_fwd.c:260:15
proj_trans  proj_4D_api.c:166:20
test_time   gie.c:1955:11