### PR TITLE
Validate pipeline units

### DIFF
--- a/docs/source/operations/pipeline.rst
+++ b/docs/source/operations/pipeline.rst
@@ -95,4 +95,17 @@ In the following the GRS80 ellipsoid will be applied to all steps.
     +step +proj=cart +inv
     +step +proj=merc
 
+**5. Units of operations must match between steps.**
+
+.. versionadded:: 5.1.0
+
+The output units of step *n* must match the expected input unit of step *n+1*. E.g., you can't
+pass an operation that outputs projected coordinates to an operation that expects angular units
+(degrees). An example of such a unit mismatch is displayed below.
+
+::
+
+    +proj=pipeline
+    +step +proj=merc  # Mercator outputs projected coordinates
+    +step +proj=robin # The Robinson projection expects angular input
 

--- a/src/PJ_axisswap.c
+++ b/src/PJ_axisswap.c
@@ -277,8 +277,8 @@ PJ *CONVERSION(axisswap,0) {
         P->left  = PJ_IO_UNITS_ANGULAR;
         P->right = PJ_IO_UNITS_ANGULAR;
     } else {
-        P->left  = PJ_IO_UNITS_PROJECTED;
-        P->right = PJ_IO_UNITS_PROJECTED;
+        P->left  = PJ_IO_UNITS_WHATEVER;
+        P->right = PJ_IO_UNITS_WHATEVER;
     }
 
 

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -470,6 +470,19 @@ PJ *OPERATION(pipeline,0) {
         }
     }
 
+    /* Check that output units from step i are compatible with expected units in step i+1 */
+    for (i = 1; i < nsteps; i++) {
+        enum pj_io_units unit_returned = pj_right (P->opaque->pipeline[i]);
+        enum pj_io_units unit_expected = pj_left  (P->opaque->pipeline[i+1]);
+
+        if ( unit_returned == PJ_IO_UNITS_WHATEVER || unit_expected == PJ_IO_UNITS_WHATEVER )
+            continue;
+        if ( unit_returned != unit_expected ) {
+            proj_log_error (P, "Pipeline: Mismatched units between step %d and %d", i, i+1);
+            return destructor (P, PJD_ERR_MALFORMED_PIPELINE);
+        }
+    }
+
     proj_log_trace (P, "Pipeline: %d steps built. Determining i/o characteristics", nsteps);
 
     /* Determine forward input (= reverse output) data type */

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -243,4 +243,26 @@ accept      440720 3751320 0
 expect      440719.958709357 3751294.2109841 -4.44340920541435
 -------------------------------------------------------------------------------
 
+-------------------------------------------------------------------------------
+Test that pipelines with unit mismatch between steps can't be constructed.
+-------------------------------------------------------------------------------
+operation   +proj=pipeline
+            +step +proj=merc
+            +step +proj=merc
+expect      failure pjd_err_malformed_pipeline
+
+operation   +proj=pipeline
+            +step +proj=latlong
+            +step +proj=merc
+            +step +proj=helmert +x=200 +y=100
+expect      failure pjd_err_malformed_pipeline
+
+operation   +proj=pipeline
+            +step +proj=merc
+            +step +proj=unitconvert +xy_in=m +xy_out=km
+accept      12          56
+expect      1335.8339   7522.963
+-------------------------------------------------------------------------------
+
+
 </gie>


### PR DESCRIPTION
As suggested [here](https://lists.osgeo.org/pipermail/grass-dev/2018-March/088123.html), steps in a pipeline are now checked for compliance.
If the right side units in step n differ from the left side units in
step n+1 the pipeline can't be constructed and an error is raised.