### PR TITLE
Enhance the precision of Spherical Mercator projection near the equator

### DIFF
--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -8,6 +8,13 @@ PROJ_HEAD(webmerc, "Web Mercator / Pseudo Mercator") "\n\tCyl, Sph\n\t";
 
 #define EPS10 1.e-10
 
+static double _tan_near_fort_pi(double x) {
+    if (fabs(x) <= __DBL_EPSILON__) {
+        return 2*x + 1.0;
+    }
+    return tan(M_FORTPI + x);
+}
+
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */
     XY xy = {0.0,0.0};
     if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) {
@@ -27,7 +34,7 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
         return xy;
 }
     xy.x = P->k0 * lp.lam;
-    xy.y = P->k0 * log(tan(M_FORTPI + .5 * lp.phi));
+    xy.y = P->k0 * log(_tan_near_fort_pi(.5 * lp.phi));
     return xy;
 }
 

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -2,6 +2,7 @@
 #include "proj_internal.h"
 #include "proj.h"
 #include "projects.h"
+#include <float.h>
 
 PROJ_HEAD(merc, "Mercator") "\n\tCyl, Sph&Ell\n\tlat_ts=";
 PROJ_HEAD(webmerc, "Web Mercator / Pseudo Mercator") "\n\tCyl, Sph\n\t";
@@ -9,7 +10,7 @@ PROJ_HEAD(webmerc, "Web Mercator / Pseudo Mercator") "\n\tCyl, Sph\n\t";
 #define EPS10 1.e-10
 
 static double _tan_near_fort_pi(double x) {
-    if (fabs(x) <= __DBL_EPSILON__) {
+    if (fabs(x) <= DBL_EPSILON) {
         return 2*x + 1.0;
     }
     return tan(M_FORTPI + x);


### PR DESCRIPTION
This uses a linear approximation of tan(x+pi/4) for better precision at small latitudes.

Before this patch:

```
cs2cs +init=epsg:4326 +to +init=epsg:3857  -v -f "%.9e" <<EOF
0 0
0 1E-14
0 1E-13
0 1E-12
0 1E-11
0 1E-10
0 1E-9
0 1
EOF
0.000000000e+00	-7.081154552e-10 0.000000000e+00
0.000000000e+00	1.416230910e-09 0.000000000e+00
0.000000000e+00	9.913616372e-09 0.000000000e+00
0.000000000e+00	1.104660110e-07 0.000000000e+00
0.000000000e+00	1.113157496e-06 0.000000000e+00
0.000000000e+00	1.113015872e-05 0.000000000e+00
0.000000000e+00	1.113199982e-04 0.000000000e+00
0.000000000e+00	1.113251429e+05 0.000000000e+00
```

After: 

```
./src/cs2cs +init=epsg:4326 +to +init=epsg:3857  -v -f "%.9e" <<EOF
0 0
0 1E-14
0 1E-13
0 1E-12
0 1E-11
0 1E-10
0 1E-9
0 1
EOF
0.000000000e+00	0.000000000e+00 0.000000000e+00
0.000000000e+00	1.416230910e-09 0.000000000e+00
0.000000000e+00	1.132984728e-08 0.000000000e+00
0.000000000e+00	1.118822419e-07 0.000000000e+00
0.000000000e+00	1.113157496e-06 0.000000000e+00
0.000000000e+00	1.113157496e-05 0.000000000e+00
0.000000000e+00	1.113199982e-04 0.000000000e+00
0.000000000e+00	1.113251429e+05 0.000000000e+00
```

All values are now more accurate (I checked using arbitrary precision arithmetic), and we have the nice property of preserving the (0,0) coordinates of the origin point.