### PR TITLE
Add CMake configuration for test/googletest and test/unit

### DIFF
--- a/test/googletest/CMakeLists.txt.in
+++ b/test/googletest/CMakeLists.txt.in
@@ -1,0 +1,18 @@
+# Source https://github.com/google/googletest/blob/master/googletest/README.md
+cmake_minimum_required(VERSION 2.8.2) # minimum version for ExternalProject_Add
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  URL https://github.com/google/googletest/archive/release-1.8.0.zip
+  URL_HASH SHA1=667f873ab7a4d246062565fad32fb6d8e203ee73
+  DOWNLOAD_NO_PROGRESS ON
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  TEST_COMMAND      ""
+  # Disable install step
+  INSTALL_COMMAND   ""
+)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,13 +1,59 @@
-#SET(CATCH2_INCLUDE ../catch.hpp)
-#include_directories(..)
+# CMake configuration for PROJ unit tests
 
-#SET(BASIC_TEST_SRC basic_test.cpp)
-#add_executable(basic_test ${BASIC_TEST_SRC} ${CATCH2_INCLUDE})
-#target_link_libraries(basic_test ${PROJ_LIBRARIES} ${TEST_MAIN_LIBRARIES})
-#set_target_properties(basic_test
-#    PROPERTIES
-#    LINKER_LANGUAGE CXX)
+# FIXME: Deal with our old-school CMakeLists.txt behaving badly
+set(_save_c_flags "${CMAKE_C_FLAGS}")
+set(_save_cxx_flags "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "\\-W[a-z\\-]+" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+string(REGEX REPLACE "\\-W[a-z\\-]+" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
 #
-#add_test( NAME basic_test
-#            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
-#            COMMAND basic_test )
+# Build Google Test
+#
+# Source https://github.com/google/googletest/blob/master/googletest/README.md
+# Download and unpack googletest at configure time
+configure_file(
+    ${CMAKE_SOURCE_DIR}/test/googletest/CMakeLists.txt.in
+    ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+# FIXME: Deal with our old-school CMakeLists.txt behaving badly
+set(CMAKE_C_FLAGS "${_save_c_flags}")
+set(CMAKE_CXX_FLAGS "${_save_cxx_flags}")
+unset(_save_c_flags)
+unset(_save_cxx_flags)
+
+#
+# Build PROJ unit tests
+#
+add_executable(proj_test_unit
+  main.cpp
+  basic_test.cpp)
+target_link_libraries(proj_test_unit
+  gtest
+  ${PROJ_LIBRARIES})
+add_test(NAME proj_test_unit COMMAND proj_test_unit)


### PR DESCRIPTION
For CMake builds, latest googletest 1.8.0 is downloaded.

Following officially recommended integration for CMake-enabled projects
https://github.com/google/googletest/blob/master/googletest/README.md

>   "Use CMake to download GoogleTest as part of the build's configure step.
>   This is just a little more complex, but doesn't have the limitations
>   of the other methods."

Since, our copy of test/googletest

- is a very minimalist copy of googletest
- does not include any official CMake scripts
- would require copying parts of googletest CMakeLists.txt, compilater/linker flags (e.g. -lpthreads)

for reliable multi-platform builds, it is reasoanable to rely on download
All pros and cons advantages are discussed in teh README.md linked above.

Closes #1033

----

Pity GNU autotools does not support the download mode.

----

Sample session to build and run proj, googletest, and proj tests

* CMake step

```
$ cmake ..
-- The C compiler identification is GNU 7.3.0
-- The CXX compiler identification is GNU 7.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
--
-- Configuring PROJ:
--
-- PROJ_VERSION                             = 5.0.0
-- Looking for include file dlfcn.h
-- Looking for include file dlfcn.h - found
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Looking for include file jni.h
-- Looking for include file jni.h - not found
-- Looking for include file memory.h
-- Looking for include file memory.h - found
-- Looking for include file stdint.h
-- Looking for include file stdint.h - found
-- Looking for include file stdlib.h
-- Looking for include file stdlib.h - found
-- Looking for include file string.h
-- Looking for include file string.h - found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include file sys/types.h
-- Looking for include file sys/types.h - found
-- Looking for include file unistd.h
-- Looking for include file unistd.h - found
-- Looking for 4 include files stdlib.h, ..., float.h
-- Looking for 4 include files stdlib.h, ..., float.h - found
-- Looking for localeconv
-- Looking for localeconv - found
-- Looking for ceil in m
-- Looking for ceil in m - found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Looking for PTHREAD_MUTEX_RECURSIVE
-- Looking for PTHREAD_MUTEX_RECURSIVE - not found
-- Performing Test C99_MATH
-- Performing Test C99_MATH - Success
-- PROJ_PLATFORM_NAME                       = x64
-- PROJ_COMPILER_NAME                       = gcc-7
-- PROJ_TESTS                               = ON
--
-- Configuring proj library:
--
-- JNI_SUPPORT                              = OFF
-- PROJ_CORE_TARGET                         = proj
-- PROJ_CORE_TARGET_OUTPUT_NAME             = proj
-- PROJ_LIBRARY_TYPE                        = SHARED
-- PROJ_LIBRARIES                           = proj
-- Configuring done
-- Generating done
-- Build files have been written to: /mnt/d/proj.4/_build.gcc7/googletest-download
Scanning dependencies of target googletest
[ 11%] Creating directories for 'googletest'
[ 22%] Performing download step (git clone) for 'googletest'
Cloning into 'googletest-src'...
Already on 'master'
Your branch is up-to-date with 'origin/master'.
[ 33%] No patch step for 'googletest'
[ 44%] Performing update step for 'googletest'
Current branch master is up to date.
[ 55%] No configure step for 'googletest'
[ 66%] No build step for 'googletest'
[ 77%] No install step for 'googletest'
[ 88%] No test step for 'googletest'
[100%] Completed 'googletest'
[100%] Built target googletest
-- Found PythonInterp: /usr/bin/python (found version "2.7.12")
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Configuring done
-- Generating done
-- Build files have been written to: /mnt/d/proj.4/_build.gcc7
```

* Build step

```
$ cmake --build .
Scanning dependencies of target proj
[  0%] Building C object src/CMakeFiles/proj.dir/nad_init.c.o
...
Scanning dependencies of target gtest
[ 96%] Building CXX object googletest-build/googlemock/gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[ 97%] Linking CXX static library ../../../lib/libgtest.a
[ 97%] Built target gtest
Scanning dependencies of target proj_test_unit
[ 98%] Building CXX object test/unit/CMakeFiles/proj_test_unit.dir/main.cpp.o
[ 98%] Building CXX object test/unit/CMakeFiles/proj_test_unit.dir/basic_test.cpp.o
[100%] Linking CXX executable ../../bin/proj_test_unit
[100%] Built target proj_test_unit
```

* Test step

```
$ ctest -R proj_test_unit
Test project /mnt/d/proj.4/_build.gcc7
    Start 30: proj_test_unit
1/1 Test #30: proj_test_unit ...................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.04 sec
```