### PR TITLE
cs2cs_emulation_setup: fix issue with non C-locale

### DIFF
--- a/src/pj_utils.c
+++ b/src/pj_utils.c
@@ -105,6 +105,8 @@ PJ *pj_latlong_from_proj( PJ *pj_in )
         {
             char* ptr = defn+strlen(defn);
             sprintf( ptr, " +es=%.16g",  pj_in->es );
+            /* TODO later: use C++ ostringstream with imbue(std::locale::classic()) */
+            /* to be locale unaware */
             for(; *ptr; ptr++)
             {
                 if( *ptr == ',' )

--- a/src/proj_4D_api.c
+++ b/src/proj_4D_api.c
@@ -519,6 +519,17 @@ Returns 1 on success, 0 on failure
     if (P->is_geocent || P->helmert || do_cart) {
         char def[150];
         sprintf (def, "break_cs2cs_recursion     proj=cart   a=%40.20g  es=%40.20g", P->a_orig, P->es_orig);
+        {
+            /* In case the current locale does not use dot but comma as decimal */
+            /* separator, replace it with dot, so that proj_atof() behaves */
+            /* correctly. */
+            /* TODO later: use C++ ostringstream with imbue(std::locale::classic()) */
+            /* to be locale unaware */
+            char* next_pos;
+            for (next_pos = def; (next_pos = strchr (next_pos, ',')) != NULL; next_pos++) {
+                *next_pos = '.';
+            }
+        }
         Q = proj_create (P->ctx, def);
         if (0==Q)
             return 0;


### PR DESCRIPTION
in +towgs84 case, we use sprintf() with floating-point formatter to output
the ellipsoid parameters. For a locale with decimal separtor != dot, the
resulting string will not be parsed correctly by proj_atof(), leading to
wrong numeric result.

The fix is similar to the one done in pj_latlong_from_proj()

Note for later: if using C++, we could use a locale-independent formatting
solution to avoid such issue.