### PR TITLE
pj_strerrno(): Change check of err value to avoid undefined behavior.

### DIFF
--- a/src/pj_strerrno.c
+++ b/src/pj_strerrno.c
@@ -74,6 +74,7 @@ pj_err_list[] = {
 };
 
 char *pj_strerrno(int err) {
+    const int max_error = 9999;
     static char note[50];
     size_t adjusted_err;
 
@@ -87,17 +88,19 @@ char *pj_strerrno(int err) {
 #else
         /* Defend string boundary against exorbitantly large err values */
         /* which may occur on platforms with 64-bit ints */
-        sprintf(note,"no system list, errno: %d\n", (err < 9999)? err: 9999);
+        sprintf(note, "no system list, errno: %d\n",
+                (err < max_error) ? err: max_error);
         return note;
 #endif
     }
 
-    /* PROJ.4 error codes are negative */
-    adjusted_err = - err - 1;
+    /* PROJ.4 error codes are negative: -1 to -9999 */
+    adjusted_err = err < -max_error ? max_error : -err - 1;
     if (adjusted_err < (sizeof(pj_err_list) / sizeof(char *)))
         return (char *)pj_err_list[adjusted_err];
 
-    sprintf( note, "invalid projection system error (%d)", (err > -9999)? err: -9999);
+    sprintf(note, "invalid projection system error (%d)",
+            (err > -max_error) ? err: -max_error);
     return note;
 }
 


### PR DESCRIPTION
src/pj_strerrno.c:96:20: runtime error: negation of -2147483648 cannot be represented in type 'int'; cast to an unsigned type to negate this value to itself
    #0 in pj_strerrno proj/src/pj_strerrno.c:96:20
    #1 in (anonymous namespace)::ProjErrnoStringTest_ProjErrnos_Test::TestBody() test/unit/proj_errno_string_test.cpp:47:5

ASAN UndefinedBehaviorSanitizer: signed-integer-overflow

Issue revealed by proj_errno_string_test.cpp added in
https://github.com/OSGeo/proj.4/commit/b87b59106879188ffc684a41a9de638ac5fd02bf from https://github.com/OSGeo/proj.4/pull/1050