### PR TITLE
Add a scripts/gen_html_coverage.sh to generate local report of code c…  …overage with lcov/genhtml

### DIFF
--- a/scripts/gen_html_coverage.sh
+++ b/scripts/gen_html_coverage.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+rm -rf coverage_html
+lcov --directory src --capture --output-file proj.info
+genhtml -o ./coverage_html --ignore-errors source --num-spaces 2 proj.info 

--- a/travis/after_success.sh
+++ b/travis/after_success.sh
@@ -10,4 +10,10 @@ if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "master"; then
     echo "publish website";
     ./travis/add_deploy_key.sh;
     ./travis/deploy_website.sh $TRAVIS_BUILD_DIR/docs/build /tmp;
+
+    # Disabled: see discussion of https://github.com/OSGeo/proj.4/pull/1035
+    # if test "$BUILD_NAME" = "linux_gcc"; then
+    #     ./scripts/gen_html_coverage.sh
+    #     ./travis/deploy_html_coverage.sh
+    # fi
 fi

--- a/travis/deploy_html_coverage.sh
+++ b/travis/deploy_html_coverage.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Not used currently. See discussion of https://github.com/OSGeo/proj.4/pull/1035
+
+set -eu
+
+mkdir proj-coverage
+cd proj-coverage
+git init
+git config user.email "projbot@proj.bot"
+git config user.name "PROJ coveragebot"
+git config push.default matching
+git remote add origin git@github.com:OSGeo/proj-coverage.git
+
+cp -r ../coverage_html .
+echo "Results of coverage of PROJ test suite" > README.md
+echo "See http://rawgithub.com/OSGeo/proj-coverage/master/coverage_html/index.html" >> README.md
+git add -A > /dev/null
+git commit -m "update with results of commit https://github.com/OSGeo/proj.4/commit/$TRAVIS_COMMIT"
+git push -f origin master
+
+cd ..

--- a/travis/linux_gcc/before_install.sh
+++ b/travis/linux_gcc/before_install.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+set -e
+
 ./travis/before_install.sh
 
 sudo apt-get update -qq
 sudo apt-get install -y cppcheck
-
-set -e
+sudo apt-get install -qq lcov
 
 scripts/cppcheck.sh
 


### PR DESCRIPTION
You can already check at https://rawgit.com/OSGeo/proj-coverage/master/coverage_html/src/index.html the result of a manual run of scripts/gen_html_coverage.sh (which can be used for local evaluation of the coverage), and ./travis/deploy_html_coverage.sh