### PR TITLE
Check for sweep_axis being an empty string in PJ_geos.

### DIFF
--- a/src/PJ_geos.c
+++ b/src/PJ_geos.c
@@ -206,8 +206,8 @@ PJ *PROJECTION(geos) {
     if (sweep_axis == NULL)
       Q->flip_axis = 0;
     else {
-        if (sweep_axis[0] == '\0' || sweep_axis[1] != '\0' ||
-            (sweep_axis[0] != 'x' && sweep_axis[0] != 'y'))
+        if ((sweep_axis[0] != 'x' && sweep_axis[0] != 'y') ||
+            sweep_axis[1] != '\0')
             return pj_default_destructor (P, PJD_ERR_INVALID_SWEEP_AXIS);
 
         if (sweep_axis[0] == 'x')

--- a/src/PJ_geos.c
+++ b/src/PJ_geos.c
@@ -206,7 +206,8 @@ PJ *PROJECTION(geos) {
     if (sweep_axis == NULL)
       Q->flip_axis = 0;
     else {
-        if (sweep_axis[1] != '\0' || (sweep_axis[0] != 'x' && sweep_axis[0] != 'y'))
+        if (sweep_axis[0] == '\0' || sweep_axis[1] != '\0' ||
+            (sweep_axis[0] != 'x' && sweep_axis[0] != 'y'))
             return pj_default_destructor (P, PJD_ERR_INVALID_SWEEP_AXIS);
 
         if (sweep_axis[0] == 'x')


### PR DESCRIPTION
Found with autofuzz MemorySanitizer: use-of-uninitialized-value

\0 after sweep causes the failure:
+proj=geos +h=17892900000020003z + +sweep^@+