### PR TITLE
Fix float-cast-overflow in PJ_isea.c:hexbin2

### DIFF
--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -66,13 +66,6 @@ void hexbin2(double width, double x, double y, int *i, int *j) {
     int ix, iy, iz, s;
     struct hex h;
 
-    if (pj_is_nan(x) || pj_is_nan(y) || pj_is_nan(width)) {
-        fprintf(stderr, "hexbin2 cannot handle NaN inputs\n");
-        *i = 0;
-        *j = 0;
-        return;
-    }
-
     x = x / cos(30 * M_PI / 180.0); /* rotated X coord */
     y = y - x / 2.0; /* adjustment for rotated X */
 
@@ -1044,6 +1037,12 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     struct pj_opaque *Q = P->opaque;
     struct isea_pt out;
     struct isea_geo in;
+
+    if (pj_is_nan(lp.lam) || pj_is_nan(lp.phi)) {
+        proj_log_error(P, "isea lp input has a NaN: lam: %lf phi: %lf",
+                       lp.lam, lp.phi);
+        return xy;
+    }
 
     in.lon = lp.lam;
     in.lat = lp.phi;

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
+#include "proj_internal.h"
 
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846
@@ -59,12 +60,18 @@ int hex_iso(struct hex *h) {
 }
 
 ISEA_STATIC
-int hexbin2(double width, double x, double y,
-                int *i, int *j) {
+void hexbin2(double width, double x, double y, int *i, int *j) {
     double z, rx, ry, rz;
     double abs_dx, abs_dy, abs_dz;
     int ix, iy, iz, s;
     struct hex h;
+
+    if (pj_is_nan(x) || pj_is_nan(y) || pj_is_nan(width)) {
+        fprintf(stderr, "hexbin2 cannot handle NaN inputs\n");
+        *i = 0;
+        *j = 0;
+        return;
+    }
 
     x = x / cos(30 * M_PI / 180.0); /* rotated X coord */
     y = y - x / 2.0; /* adjustment for rotated X */
@@ -105,7 +112,6 @@ int hexbin2(double width, double x, double y,
     hex_xy(&h);
     *i = h.x;
     *j = h.y;
-        return ix * 100 + iy;
 }
 #ifndef ISEA_STATIC
 #define ISEA_STATIC
@@ -1134,4 +1140,3 @@ PJ *PROJECTION(isea) {
 
     return P;
 }
-

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
-#include "proj_internal.h"
 
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846
@@ -60,7 +59,8 @@ int hex_iso(struct hex *h) {
 }
 
 ISEA_STATIC
-void hexbin2(double width, double x, double y, int *i, int *j) {
+int hexbin2(double width, double x, double y,
+                int *i, int *j) {
     double z, rx, ry, rz;
     double abs_dx, abs_dy, abs_dz;
     int ix, iy, iz, s;
@@ -105,6 +105,7 @@ void hexbin2(double width, double x, double y, int *i, int *j) {
     hex_xy(&h);
     *i = h.x;
     *j = h.y;
+        return ix * 100 + iy;
 }
 #ifndef ISEA_STATIC
 #define ISEA_STATIC
@@ -1038,12 +1039,6 @@ static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */
     struct isea_pt out;
     struct isea_geo in;
 
-    if (pj_is_nan(lp.lam) || pj_is_nan(lp.phi)) {
-        proj_log_error(P, "isea lp input has a NaN: lam: %lf phi: %lf",
-                       lp.lam, lp.phi);
-        return xy;
-    }
-
     in.lon = lp.lam;
     in.lat = lp.phi;
 
@@ -1139,3 +1134,4 @@ PJ *PROJECTION(isea) {
 
     return P;
 }
+

--- a/src/pj_fwd.c
+++ b/src/pj_fwd.c
@@ -191,7 +191,7 @@ XY pj_fwd(LP lp, PJ *P) {
 
     if (!P->skip_fwd_prepare)
         coo = fwd_prepare (P, coo);
-    if (HUGE_VAL==coo.v[0])
+    if (HUGE_VAL==coo.v[0] || pj_is_nan(coo.v[0]))
         return proj_coord_error ().xy;
 
     /* Do the transformation, using the lowest dimensional transformer available */


### PR DESCRIPTION
src/PJ_isea.c:79:10: runtime error: nan is outside the range of representable values of type 'int'

Found with autofuzz UndefinedBehaviorSanitizer

Input:
src: "++mode=di ++proj=isea +  ++step +stepp +"
dst: "++init=epsg:3249 +f=2src: \"++proj=naearth + +R_hj=nae=naea  +R_a +R_hj=natea0-src\\\" +axis=wde  +pr+R_h +oR_aejea"
x: 0
y: 3
z: 3