### PR TITLE
Fixes for webmerc projection (fixes #1078)

### DIFF
--- a/docs/source/operations/projections/webmerc.rst
+++ b/docs/source/operations/projections/webmerc.rst
@@ -24,9 +24,9 @@ From `Wikipedia <https://en.wikipedia.org/wiki/Web_Mercator>`_:
 +---------------------+----------------------------------------------------------+
 | **Classification**  | Cylindrical (non conformant if used with ellipsoid)      |
 +---------------------+----------------------------------------------------------+
-| **Available forms** | Forward and inverse, spherical projection                |
+| **Available forms** | Forward and inverse                                      |
 +---------------------+----------------------------------------------------------+
-| **Defined area**    | Global, but best used near the equator                   |
+| **Defined area**    | Global                                                   |
 +---------------------+----------------------------------------------------------+
 | **Alias**           | webmerc                                                  |
 +---------------------+----------------------------------------------------------+
@@ -49,9 +49,13 @@ Example::
 Parameters
 ################################################################################
 
-.. note:: All parameters for the projection are optional.
+.. note:: All parameters for the projection are optional, except the ellipsoid
+          definition, which is WGS84 for the typical use case of EPSG:3857.
+          In which case, the other parameters are set to their default 0 value.
 
-.. include:: ../options/R.rst
+.. include:: ../options/ellps.rst
+
+.. include:: ../options/lon_0.rst
 
 .. include:: ../options/x_0.rst
 

--- a/src/PJ_merc.c
+++ b/src/PJ_merc.c
@@ -9,7 +9,7 @@
 #include "projects.h"
 
 PROJ_HEAD(merc, "Mercator") "\n\tCyl, Sph&Ell\n\tlat_ts=";
-PROJ_HEAD(webmerc, "Web Mercator / Pseudo Mercator") "\n\tCyl, Sph\n\t";
+PROJ_HEAD(webmerc, "Web Mercator / Pseudo Mercator") "\n\tCyl, Ell\n\t";
 
 #define EPS10 1.e-10
 static double logtanpfpim1(double x) {       /* log(tan(x/2 + M_FORTPI)) */
@@ -92,15 +92,9 @@ PJ *PROJECTION(merc) {
 
 PJ *PROJECTION(webmerc) {
 
-    /* Overriding k_0, lat_0 and lon_0 with fixed parameters */
+    /* Overriding k_0 with fixed parameter */
     P->k0 = 1.0;
-    P->phi0 = 0.0;
-    P->lam0 = 0.0;
 
-    P->b = P->a;
-    /* Clean up the ellipsoidal parameters to reflect the sphere */
-    P->es = P->e = P->f = 0;
-    pj_calc_ellipsoid_params (P, P->a, 0);
     P->inv = s_inverse;
     P->fwd = s_forward;
     return P;


### PR DESCRIPTION
This is intended to supersed https://github.com/OSGeo/proj.4/pull/1080
with a number of differences.

What is kept from #1080 is not forcing the ellipsoid_params to be the one
of a sphere. This is not required for correct coordinate computation and
avoid lying on the various distorsion parameters.

For better interoperability with EPSG, we also no longer force the
lam0 parameter to 0, because
https://www.epsg-registry.org/export.htm?gml=urn:ogc:def:method:EPSG::1024
has a provision for it, even if in practice they will always be zero
phi0 should always be zero and is not used by the formulas.

Another difference with the #1080 approach is that we do not force the
WGS84 ellipsoid. Perhaps someone will use webmerc for another planet,
even if that is a crazy idea...