### PR TITLE
Update URL & filename for Swiss datumgrids.

### DIFF
--- a/nad/CH
+++ b/nad/CH
@@ -1,6 +1,6 @@
 # This init file provides definitions for CH1903 and CH1903/LV03
 # projections using the distortion grids developed by Swisstopo.
-# See: http://www.swisstopo.admin.ch/internet/swisstopo/en/home/topics/survey/lv03-lv95/chenyx06/distortion_grids.html
+# See: https://shop.swisstopo.admin.ch/en/products/geo_software/GIS_info
 #
 # You'll need to download the grids separately and put in a directory
 # scanned by libproj. Directories may be added to the scan list through
@@ -18,6 +18,6 @@
 #
 <metadata> +origin=Swisstopo +lastupdate=2012-02-27
 # CH1903/LV03
-<1903_LV03>  +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +nadgrids=chenyx06etrs.gsb +no_defs
+<1903_LV03>  +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +nadgrids=CHENYX06_etrs.gsb +no_defs
 # CH1903
-<1903> +proj=longlat +ellps=bessel +nadgrids=chenyx06etrs.gsb +no_defs  <>
+<1903> +proj=longlat +ellps=bessel +nadgrids=CHENYX06_etrs.gsb +no_defs  <>


### PR DESCRIPTION
As discussed in #972 the URL for the Swiss datumgrids in `nad/CH` is outdated.

The current downloads for the grids also change the filename for which the init file needs to be updated.

Fixes: #972 