### PR TITLE
Don't install gtest libraries.

### DIFF
--- a/test/googletest/Makefile.am
+++ b/test/googletest/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = src include
 
 AM_CPPFLAGS = -I$(top_srcdir)/test/googletest/include
 
-lib_LTLIBRARIES = libgtest.la
+noinst_LTLIBRARIES = libgtest.la
 
 libgtest_la_LDFLAGS = -no-undefined
 libgtest_la_SOURCES = src/gtest-all.cc


### PR DESCRIPTION
Only required during the build for the test target.