### PR TITLE
fix missing pj_acquire_lock etc. in proj.def

### DIFF
--- a/src/proj.def
+++ b/src/proj.def
@@ -155,3 +155,7 @@ EXPORTS
 
     proj_geod                      @140
     proj_context_errno             @141
+
+    pj_acquire_lock                @142
+    pj_release_lock                @143
+    pj_cleanup_lock                @144


### PR DESCRIPTION
make functions
pj_acquire_lock, pj_release_lock and pj_cleanup_lock
available to users of the dll on windows builds.