### PR TITLE
Do not pivot over WGS84 when doing cs2cs-emulation with geocent

### DIFF
--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -524,11 +524,13 @@ Returns 1 on success, 0 on failure
             return 0;
         P->cart = skip_prep_fin (Q);
 
-        sprintf (def, "break_cs2cs_recursion     proj=cart  ellps=WGS84");
-        Q = proj_create (P->ctx, def);
-        if (0==Q)
-            return 0;
-        P->cart_wgs84 = skip_prep_fin (Q);
+        if (!P->is_geocent) {
+            sprintf (def, "break_cs2cs_recursion     proj=cart  ellps=WGS84");
+            Q = proj_create (P->ctx, def);
+            if (0==Q)
+                return 0;
+            P->cart_wgs84 = skip_prep_fin (Q);
+        }
     }
 
     return 1;

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -291,4 +291,22 @@ accept      4.05        52.1        0
 expect      4.05        52.1        -10
 -------------------------------------------------------------------------------
 
+-------------------------------------------------------------------------------
+Test bug fix of https://github.com/OSGeo/proj.4/issues/1025.
+Using geocent in the new API with a custom ellipsoid should return coordinates
+that correspond to that particular ellipsoid and not WGS84 as demonstrated in
+the bug report.
+-------------------------------------------------------------------------------
+operation   +proj=pipeline +step
+            +proj=longlat +a=3396190 +b=3376200 +inv +step
+            +proj=geocent +a=3396190 +b=3376200 +lon_0=0 +units=m
+accept      0.0         0.0     0.0
+expect      3396190.0   0.0     0.0
+roundtrip   1
+
+operation   +proj=geocent +a=3396190 +b=3376200 +lon_0=0 +units=m
+accept      0.0         0.0     0.00
+expect      3396190.0   0.0     0.0
+roundtrip   1
+
 </gie>


### PR DESCRIPTION
Fixes #1025