### PR TITLE
cct: forward comments to output

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -139,6 +139,13 @@ Should give results comparable to the classic :program:`proj` command
 
       cct -t 0 -z 0 +proj=utm +ellps=GRS80 +zone=32
 
+6. Auxiliary data following the coordinate input is forward to the output
+   stream:
+
+.. code-block:: console
+
+    $ echo 12 56 100 2018.0 auxiliary data | cct +proj=merc
+    1335833.8895   7522963.2411      100.0000     2018.0000 auxiliary data
 
 Background
 **********


### PR DESCRIPTION
Any text written after the coordinate input will automatically be
forwarded to the output stream. Text in columns before the coordinate
input is discarded in the output. This works for any combination of `-c`, `-t`
and `-z` parameters:

```
$ echo 12 56 100 2018.0 comment comment | cct +proj=merc
 1335833.8895   7522963.2411      100.0000     2018.0000 comment commen

$ echo text 12 56 100 2018.0 comment | cct -c 2,3,4,5 +proj=merc
 1335833.8895   7522963.2411      100.0000     2018.0000 comment

$ echo text 12 56 comment | cct -c 2,3 -t0 -z0 +proj=merc
 1335833.8895   7522963.2411        0.0000        0.0000 comment

$ echo 12 56 comment | cct -t0 -z0 +proj=merc
 1335833.8895   7522963.2411        0.0000        0.0000 comment
```

Closes #918