### PR TITLE
Limit the number of round trips to 1 million and check for underflows

### DIFF
--- a/docs/source/apps/gie.rst
+++ b/docs/source/apps/gie.rst
@@ -207,10 +207,26 @@ gie command language
     to function. The accepted coordinate is passed to the operation first in
     it's forward mode, then the output from the forward operation is passed
     back to the inverse operation. This procedure is done ``n`` times. If the
-    resulting coordinate is within the set tolerance of the initial coordinate
+    resulting coordinate is within the set tolerance of the initial coordinate,
     the test is passed.
 
-    Example:
+    Example with the default 100 iterations and the default tolerance:
+
+    .. code-block:: console
+
+        operation       proj=merc
+        accept          12 55
+        roundtrip
+
+   Example with count and default tolerance:
+
+    .. code-block:: console
+
+        operation       proj=merc
+        accept          12 55
+        roundtrip       10000
+
+   Example with count and tolerance:
 
     .. code-block:: console
 

--- a/src/gie.c
+++ b/src/gie.c
@@ -705,6 +705,20 @@ static int roundtrip (const char *args) {
 /*****************************************************************************
 Check how far we go from the ACCEPTed point when doing successive
 back/forward transformation pairs.
+
+Without args, roundtrip defaults to 100 iterations:
+
+  roundtrip
+
+With one arg, roundtrip will default to a tolerance of T.tolerance:
+
+  roundtrip ntrips
+
+With two args:
+
+  roundtrip ntrips tolerance
+
+Always returns 0.
 ******************************************************************************/
     int ntrips;
     double d, r, ans;
@@ -719,7 +733,17 @@ back/forward transformation pairs.
     }
 
     ans = proj_strtod (args, &endp);
-    ntrips = (int) (endp==args? 100: fabs(ans));
+    if (endp==args) {
+        /* Default to 100 iterations if not args. */
+        ntrips = 100;
+    } else {
+        if (ans < 1.0 || ans > 1000000.0) {
+            errmsg (2, "Invalid number of roundtrips: %lf\n", ans);
+            return another_failing_roundtrip ();
+        }
+        ntrips = (int)ans;
+    }
+
     d = strtod_scaled (endp, 1);
     d = d==HUGE_VAL?  T.tolerance:  d;
 


### PR DESCRIPTION
Why was fabs applied to ntrips?  And why is it parsed as a float?
Also add documentation for roundtrip.
External rst docs do not match this function.

Fixes #1010