### PR TITLE
CMake: bump PROJ version to 5.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ colormsg(_HIBLUE_ "Configuring PROJ:")
 #PROJ version information
 #################################################################################
 include(ProjVersion)
-proj_version(MAJOR 5 MINOR 0 PATCH 0)
+proj_version(MAJOR 5 MINOR 1 PATCH 0)
 set(PROJ_API_VERSION "14")
 set(PROJ_BUILD_VERSION "14.0.1")
 


### PR DESCRIPTION
Align version with the one defined in configure.ac.

https://github.com/OSGeo/proj.4/blob/3e8a1984e9ee662e74254704275c8e30791a5af0/configure.ac#L4-L5

## Tasklist

- [x] Update `PROJ_VERSION`
- [x] Update `PROJ_API_VERSION`
- [x] Update `PROJ_BUILD_VERSION`

How should I update the last two?