### PR TITLE
Start a `customstyle` for bibliographic references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
+*.bak
+*.pyc
 build.local.bat
 build.local.sh
 Makefile

--- a/docs/source/bibstyle.py
+++ b/docs/source/bibstyle.py
@@ -1,0 +1,64 @@
+###############################################################################
+#
+#  Purpose: Configure custom bibliography style for sphinxcontrib-bibtex
+#  Author:  Mike Toews <mwtoews at gmail.com>
+#
+###############################################################################
+#  Copyright (c) 2018, Mike Toews <mwtoews at gmail.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import re
+from pybtex.style.formatting.unsrt import Style as UnsrtStyle
+from pybtex.style.labels.alpha import LabelStyle
+from pybtex.plugin import register_plugin
+
+
+class LinkLabelStyle(LabelStyle):
+    """Citation label used in text, and before each item in the
+    References section"""
+
+    re_char_nums = re.compile(r'^[\d\w]+$')
+
+    def format_label(self, entry):
+        """Returns BibTeX key for label
+
+        Raises KeyError if BibTeX key has other characters other than letters
+        and numbers.
+        """
+        label = entry.key
+        if not self.re_char_nums.match(label):
+            raise KeyError(
+                'BibTeX key must contain only letters and numbers '
+                '(found {0!r})'.format(label))
+        return label
+
+
+class CustomStyle(UnsrtStyle):
+    """Citation style in the References section"""
+
+    default_label_style = 'linklabel'
+    default_name_style = 'lastfirst'
+    default_sorting_style = 'author_year_title'
+    # TODO: Make more Harvard-like, i.e. year after name(s)
+
+
+register_plugin('pybtex.style.labels', 'linklabel', LinkLabelStyle)
+register_plugin('pybtex.style.formatting', 'customstyle', CustomStyle)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,9 @@ import datetime
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
+
+import bibstyle
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -156,7 +156,7 @@
 }
 
 @Article{Komsta2016,
-  Title                    = {ATPOL geobotanical grid revisited -- a proposal of coordinate conversion algorithms},
+  Title                    = {{ATPOL} geobotanical grid revisited -- a proposal of coordinate conversion algorithms},
   Author                   = {Ł. Komsta},
   Journal                  = {Annales UMCS Sectio E Agricultura},
   Year                     = {2016},

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -8,3 +8,4 @@
 
 .. bibliography:: references.bib
    :cited:
+   :style: customstyle


### PR DESCRIPTION
This PR follows on from #1041

Modifies reference label to use BibTeX key name, as it was last week. There is a check to ensure the BibTeX key name is just letters and numbers, for the RST link. Also, it's my preference to format names in References section with [`lastfirst`](https://bitbucket.org/pybtex-devs/pybtex/src/master/pybtex/style/names/lastfirst.py), e.g. switch from "F. W. Bessel" to "Bessel, F. W." However, if anyone has a strong preference to keep it `plain` (as it is right now), I can do this before merge.

TODO (if we get there) is to modify the reference style to be more Harvard-like, with year after name(s). This looks to be much more work, but it could be put into `bibstyle.py` too, or potentially committed upstream to Pybtex.

Other misc. minor additions in this commit is to fix an uppercase title for an entry, and add a few more file types to `.gitignore`. The `*.bak` is from JabRef.