### PR TITLE
Fix buffer overflow in gie.c:append_args()

### DIFF
--- a/src/gie.c
+++ b/src/gie.c
@@ -1406,7 +1406,7 @@ static int append_args (ffio *G) {
     if (tag)
         skip_chars = strlen (tag);
 
-    if (G->args_size < args_len + next_len - skip_chars + 1) {
+    if (G->args_size < args_len + next_len - skip_chars + 2) {
         void *p = realloc (G->args, 2 * G->args_size);
         if (0==p)
             return 0;

--- a/src/gie.c
+++ b/src/gie.c
@@ -1406,6 +1406,7 @@ static int append_args (ffio *G) {
     if (tag)
         skip_chars = strlen (tag);
 
+    /* +2: 1 for the space separator and 1 for the NUL termination. */
     if (G->args_size < args_len + next_len - skip_chars + 2) {
         void *p = realloc (G->args, 2 * G->args_size);
         if (0==p)


### PR DESCRIPTION
Observed a buffer overflow in append_args with autofuzz with the strcpy in append_args.
I think the +2 is required to account for both a nul char and the space.