### PR TITLE
Print help

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -49,6 +49,10 @@ The following control parameters can  appear  in any order:
     Write non-essential, but potentially useful, information to stderr.
     Repeat for additional information (``-vv``, ``-vvv``, etc.)
 
+.. option:: --version
+
+    Print version number.
+
 The *+args* arguments are associated with coordinate operation parameters.
 Usage varies with operation.
 

--- a/docs/source/apps/gie.rst
+++ b/docs/source/apps/gie.rst
@@ -47,6 +47,10 @@ already employed for compiling the library.
 
     List the PROJ internal system error codes
 
+.. option:: --version
+
+    Print version number
+
 Tests for :program:`gie` are defined in simple text files. Usually having the
 extension ``.gie``. Test for :program:`gie` are written in the purpose-build command language for gie.
 The basic functionality of the gie command language is implemented through just

--- a/src/cct.c
+++ b/src/cct.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
     if (0==o)
         return 0;
 
-    if (opt_given (o, "h")) {
+    if (opt_given (o, "h") || argc==1) {
         printf (usage, o->progname);
         return 0;
     }

--- a/src/cct.c
+++ b/src/cct.c
@@ -117,6 +117,7 @@ static const char usage[] = {
     "    --verbose         Alias for -v\n"
     "    --inverse         Alias for -I\n"
     "    --help            Alias for -h\n"
+    "    --version         Print version number\n"
     "--------------------------------------------------------------------------------\n"
     "Operator Specs:\n"
     "--------------------------------------------------------------------------------\n"

--- a/src/gie.c
+++ b/src/gie.c
@@ -221,6 +221,7 @@ static const char usage[] = {
     "    --verbose         Alias for -v\n"
     "    --help            Alias for -h\n"
     "    --list            Alias for -l\n"
+    "    --version         Print version number\n"
     "--------------------------------------------------------------------------------\n"
     "Examples:\n"
     "--------------------------------------------------------------------------------\n"

--- a/src/gie.c
+++ b/src/gie.c
@@ -248,7 +248,7 @@ int main (int argc, char **argv) {
     if (0==o)
         return 0;
 
-    if (opt_given (o, "h")) {
+    if (opt_given (o, "h") || argc==1) {
         printf (usage, o->progname);
         free (o);
         return 0;

--- a/src/gie.c
+++ b/src/gie.c
@@ -250,19 +250,22 @@ int main (int argc, char **argv) {
 
     if (opt_given (o, "h")) {
         printf (usage, o->progname);
+        free (o);
         return 0;
     }
 
 
     if (opt_given (o, "version")) {
         fprintf (stdout, "%s: %s\n", o->progname, pj_get_release ());
+        free (o);
         return 0;
     }
 
 
-    if (opt_given (o, "l"))
+    if (opt_given (o, "l")) {
+        free (o);
         return list_err_codes ();
-
+    }
 
     T.verbosity = opt_given (o, "q");
     if (T.verbosity)


### PR DESCRIPTION
Print help text when calling `cct` or `gie` without any arguments.