### PR TITLE
Helmert: consider that xyzt.t == HUGE_VAL means t_epoch

### DIFF
--- a/src/PJ_helmert.c
+++ b/src/PJ_helmert.c
@@ -431,8 +431,9 @@ static PJ_COORD helmert_forward_4d (PJ_COORD point, PJ *P) {
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.xyzt.t;
+    double t_obs = (point.xyzt.t == HUGE_VAL) ? Q->t_epoch : point.xyzt.t;
+    if (t_obs != Q->t_obs) {
+        Q->t_obs = t_obs;
         update_parameters(P);
         build_rot_matrix(P);
     }
@@ -448,8 +449,9 @@ static PJ_COORD helmert_reverse_4d (PJ_COORD point, PJ *P) {
 
     /* We only need to rebuild the rotation matrix if the
      * observation time is different from the last call */
-    if (point.xyzt.t != Q->t_obs) {
-        Q->t_obs = point.xyzt.t;
+    double t_obs = (point.xyzt.t == HUGE_VAL) ? Q->t_epoch : point.xyzt.t;
+    if (t_obs != Q->t_obs) {
+        Q->t_obs = t_obs;
         update_parameters(P);
         build_rot_matrix(P);
     }


### PR DESCRIPTION
Currently when doing
```
echo "2 49 0" | src/cct  +proj=pipeline +ellps=GRS80 +step +proj=cart +step +proj=helmert +x=10 +y=3 +z=1
```
we get as a result:
```
         -nan           -nan          -nan           inf
```
This is due to cct initializing the xyzt.t to HUGE_VAL