### PR TITLE
initialize the struct CTABLE

### DIFF
--- a/src/nad2bin.c
+++ b/src/nad2bin.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv) {
     const char *SUB_NAME = "";
     const char *CREATED  = "";
     const char *UPDATED  = "";
+    memset(&ct, 0, sizeof(ct));
 
 /* ==================================================================== */
 /*      Process arguments.                                              */


### PR DESCRIPTION
Without this patch,
openSUSE's [python-pyproj](https://github.com/jswhit/pyproj/pull/143) package would differ in every build, because
./nad2bin /tmp/x < datumgrid/stpaul.lla && md5sum /tmp/x
would differ after byte 41 because uninitialized memory was written
to the file and [ASLR](https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/aslr) randomized the memory content

See https://reproducible-builds.org/ for why this matters.

This PR was done while working on reproducible builds for openSUSE.