### PR TITLE
Fix SONAME decrement from libproj.so.13 to libproj.so.12.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,7 @@ geodtest_LDADD = libproj.la
 
 lib_LTLIBRARIES = libproj.la
 
-libproj_la_LDFLAGS = -no-undefined -version-info 14:0:2
+libproj_la_LDFLAGS = -no-undefined -version-info 14:1:1
 
 libproj_la_SOURCES = \
 	pj_list.h proj_internal.h proj_math.h\


### PR DESCRIPTION
Increment age instead of revision for added interfaces, see:

 https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html