### PR TITLE
vgridshift: add a +multiplier={value}

### DIFF
--- a/docs/source/operations/transformations/vgridshift.rst
+++ b/docs/source/operations/transformations/vgridshift.rst
@@ -113,3 +113,19 @@ Optional
 .. include:: ../options/t_final.rst
 .. versionadded:: 5.1.0
 
+.. option:: +multiplier=<value>
+
+    Specify the multiplier to apply to the grid value in the forward transformation
+    direction, such that:
+
+    .. math::
+        :label: multiplier_formula
+
+        Z_{target} = Z_{source} + multiplier \times gridvalue
+
+    The multiplier can be used to control whether the gridvalue should be added
+    or sustracted, and if unit conversion must be done (the multiplied gridvalue
+    must be expressed in metre).
+
+    Note that the default is `-1.0` for historical reasons.
+.. versionadded:: 5.2.0

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -205,8 +205,12 @@ operation proj=vgridshift grids=nonexistinggrid.gtx
 expect    failure errno failed_to_load_grid
 -------------------------------------------------------------------------------
 
-
-
+-------------------------------------------------------------------------------
+operation  proj=vgridshift  grids=egm96_15.gtx  ellps=GRS80     multiplier=0.1
+tolerance 15 cm
+ignore    pjd_err_failed_to_load_grid
+accept    12.5 55.5   0                  0
+expect    12.5 55.5  3.6021305084228516  0
 
 -------------------------------------------------------------------------------
 Some tests from PJ_hgridshift.c


### PR DESCRIPTION
As mentionned in #1071, it is often unclear how the offset of a vertical grid
is applied.