### PR TITLE
Don't install test executables.

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -7,9 +7,9 @@ noinst_HEADERS = gtest_include.h
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/test -I$(top_srcdir)/test/googletest/include
 AM_CXXFLAGS = @CXX_WFLAGS@ @NO_ZERO_AS_NULL_POINTER_CONSTANT_FLAG@
 
-bin_PROGRAMS = basic_test
-bin_PROGRAMS += pj_phi2_test
-bin_PROGRAMS += proj_errno_string_test
+noinst_PROGRAMS = basic_test
+noinst_PROGRAMS += pj_phi2_test
+noinst_PROGRAMS += proj_errno_string_test
 
 basic_test_SOURCES = basic_test.cpp main.cpp
 basic_test_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la


### PR DESCRIPTION
Only required during the build for the test target.