### PR TITLE
Cleanup pj_phi2.c

### DIFF
--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,26 +1,48 @@
-/* determine latitude angle phi-2 */
+/* Determine latitude angle phi-2. */
 
 #include <math.h>
 
 #include "projects.h"
 
-static const double TOL = 1.0e-10;
-static const int N_ITER = 15;
+/*****************************************************************************/
+double pj_phi2(projCtx ctx, double ts, double e) {
+/******************************************************************************
+Determine latitude angle phi-2.
 
-double
-pj_phi2(projCtx ctx, double ts, double e) {
-    const double eccnth = 0.5 * e;
+Inputs:
+  ts = exp(-psi) where psi is the isometric latitude (dimensionless)
+  e = eccentricity of the ellipsoid (dimensionless)
+Output:
+  phi = geographic latitude (radians)
+
+Here isometric latitude is defined by
+
+  psi = log( tan(pi/4 + phi/2) *
+             ( (1 - e*sin(phi)) / (1 + e*sin(phi)) )^(e/2) )
+      = asinh(tan(phi)) - e * atanh(e * sin(phi))
+
+This routine inverts this relation using the iterative scheme given
+by Snyder (1987), Eqs. (7-9) - (7-11)
+*******************************************************************************/
+    const double TOL = 1.0e-10;
+    const int N_ITER = 15;
     double phi = M_HALFPI - 2.0 * atan(ts);
-    int i = N_ITER;
-    for(;;) {
+    int i;
+
+    for (i = N_ITER;  i > 0;  i--) {
         const double con = e * sin(phi);
-        const double dphi = M_HALFPI - 2.0 * atan(ts * pow((1.0 - con) /
-           (1.0 + con), eccnth)) - phi;
+        const double dphi =
+            M_HALFPI -
+            2.0 * atan(ts * pow((1.0 - con) / (1.0 + con), 0.5 * e)) - phi;
+
         phi += dphi;
-        if( !(fabs(dphi) > TOL && --i) )
-            break;
+
+        if (fabs(dphi) < TOL)
+            return phi;
     }
-    if (i <= 0)
+
+    if (i == 0)
         pj_ctx_set_errno(ctx, PJD_ERR_NON_CON_INV_PHI2);
-    return phi;
+
+    return HUGE_VAL;
 }

--- a/src/pj_phi2.c
+++ b/src/pj_phi2.c
@@ -1,28 +1,26 @@
 /* determine latitude angle phi-2 */
+
+#include <math.h>
+
 #include "projects.h"
 
-#define TOL 1.0e-10
-#define N_ITER 15
+static const double TOL = 1.0e-10;
+static const int N_ITER = 15;
 
-	double
+double
 pj_phi2(projCtx ctx, double ts, double e) {
-	double eccnth, Phi, con;
-	int i;
-
-	eccnth = .5 * e;
-	Phi = M_HALFPI - 2. * atan (ts);
-	i = N_ITER;
-	for(;;) {
-		double dphi;
-		con = e * sin (Phi);
-		dphi = M_HALFPI - 2. * atan (ts * pow((1. - con) /
-		   (1. + con), eccnth)) - Phi;
-		Phi += dphi;
-		if( fabs(dphi) > TOL && --i )
-			continue;
-                break;
-	}
-	if (i <= 0)
-		pj_ctx_set_errno( ctx, -18 );
-	return Phi;
+    const double eccnth = 0.5 * e;
+    double phi = M_HALFPI - 2.0 * atan(ts);
+    int i = N_ITER;
+    for(;;) {
+        const double con = e * sin(phi);
+        const double dphi = M_HALFPI - 2.0 * atan(ts * pow((1.0 - con) /
+           (1.0 + con), eccnth)) - phi;
+        phi += dphi;
+        if( !(fabs(dphi) > TOL && --i) )
+            break;
+    }
+    if (i <= 0)
+        pj_ctx_set_errno(ctx, PJD_ERR_NON_CON_INV_PHI2);
+    return phi;
 }


### PR DESCRIPTION
- tabs -> spaces
- IWYU
- #define -> static const typed
- Add const
- At least one digit on either side of decimal points
- Combine definition and initialization
- Minimize scope of variables when possible
- Remove the odd continue / break usage inside the for
- Use the defined symbol rather than embedding bare literals
  -18 -> PJD_ERR_NON_CON_INV_PHI2