### PR TITLE
Rename level -> log_level for proj_log_level to match function definition

### DIFF
--- a/src/proj.h
+++ b/src/proj.h
@@ -361,7 +361,7 @@ int  proj_errno_reset (const PJ *P);
 int  proj_errno_restore (const PJ *P, int err);
 const char* proj_errno_string (int err);
 
-PJ_LOG_LEVEL proj_log_level (PJ_CONTEXT *ctx, PJ_LOG_LEVEL level);
+PJ_LOG_LEVEL proj_log_level (PJ_CONTEXT *ctx, PJ_LOG_LEVEL log_level);
 void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf);
 
 /* Scaling and angular distortion factors */


### PR DESCRIPTION
Found on https://github.com/OSGeo/proj.4/commit/2f082b70cbdafdea49bb123e027406089e7ad65b

http://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html

    function 'proj_log_level' has a definition with different parameter names
    src/pj_internal.c:374:14: the definition seen here
    src/proj.h:364:14: differing parameters are named here: ('level'), in definition: ('log_level')