### PR TITLE
Dont do false easting/northing on cartesian coords

### DIFF
--- a/src/pj_fwd.c
+++ b/src/pj_fwd.c
@@ -112,9 +112,6 @@ static PJ_COORD fwd_finalize (PJ *P, PJ_COORD coo) {
             coo = proj_trans (P->cart, PJ_FWD, coo);
         }
 
-        coo.xyz.x = P->fr_meter * (coo.xyz.x + P->x0);
-        coo.xyz.y = P->fr_meter * (coo.xyz.y + P->y0);
-        coo.xyz.z = P->fr_meter * (coo.xyz.z + P->z0);
         break;
 
     /* Classic proj.4 functions return plane coordinates in units of the semimajor axis */

--- a/src/pj_inv.c
+++ b/src/pj_inv.c
@@ -98,10 +98,6 @@ static PJ_COORD inv_prepare (PJ *P, PJ_COORD coo) {
 
     /* de-scale and de-offset */
     case PJ_IO_UNITS_CARTESIAN:
-        coo.xyz.x = P->to_meter * coo.xyz.x - P->x0;
-        coo.xyz.y = P->to_meter * coo.xyz.y - P->y0;
-        coo.xyz.z = P->to_meter * coo.xyz.z - P->z0;
-
         if (P->is_geocent)
             coo = proj_trans (P->cart, PJ_INV, coo);
 


### PR DESCRIPTION
False easting and northing should only be applied to projected
coordinates (`PJ_IO_UNITS_PROJECTED`). This commit removes the option of
false easting/northing on operations suchs as `helmert` and `deformation`
that both work on cartesian coordinates.