### PR TITLE
Build docs from maintenance branch

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -175,9 +175,10 @@ See step 1.6 above. Do not rename the archives with RC postfixes.
 2.2 Update website
 ------------------------------------------------------------------------------
 
-  - Update the version number in `doc/source/conf.py`
   - Add the release notes from `NEWS` to `docs/source/news.rst`
   - Update download links in `docs/source/download.rst`
+  - Update `$TRAVIS_BRANCH` in `travis\after_success.sh` to new maintenance
+    branch.
 
 *Commit the changes to master and cherry-pick into maintenance branch.*
 
@@ -231,6 +232,7 @@ version numbers in the files.
   - src/proj_api.h:       Update PJ_VERSION.
   - src/pj_release.c:     Update date to the scheduled release date.
   - CMakelists.txt:       Update proj_version()
+  - doc/source/conf.py:   Update version number
 
 
 *Commit changes to master branch.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ copyright = u'1983-{0}'.format(now.year)
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-version = '5.2.0'
+version = '6.0.0'
 
 # use same |release| as |version|
 release = version

--- a/travis/after_success.sh
+++ b/travis/after_success.sh
@@ -6,7 +6,8 @@ set -e
 coveralls --extension .c --exclude build_autoconf --exclude build_cmake
 echo "$TRAVIS_SECURE_ENV_VARS"
 ./travis/build_docs.sh
-if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "master"; then
+# Only build and publish docs when changes are made on most recent maintenance branch
+if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "5.2"; then
     echo "publish website";
     ./travis/add_deploy_key.sh;
     ./travis/deploy_website.sh $TRAVIS_BUILD_DIR/docs/build /tmp;


### PR DESCRIPTION
I believe this is all it takes to only publish doc changes to the website when they are done on the 5.2 branch. Once merged the first commit should be cherry-picked into 5.2 for the changes to take effect.

@hobu have I missed anything?

Closes #1128