### PR TITLE
deploy_website.sh: update gh-pages with a single force-pushed commit (fixes #1059)

### DIFF
--- a/travis/deploy_website.sh
+++ b/travis/deploy_website.sh
@@ -3,22 +3,27 @@
 builddir=$1
 destdir=$2
 
-
-git clone git@github.com:OSGeo/proj.4.git $destdir/projdocs
-cd $destdir/projdocs
-git checkout gh-pages
-
+rm -rf $destdir/projdocs
+mkdir -p $destdir/projdocs
 
 cd $builddir/html
 cp -rf * $destdir/projdocs
 cp $builddir/latex/proj.pdf $destdir/projdocs
 
 cd $destdir/projdocs
+git init
+git checkout -b gh-pages
+git remote add origin git@github.com:OSGeo/proj.4.git
+
 git config user.email "proj4bot@proj4.bot"
 git config user.name "proj.4 deploybot"
 
+# A few files we must manually create
+echo "_site" > .gitignore
+touch .nojekyll
+echo "proj4.org" > CNAME
 
 git add -A
 git commit -m "update with results of commit https://github.com/OSGeo/proj.4/commit/$TRAVIS_COMMIT"
-git push origin gh-pages
+git push -f origin gh-pages
 


### PR DESCRIPTION
This will avoid the history of gh-pages to grow indifinitely, and thus
the size of the PROJ git repository, whereas it has heavy binary objects
like proj.pdf that are modified by each commit.