### PR TITLE
cs2cs: Always convert to degrees when angular output is received

### DIFF
--- a/src/cs2cs.c
+++ b/src/cs2cs.c
@@ -135,8 +135,8 @@ static void process(FILE *fid)
                 fputs(rtodms(pline, data.v, 'N', 'S'), stdout);
             }
 
-        } else {	/* x-y or decimal degree ascii output */
-            if ( pj_is_latlong(toProj) ) {
+        } else { /* x-y or decimal degree ascii output */
+            if ( proj_angular_output(toProj, PJ_FWD)) {
                 data.v *= RAD_TO_DEG;
                 data.u *= RAD_TO_DEG;
             }

--- a/src/cs2cs.c
+++ b/src/cs2cs.c
@@ -136,7 +136,7 @@ static void process(FILE *fid)
             }
 
         } else { /* x-y or decimal degree ascii output */
-            if ( proj_angular_output(toProj, PJ_FWD)) {
+            if ( proj_angular_output(toProj, PJ_FWD) ) {
                 data.v *= RAD_TO_DEG;
                 data.u *= RAD_TO_DEG;
             }


### PR DESCRIPTION
Previous to this commit cs2cs did not convert angular output to degrees
when using operations setting PJ->right = PJ_IO_UNITS_ANGULAR. This
commit adopts the conventions used after the introduction of pipelines.

In practice, this allows the following and similar transformations to
output in degrees and not radians:

```
echo 37.3916666667   -6.9325000 | cs2cs +proj=latlong +ellps=clrk80 \
    +to +proj=molodensky +ellps=clrk80 +da=-112.145 +df=-0.54750714e-4 \
    +dx=-175 +dy=-23 +dz=-303
37.39   -6.93 -8.2
```