### PR TITLE
Clang tidying

### DIFF
--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -145,7 +145,6 @@ static void update_parameters(PJ *P) {
         proj_log_trace(P, "rz: %g", Q->opk.k);
         proj_log_trace(P, "theta: %g", Q->theta);
     }
-    return;
 }
 
 /**************************************************************************/
@@ -302,8 +301,6 @@ static void build_rot_matrix(PJ *P) {
         proj_log_trace(P, "  | % 6.6g  % 6.6g  % 6.6g |", R10, R11, R12);
         proj_log_trace(P, "  | % 6.6g  % 6.6g  % 6.6g |", R20, R21, R22);
     }
-
-    return;
 }
 
 

--- a/src/PJ_isea.c
+++ b/src/PJ_isea.c
@@ -608,7 +608,6 @@ isea_orient_isea(struct isea_dgg * g)
     g->o_lat = ISEA_STD_LAT;
     g->o_lon = ISEA_STD_LON;
     g->o_az = 0.0;
-    return;
 }
 
 ISEA_STATIC
@@ -620,7 +619,6 @@ isea_orient_pole(struct isea_dgg * g)
     g->o_lat = M_PI / 2.0;
     g->o_lon = 0.0;
     g->o_az = 0;
-    return;
 }
 
 ISEA_STATIC

--- a/src/PJ_omerc.c
+++ b/src/PJ_omerc.c
@@ -124,9 +124,9 @@ PJ *PROJECTION(omerc) {
 
     Q->no_rot = pj_param(P->ctx, P->params, "bno_rot").i;
         if ((alp = pj_param(P->ctx, P->params, "talpha").i) != 0)
-        alpha_c = pj_param(P->ctx, P->params, "ralpha").f;
+            alpha_c = pj_param(P->ctx, P->params, "ralpha").f;
         if ((gam = pj_param(P->ctx, P->params, "tgamma").i) != 0)
-        gamma = pj_param(P->ctx, P->params, "rgamma").f;
+            gamma = pj_param(P->ctx, P->params, "rgamma").f;
     if (alp || gam) {
         lamc    = pj_param(P->ctx, P->params, "rlonc").f;
         no_off =

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -118,8 +118,8 @@ static PJ_COORD pipeline_forward_4d (PJ_COORD, PJ *P);
 static PJ_COORD pipeline_reverse_4d (PJ_COORD, PJ *P);
 static XYZ    pipeline_forward_3d (LPZ lpz, PJ *P);
 static LPZ    pipeline_reverse_3d (XYZ xyz, PJ *P);
-static XY     pipeline_forward (LP lpz, PJ *P);
-static LP     pipeline_reverse (XY xyz, PJ *P);
+static XY     pipeline_forward (LP lp, PJ *P);
+static LP     pipeline_reverse (XY xy, PJ *P);
 
 
 

--- a/src/PJ_pipeline.c
+++ b/src/PJ_pipeline.c
@@ -114,8 +114,8 @@ struct pj_opaque {
 
 
 
-static PJ_COORD pipeline_forward_4d (PJ_COORD, PJ *P);
-static PJ_COORD pipeline_reverse_4d (PJ_COORD, PJ *P);
+static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P);
+static PJ_COORD pipeline_reverse_4d (PJ_COORD point, PJ *P);
 static XYZ    pipeline_forward_3d (LPZ lpz, PJ *P);
 static LPZ    pipeline_reverse_3d (XYZ xyz, PJ *P);
 static XY     pipeline_forward (LP lp, PJ *P);

--- a/src/cct.c
+++ b/src/cct.c
@@ -88,7 +88,7 @@ Thomas Knudsen, thokn@sdfe.dk, 2016-05-25/2017-10-26
 double proj_strtod(const char *str, char **endptr);
 double proj_atof(const char *str);
 static void logger(void *data, int level, const char *msg);
-static void print(PJ_LOG_LEVEL verbosity, const char *fmt, ...);
+static void print(PJ_LOG_LEVEL log_level, const char *fmt, ...);
 
 /* Prototypes from functions in this file */
 char *column (char *buf, int n);

--- a/src/geocent.c
+++ b/src/geocent.c
@@ -432,6 +432,5 @@ void pj_Convert_Geocentric_To_Geodetic (GeocentricInfo *gi,
 /*	ellipsoidal (geodetic) latitude */
     *Latitude=atan2(SPHI, fabs(CPHI));
 
-    return;
 #endif /* defined(USE_ITERATIVE_METHOD) */
 } /* END OF Convert_Geocentric_To_Geodetic */

--- a/src/geodesic.c
+++ b/src/geodesic.c
@@ -331,7 +331,7 @@ static real Lambda12(const struct geod_geodesic* g,
                      real* pssig1, real* pcsig1,
                      real* pssig2, real* pcsig2,
                      real* peps,
-                     real* pgomg12,
+                     real* pdomg12,
                      boolx diffp, real* pdlam12,
                      /* Scratch area of the right size */
                      real Ca[]);
@@ -481,10 +481,10 @@ void geod_lineinit(struct geod_geodesicline* l,
 void geod_gendirectline(struct geod_geodesicline* l,
                         const struct geod_geodesic* g,
                         real lat1, real lon1, real azi1,
-                        unsigned flags, real a12_s12,
+                        unsigned flags, real s12_a12,
                         unsigned caps) {
   geod_lineinit(l, g, lat1, lon1, azi1, caps);
-  geod_gensetdistance(l, flags, a12_s12);
+  geod_gensetdistance(l, flags, s12_a12);
 }
 
 void geod_directline(struct geod_geodesicline* l,

--- a/src/gie.c
+++ b/src/gie.c
@@ -134,15 +134,15 @@ typedef struct ffio {
     size_t level;
 }  ffio;
 
-static int get_inp (ffio *F);
-static int skip_to_next_tag (ffio *F);
-static int step_into_gie_block (ffio *F);
-static int locate_tag (ffio *F, const char *tag);
-static int nextline (ffio *F);
-static int at_end_delimiter (ffio *F);
-static const char *at_tag (ffio *F);
-static int at_decorative_element (ffio *F);
-static ffio *ffio_destroy (ffio *F);
+static int get_inp (ffio *G);
+static int skip_to_next_tag (ffio *G);
+static int step_into_gie_block (ffio *G);
+static int locate_tag (ffio *G, const char *tag);
+static int nextline (ffio *G);
+static int at_end_delimiter (ffio *G);
+static const char *at_tag (ffio *G);
+static int at_decorative_element (ffio *G);
+static ffio *ffio_destroy (ffio *G);
 static ffio *ffio_create (const char **tags, size_t n_tags, size_t max_record_size);
 
 static const char *gie_tags[] = {
@@ -1172,15 +1172,15 @@ See the PROJ ".gie" test suites for examples of supported formatting.
 
 
 
-static int get_inp (ffio *F);
-static int skip_to_next_tag (ffio *F);
-static int step_into_gie_block (ffio *F);
-static int locate_tag (ffio *F, const char *tag);
-static int nextline (ffio *F);
-static int at_end_delimiter (ffio *F);
-static const char *at_tag (ffio *F);
-static int at_decorative_element (ffio *F);
-static ffio *ffio_destroy (ffio *F);
+static int get_inp (ffio *G);
+static int skip_to_next_tag (ffio *G);
+static int step_into_gie_block (ffio *G);
+static int locate_tag (ffio *G, const char *tag);
+static int nextline (ffio *G);
+static int at_end_delimiter (ffio *G);
+static const char *at_tag (ffio *G);
+static int at_decorative_element (ffio *G);
+static ffio *ffio_destroy (ffio *G);
 static ffio *ffio_create (const char **tags, size_t n_tags, size_t max_record_size);
 
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -1160,30 +1160,6 @@ See the PROJ ".gie" test suites for examples of supported formatting.
 
 ****************************************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-
-#include <string.h>
-#include <ctype.h>
-
-#include <math.h>
-#include <errno.h>
-
-
-
-static int get_inp (ffio *G);
-static int skip_to_next_tag (ffio *G);
-static int step_into_gie_block (ffio *G);
-static int locate_tag (ffio *G, const char *tag);
-static int nextline (ffio *G);
-static int at_end_delimiter (ffio *G);
-static const char *at_tag (ffio *G);
-static int at_decorative_element (ffio *G);
-static ffio *ffio_destroy (ffio *G);
-static ffio *ffio_create (const char **tags, size_t n_tags, size_t max_record_size);
-
-
 
 /***************************************************************************************/
 static ffio *ffio_create (const char **tags, size_t n_tags, size_t max_record_size) {

--- a/src/gie.c
+++ b/src/gie.c
@@ -303,9 +303,11 @@ int main (int argc, char **argv) {
         process_file (o->fargv[i]);
 
     if (T.verbosity > 0) {
-        if (o->fargc > 1)
-        fprintf (T.fout, "%sGrand total: %d. Success: %d, Skipped: %d, Failure: %d\n",
-                 delim, T.grand_ok+T.grand_ko+T.grand_skip, T.grand_ok, T.grand_skip, T.grand_ko);
+        if (o->fargc > 1) {
+            fprintf (T.fout, "%sGrand total: %d. Success: %d, Skipped: %d, Failure: %d\n",
+                     delim, T.grand_ok+T.grand_ko+T.grand_skip, T.grand_ok, T.grand_skip,
+                     T.grand_ko);
+        }
         fprintf (T.fout, "%s", delim);
         if (T.verbosity > 1) {
             fprintf (T.fout, "Failing roundtrips: %4d,    Succeeding roundtrips: %4d\n", fail_rtps, succ_rtps);
@@ -414,10 +416,11 @@ static int process_file (const char *fname) {
     T.grand_ok   += T.total_ok;
     T.grand_ko   += T.total_ko;
     T.grand_skip += T.grand_skip;
-    if (T.verbosity > 0)
-    fprintf (T.fout, "%stotal: %2d tests succeeded, %2d tests skipped, %2d tests %s\n",
-             delim, T.total_ok, T.total_skip, T.total_ko, T.total_ko? "FAILED!": "failed.");
-
+    if (T.verbosity > 0) {
+        fprintf (T.fout, "%stotal: %2d tests succeeded, %2d tests skipped, %2d tests %s\n",
+                 delim, T.total_ok, T.total_skip, T.total_ko,
+                 T.total_ko? "FAILED!": "failed.");
+    }
     if (F->level==0)
         return errmsg (-3, "File '%s':Missing '<gie>' cmnd - bye!\n", fname);
     if (F->level && F->level%2)

--- a/src/pj_apply_gridshift.c
+++ b/src/pj_apply_gridshift.c
@@ -174,7 +174,7 @@ static struct CTABLE* find_ctable(projCtx ctx, LP input, int grid_count, PJ_GRID
 /*      This is the real workhorse, given a gridlist.                   */
 /************************************************************************/
 
-int pj_apply_gridshift_3( projCtx ctx, PJ_GRIDINFO **tables, int grid_count,
+int pj_apply_gridshift_3( projCtx ctx, PJ_GRIDINFO **gridlist, int gridlist_count,
                           int inverse, long point_count, int point_offset,
                           double *x, double *y, double *z )
 {
@@ -183,7 +183,7 @@ int pj_apply_gridshift_3( projCtx ctx, PJ_GRIDINFO **tables, int grid_count,
     static int debug_count = 0;
     (void) z;
 
-    if( tables == NULL || grid_count == 0 )
+    if( gridlist== NULL || gridlist_count == 0 )
     {
         pj_ctx_set_errno(ctx, PJD_ERR_FAILED_TO_LOAD_GRID);
         return PJD_ERR_FAILED_TO_LOAD_GRID;
@@ -202,7 +202,7 @@ int pj_apply_gridshift_3( projCtx ctx, PJ_GRIDINFO **tables, int grid_count,
         output.phi = HUGE_VAL;
         output.lam = HUGE_VAL;
 
-        ct = find_ctable(ctx, input, grid_count, tables);
+        ct = find_ctable(ctx, input, gridlist_count, gridlist);
         if( ct != NULL )
         {
             output = nad_cvt( input, inverse, ct );
@@ -220,9 +220,9 @@ int pj_apply_gridshift_3( projCtx ctx, PJ_GRIDINFO **tables, int grid_count,
                     "                      location (%.7fdW,%.7fdN)",
                     x[io] * RAD_TO_DEG,
                     y[io] * RAD_TO_DEG );
-                for( itable = 0; itable < grid_count; itable++ )
+                for( itable = 0; itable < gridlist_count; itable++ )
                 {
-                    PJ_GRIDINFO *gi = tables[itable];
+                    PJ_GRIDINFO *gi = gridlist[itable];
                     if( itable == 0 )
                         pj_log( ctx, PJ_LOG_DEBUG_MAJOR, "   tried: %s", gi->gridname );
                     else

--- a/src/pj_gridcatalog.c
+++ b/src/pj_gridcatalog.c
@@ -234,7 +234,7 @@ int pj_gc_apply_gridshift( PJ *defn, int inverse,
 
 PJ_GRIDINFO *pj_gc_findgrid( projCtx ctx, PJ_GridCatalog *catalog, int after,
                              LP location, double date,
-                             PJ_Region *optimal_region,
+                             PJ_Region *optional_region,
                              double *grid_date ) 
 {
     int iEntry;
@@ -264,15 +264,15 @@ PJ_GRIDINFO *pj_gc_findgrid( projCtx ctx, PJ_GridCatalog *catalog, int after,
     {
         if( grid_date )
             *grid_date = 0.0;
-        if( optimal_region != NULL )
-            memset( optimal_region, 0, sizeof(PJ_Region));
+        if( optional_region != NULL )
+            memset( optional_region, 0, sizeof(PJ_Region));
         return NULL;
     }
 
     if( grid_date )
         *grid_date = entry->date;
 
-    if( optimal_region )
+    if( optional_region )
     {
         
     }

--- a/src/pj_internal.c
+++ b/src/pj_internal.c
@@ -134,7 +134,6 @@ void proj_context_set (PJ *P, PJ_CONTEXT *ctx) {
     if (0==ctx)
         ctx = pj_get_default_ctx ();
     pj_set_ctx (P, ctx);
-    return;
 }
 
 
@@ -143,7 +142,6 @@ void proj_context_inherit (PJ *parent, PJ *child) {
         pj_set_ctx (child, pj_get_default_ctx());
     else
         pj_set_ctx (child, pj_get_ctx(parent));
-    return;
 }
 
 
@@ -361,7 +359,6 @@ to that context.
     if (0==ctx)
         ctx = pj_get_default_ctx();
     pj_ctx_set_errno (ctx, err);
-    return;
 }
 
 /*  logging  */

--- a/src/pj_transform.c
+++ b/src/pj_transform.c
@@ -495,66 +495,66 @@ static int long_wrap (PJ *P, long n, int dist, double *x) {
 /************************************************************************/
 
 int pj_transform(
-    PJ *srcdefn, PJ *dstdefn,
+    PJ *src, PJ *dst,
     long point_count, int point_offset,
     double *x, double *y, double *z
 ){
     int       err;
 
-    srcdefn->ctx->last_errno = 0;
-    dstdefn->ctx->last_errno = 0;
+    src->ctx->last_errno = 0;
+    dst->ctx->last_errno = 0;
 
     if( point_offset == 0 )
         point_offset = 1;
 
     /* Bring input to "normal form": longitude, latitude, ellipsoidal height */
 
-    err = adjust_axes (srcdefn, PJ_INV, point_count, point_offset, x, y, z);
+    err = adjust_axes (src, PJ_INV, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = geographic_to_cartesian (srcdefn, PJ_INV, point_count, point_offset, x, y, z);
+    err = geographic_to_cartesian (src, PJ_INV, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = projected_to_geographic (srcdefn, point_count, point_offset, x, y, z);
+    err = projected_to_geographic (src, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = prime_meridian (srcdefn, PJ_INV, point_count, point_offset, x);
+    err = prime_meridian (src, PJ_INV, point_count, point_offset, x);
     if (err)
         return err;
-    err = height_unit (srcdefn, PJ_INV, point_count, point_offset, z);
+    err = height_unit (src, PJ_INV, point_count, point_offset, z);
     if (err)
         return err;
-    err = geometric_to_orthometric (srcdefn, PJ_INV, point_count, point_offset, x, y, z);
+    err = geometric_to_orthometric (src, PJ_INV, point_count, point_offset, x, y, z);
     if (err)
         return err;
 
     /* At the center of the process we do the datum shift (if needed) */
 
-    err = datum_transform(srcdefn, dstdefn, point_count, point_offset, x, y, z );
+    err = datum_transform(src, dst, point_count, point_offset, x, y, z );
     if (err)
         return err;
 
     /* Now get out on the other side: Bring "normal form" to output form */
 
-    err = geometric_to_orthometric (dstdefn, PJ_FWD, point_count, point_offset, x, y, z);
+    err = geometric_to_orthometric (dst, PJ_FWD, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = height_unit (dstdefn, PJ_FWD, point_count, point_offset, z);
+    err = height_unit (dst, PJ_FWD, point_count, point_offset, z);
     if (err)
         return err;
-    err = prime_meridian (dstdefn, PJ_FWD, point_count, point_offset, x);
+    err = prime_meridian (dst, PJ_FWD, point_count, point_offset, x);
     if (err)
         return err;
-    err = geographic_to_cartesian (dstdefn, PJ_FWD, point_count, point_offset, x, y, z);
+    err = geographic_to_cartesian (dst, PJ_FWD, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = geographic_to_projected (dstdefn, point_count, point_offset, x, y, z);
+    err = geographic_to_projected (dst, point_count, point_offset, x, y, z);
     if (err)
         return err;
-    err = long_wrap (dstdefn, point_count, point_offset, x);
+    err = long_wrap (dst, point_count, point_offset, x);
     if (err)
         return err;
-    err = adjust_axes (dstdefn, PJ_FWD, point_count, point_offset, x, y, z);
+    err = adjust_axes (dst, PJ_FWD, point_count, point_offset, x, y, z);
     if (err)
         return err;
 
@@ -799,7 +799,7 @@ int pj_geocentric_from_wgs84( PJ *defn,
 /*      coordinates in radians in the destination datum.                */
 /************************************************************************/
 
-int pj_datum_transform( PJ *srcdefn, PJ *dstdefn,
+int pj_datum_transform( PJ *src, PJ *dst,
                         long point_count, int point_offset,
                         double *x, double *y, double *z )
 
@@ -813,21 +813,21 @@ int pj_datum_transform( PJ *srcdefn, PJ *dstdefn,
 /*      (ie. only a +ellps declaration, no +datum).  This is new        */
 /*      behavior for PROJ 4.6.0.                                        */
 /* -------------------------------------------------------------------- */
-    if( srcdefn->datum_type == PJD_UNKNOWN
-        || dstdefn->datum_type == PJD_UNKNOWN )
+    if( src->datum_type == PJD_UNKNOWN
+        || dst->datum_type == PJD_UNKNOWN )
         return 0;
 
 /* -------------------------------------------------------------------- */
 /*      Short cut if the datums are identical.                          */
 /* -------------------------------------------------------------------- */
-    if( pj_compare_datums( srcdefn, dstdefn ) )
+    if( pj_compare_datums( src, dst ) )
         return 0;
 
-    src_a = srcdefn->a_orig;
-    src_es = srcdefn->es_orig;
+    src_a = src->a_orig;
+    src_es = src->es_orig;
 
-    dst_a = dstdefn->a_orig;
-    dst_es = dstdefn->es_orig;
+    dst_a = dst->a_orig;
+    dst_es = dst->es_orig;
 
 /* -------------------------------------------------------------------- */
 /*      Create a temporary Z array if one is not provided.              */
@@ -846,16 +846,16 @@ int pj_datum_transform( PJ *srcdefn, PJ *dstdefn,
 /*	If this datum requires grid shifts, then apply it to geodetic   */
 /*      coordinates.                                                    */
 /* -------------------------------------------------------------------- */
-    if( srcdefn->datum_type == PJD_GRIDSHIFT )
+    if( src->datum_type == PJD_GRIDSHIFT )
     {
-        pj_apply_gridshift_2( srcdefn, 0, point_count, point_offset, x, y, z );
-        CHECK_RETURN(srcdefn);
+        pj_apply_gridshift_2( src, 0, point_count, point_offset, x, y, z );
+        CHECK_RETURN(src);
 
         src_a = SRS_WGS84_SEMIMAJOR;
         src_es = SRS_WGS84_ESQUARED;
     }
 
-    if( dstdefn->datum_type == PJD_GRIDSHIFT )
+    if( dst->datum_type == PJD_GRIDSHIFT )
     {
         dst_a = SRS_WGS84_SEMIMAJOR;
         dst_es = SRS_WGS84_ESQUARED;
@@ -865,52 +865,52 @@ int pj_datum_transform( PJ *srcdefn, PJ *dstdefn,
 /*      Do we need to go through geocentric coordinates?                */
 /* ==================================================================== */
     if( src_es != dst_es || src_a != dst_a
-        || srcdefn->datum_type == PJD_3PARAM
-        || srcdefn->datum_type == PJD_7PARAM
-        || dstdefn->datum_type == PJD_3PARAM
-        || dstdefn->datum_type == PJD_7PARAM)
+        || src->datum_type == PJD_3PARAM
+        || src->datum_type == PJD_7PARAM
+        || dst->datum_type == PJD_3PARAM
+        || dst->datum_type == PJD_7PARAM)
     {
 /* -------------------------------------------------------------------- */
 /*      Convert to geocentric coordinates.                              */
 /* -------------------------------------------------------------------- */
-        srcdefn->ctx->last_errno =
+        src->ctx->last_errno =
             pj_geodetic_to_geocentric( src_a, src_es,
                                        point_count, point_offset, x, y, z );
-        CHECK_RETURN(srcdefn);
+        CHECK_RETURN(src);
 
 /* -------------------------------------------------------------------- */
 /*      Convert between datums.                                         */
 /* -------------------------------------------------------------------- */
-        if( srcdefn->datum_type == PJD_3PARAM
-            || srcdefn->datum_type == PJD_7PARAM )
+        if( src->datum_type == PJD_3PARAM
+            || src->datum_type == PJD_7PARAM )
         {
-            pj_geocentric_to_wgs84( srcdefn, point_count, point_offset,x,y,z);
-            CHECK_RETURN(srcdefn);
+            pj_geocentric_to_wgs84( src, point_count, point_offset,x,y,z);
+            CHECK_RETURN(src);
         }
 
-        if( dstdefn->datum_type == PJD_3PARAM
-            || dstdefn->datum_type == PJD_7PARAM )
+        if( dst->datum_type == PJD_3PARAM
+            || dst->datum_type == PJD_7PARAM )
         {
-            pj_geocentric_from_wgs84( dstdefn, point_count,point_offset,x,y,z);
-            CHECK_RETURN(dstdefn);
+            pj_geocentric_from_wgs84( dst, point_count,point_offset,x,y,z);
+            CHECK_RETURN(dst);
         }
 
 /* -------------------------------------------------------------------- */
 /*      Convert back to geodetic coordinates.                           */
 /* -------------------------------------------------------------------- */
-        dstdefn->ctx->last_errno =
+        dst->ctx->last_errno =
             pj_geocentric_to_geodetic( dst_a, dst_es,
                                        point_count, point_offset, x, y, z );
-        CHECK_RETURN(dstdefn);
+        CHECK_RETURN(dst);
     }
 
 /* -------------------------------------------------------------------- */
 /*      Apply grid shift to destination if required.                    */
 /* -------------------------------------------------------------------- */
-    if( dstdefn->datum_type == PJD_GRIDSHIFT )
+    if( dst->datum_type == PJD_GRIDSHIFT )
     {
-        pj_apply_gridshift_2( dstdefn, 1, point_count, point_offset, x, y, z );
-        CHECK_RETURN(dstdefn);
+        pj_apply_gridshift_2( dst, 1, point_count, point_offset, x, y, z );
+        CHECK_RETURN(dst);
     }
 
     if( z_is_temp )


### PR DESCRIPTION
Takes care of most warnings reported in https://github.com/OSGeo/proj.4/issues/859

There's a few cases where `clang-tidy` raises an indentation warning but the original code is formatted nicely although it doesn't follow `clang-tidy`s rules. Additionally there are warnings on some function parameters that could be changed to `const` which I have opted not to do since that would cause changes to prototypes in `projects.h` and `proj_api.h`.

I don't get any errors if I run

```
clang-tidy -checks=-*,readability-*,-readability-braces-around-statements*,-readability-else-after-return*,-readability-non-const-parameter,-readability-misleading-indentation *.
```

@cffk I have made a few modifications to `geodesic.c`. A few parameters names differed between `geodesic.h` and `geodesic.c` - can you check that they are okay?

Closes #859.