### PR TITLE
DOC: Remove free grids from 'Non-Free Grids' section

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -93,44 +93,6 @@ Non-Free Grids
 Not all grid shift files have licensing that allows them to be freely
 distributed, but can be obtained by users through free and legal methods.
 
-Canada NTv2.0
-................................................................................
-Although NTv1 grid shifts are provided freely with PROJ, the higher-quality
-NTv2.0 file needs to be downloaded from Natural Resources Canada. More info:
-http://www.geod.nrcan.gc.ca/tools-outils/ntv2_e.php.
-
-Procedure:
-
-1. Visit the `NTv2 <http://webapp.geod.nrcan.gc.ca/geod/tools-outils/applications.php?locale=en#ntv2>`__, and register/login
-2. Follow the Download NTv2 link near the bottom of the page.
-3. Unzip ``ntv2_100325.zip`` (or similar), and move the grid shift file ``NTV2_0.GSB`` to the proj directory (be sure to change the name to lowercase for consistency) 
-   e.g.: ``mv NTV2_0.GSB /usr/local/share/proj/ntv2_0.gsb``
-4. Test it using:
-
-    ::
-
-        cs2cs +proj=latlong +ellps=clrk66 +nadgrids=@ntv2_0.gsb +to +proj=latlong +ellps=GRS80 +datum=NAD83
-        -111 50
-
-    ::
-
-        111d0'3.006"W   50d0'0.103"N 0.000  # correct answer
-
-Australia
-................................................................................
-
-`Geocentric Datum of Australia AGD66/AGD84 <http://www.icsm.gov.au/gda/tech.html>`__
-
-Canada
-................................................................................
-
-`Canadian NTv2 grid shift binary <http://open.canada.ca/data/en/dataset/b3534942-31ea-59cf-bcc3-f8dc4875081a>`__ for NAD27 <=> NAD83.
-
-Germany
-................................................................................
-
-`German BeTA2007 DHDN GK3 => ETRS89/UTM <http://crs.bkg.bund.de/crseu/crs/descrtrans/BeTA/de_dhdn2etrs_beta.php>`__
-
 Great Britain
 ................................................................................
 

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -93,43 +93,42 @@ Non-Free Grids
 Not all grid shift files have licensing that allows them to be freely
 distributed, but can be obtained by users through free and legal methods.
 
-Great Britain
-................................................................................
-
-
-`Great Britain's OSTN15_NTv2: OSGB 1936 => ETRS89 <https://www.ordnancesurvey.co.uk/docs/gps/OSTN15_NTv2.zip>`__
-
-`Great Britain's OSTN02_NTv2: OSGB 1936 => ETRS89 <http://www.ordnancesurvey.co.uk/business-and-government/help-and-support/navigation-technology/os-net/ostn02-ntv2-format.html>`__
-
 Austria
 ................................................................................
 
 `Austrian Grid <http://www.bev.gv.at/portal/page?_pageid=713,2204753&_dad=portal&_schema=PORTAL>`__ for MGI
-
-Spain
-................................................................................
-
-`Spanish grids <http://www.ign.es/ign/layoutIn/herramientas.do#DATUM>`__ for ED50.
-
-Portugal
-................................................................................
-
-`Portuguese grids <http://www.fc.up.pt/pessoas/jagoncal/coordenadas/index.htm>`__ for ED50, Lisbon 1890, Lisbon 1937 and Datum 73
 
 Brazil
 ................................................................................
 
 `Brazilian grids <http://www.ibge.gov.br/home/geociencias/geodesia/param_transf/default_param_transf.shtm>`__ for datums Corrego Alegre 1961, Corrego Alegre 1970-72, SAD69 and SAD69(96)
 
-South Africa
+Great Britain
 ................................................................................
 
-`South African grid <http://eepublishers.co.za/article/datum-transformations-using-the-ntv2-grid.html>`__ (Cape to Hartebeesthoek94 or WGS84)
+`Great Britain's OSTN15_NTv2: OSGB 1936 => ETRS89 <https://www.ordnancesurvey.co.uk/docs/gps/OSTN15_NTv2.zip>`__
+
+`Great Britain's OSTN02_NTv2: OSGB 1936 => ETRS89 <http://www.ordnancesurvey.co.uk/business-and-government/help-and-support/navigation-technology/os-net/ostn02-ntv2-format.html>`__
 
 Netherlands
 ................................................................................
 
 `Dutch grid <https://www.kadaster.nl/web/Themas/Registraties/Rijksdriehoeksmeting/Transformatie-van-coordinaten.htm>`__ (Registration required before download)
+
+Portugal
+................................................................................
+
+`Portuguese grids <http://www.fc.up.pt/pessoas/jagoncal/coordenadas/index.htm>`__ for ED50, Lisbon 1890, Lisbon 1937 and Datum 73
+
+South Africa
+................................................................................
+
+`South African grid <http://eepublishers.co.za/article/datum-transformations-using-the-ntv2-grid.html>`__ (Cape to Hartebeesthoek94 or WGS84)
+
+Spain
+................................................................................
+
+`Spanish grids <http://www.ign.es/ign/layoutIn/herramientas.do#DATUM>`__ for ED50.
 
 
 

--- a/docs/source/usage/transformation.rst
+++ b/docs/source/usage/transformation.rst
@@ -252,7 +252,7 @@ Skipping Missing Grids
 The special prefix ``@`` may be prefixed to a grid to make it optional.  If it
 not found, the search will continue to the next grid.  Normally any grid not
 found will cause an error.  For instance, the following would use the
-``ntv2_0.gsb`` file if available (see :ref:`nonfreegrids`), otherwise it would
+``ntv2_0.gsb`` file if available, otherwise it would
 fallback to using the ``ntv1_can.dat`` file.
 
 ::


### PR DESCRIPTION
These are included with proj-datumgrid:
 - Australia (various files)
 - Canada: ntv2_0.gsb
 - Germany: BETA2007.gsb

The last commit alphabetises the section, preserving the content.