### PR TITLE
Make PROJ_HEAD descriptions more uniform

### DIFF
--- a/src/PJ_airy.c
+++ b/src/PJ_airy.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include "projects.h"
 
-PROJ_HEAD(airy, "Airy") "\n\tMisc Sph, no inv.\n\tno_cut lat_b=";
+PROJ_HEAD(airy, "Airy") "\n\tMisc Sph, no inv\n\tno_cut lat_b=";
 
 
 enum Mode {

--- a/src/PJ_august.c
+++ b/src/PJ_august.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(august, "August Epicycloidal") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(august, "August Epicycloidal") "\n\tMisc Sph, no inv";
 #define M 1.333333333333333
 
 

--- a/src/PJ_bacon.c
+++ b/src/PJ_bacon.c
@@ -12,9 +12,9 @@ struct pj_opaque {
 	int ortl;
 };
 
-PROJ_HEAD(apian, "Apian Globular I") "\n\tMisc Sph, no inv.";
-PROJ_HEAD(ortel, "Ortelius Oval") "\n\tMisc Sph, no inv.";
-PROJ_HEAD(bacon, "Bacon Globular") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(apian, "Apian Globular I") "\n\tMisc Sph, no inv";
+PROJ_HEAD(ortel, "Ortelius Oval") "\n\tMisc Sph, no inv";
+PROJ_HEAD(bacon, "Bacon Globular") "\n\tMisc Sph, no inv";
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */

--- a/src/PJ_bipc.c
+++ b/src/PJ_bipc.c
@@ -6,7 +6,7 @@
 #include "projects.h"
 #include "proj_math.h"
 
-PROJ_HEAD(bipc, "Bipolar conic of western hemisphere") "\n\tConic Sph.";
+PROJ_HEAD(bipc, "Bipolar conic of western hemisphere") "\n\tConic Sph";
 
 # define EPS    1e-10
 # define EPS10  1e-10

--- a/src/PJ_boggs.c
+++ b/src/PJ_boggs.c
@@ -3,7 +3,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl., no inv., Sph.";
+PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl, no inv, Sph";
 # define NITER	20
 # define EPS	1e-7
 # define FXC	2.00276

--- a/src/PJ_ccon.c
+++ b/src/PJ_ccon.c
@@ -37,7 +37,7 @@ struct pj_opaque {
 };
 
 PROJ_HEAD(ccon, "Central Conic")
-    "\n\tCentral Conic, Sph.\n\tlat_1=";
+    "\n\tCentral Conic, Sph\n\tlat_1=";
 
 
 

--- a/src/PJ_chamb.c
+++ b/src/PJ_chamb.c
@@ -19,7 +19,7 @@ struct pj_opaque {
     double beta_0, beta_1, beta_2;
 };
 
-PROJ_HEAD(chamb, "Chamberlin Trimetric") "\n\tMisc Sph, no inv."
+PROJ_HEAD(chamb, "Chamberlin Trimetric") "\n\tMisc Sph, no inv"
 "\n\tlat_1= lon_1= lat_2= lon_2= lat_3= lon_3=";
 
 #include <stdio.h>

--- a/src/PJ_collg.c
+++ b/src/PJ_collg.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(collg, "Collignon") "\n\tPCyl, Sph.";
+PROJ_HEAD(collg, "Collignon") "\n\tPCyl, Sph";
 #define FXC 1.12837916709551257390
 #define FYC 1.77245385090551602729
 #define ONEEPS  1.0000001

--- a/src/PJ_comill.c
+++ b/src/PJ_comill.c
@@ -12,7 +12,7 @@ Port to PROJ.4 by Bojan Savric, 4 April 2016
 
 #include "projects.h"
 
-PROJ_HEAD(comill, "Compact Miller") "\n\tCyl., Sph.";
+PROJ_HEAD(comill, "Compact Miller") "\n\tCyl, Sph";
 
 #define K1 0.9902
 #define K2 0.1604

--- a/src/PJ_crast.c
+++ b/src/PJ_crast.c
@@ -3,7 +3,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(crast, "Craster Parabolic (Putnins P4)") "\n\tPCyl., Sph.";
+PROJ_HEAD(crast, "Craster Parabolic (Putnins P4)") "\n\tPCyl, Sph";
 
 #define XM  0.97720502380583984317
 #define RXM 1.02332670794648848847

--- a/src/PJ_denoy.c
+++ b/src/PJ_denoy.c
@@ -3,7 +3,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(denoy, "Denoyer Semi-Elliptical") "\n\tPCyl., no inv., Sph.";
+PROJ_HEAD(denoy, "Denoyer Semi-Elliptical") "\n\tPCyl, no inv, Sph";
 
 #define C0  0.95
 #define C1 -0.08333333333333333333

--- a/src/PJ_eck1.c
+++ b/src/PJ_eck1.c
@@ -3,7 +3,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(eck1, "Eckert I") "\n\tPCyl., Sph.";
+PROJ_HEAD(eck1, "Eckert I") "\n\tPCyl, Sph";
 #define FC  0.92131773192356127802
 #define RP  0.31830988618379067154
 

--- a/src/PJ_eck2.c
+++ b/src/PJ_eck2.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(eck2, "Eckert II") "\n\tPCyl. Sph.";
+PROJ_HEAD(eck2, "Eckert II") "\n\tPCyl, Sph";
 
 #define FXC     0.46065886596178063902
 #define FYC     1.44720250911653531871

--- a/src/PJ_eck3.c
+++ b/src/PJ_eck3.c
@@ -5,10 +5,10 @@
 
 #include "projects.h"
 
-PROJ_HEAD(eck3, "Eckert III") "\n\tPCyl, Sph.";
-PROJ_HEAD(putp1, "Putnins P1") "\n\tPCyl, Sph.";
-PROJ_HEAD(wag6, "Wagner VI") "\n\tPCyl, Sph.";
-PROJ_HEAD(kav7, "Kavraisky VII") "\n\tPCyl, Sph.";
+PROJ_HEAD(eck3, "Eckert III") "\n\tPCyl, Sph";
+PROJ_HEAD(putp1, "Putnins P1") "\n\tPCyl, Sph";
+PROJ_HEAD(wag6, "Wagner VI") "\n\tPCyl, Sph";
+PROJ_HEAD(kav7, "Kavraisky VII") "\n\tPCyl, Sph";
 
 struct pj_opaque {
     double C_x, C_y, A, B;

--- a/src/PJ_eck4.c
+++ b/src/PJ_eck4.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(eck4, "Eckert IV") "\n\tPCyl, Sph.";
+PROJ_HEAD(eck4, "Eckert IV") "\n\tPCyl, Sph";
 
 #define C_x .42223820031577120149
 #define C_y 1.32650042817700232218

--- a/src/PJ_eck5.c
+++ b/src/PJ_eck5.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(eck5, "Eckert V") "\n\tPCyl, Sph.";
+PROJ_HEAD(eck5, "Eckert V") "\n\tPCyl, Sph";
 
 #define XF  0.44101277172455148219
 #define RXF 2.26750802723822639137

--- a/src/PJ_eqearth.c
+++ b/src/PJ_eqearth.c
@@ -18,7 +18,7 @@ Added ellipsoidal equations by Bojan Savric, 22 August 2018
 
 #include "projects.h"
 
-PROJ_HEAD(eqearth, "Equal Earth") "\n\tPCyl., Sph&Ell";
+PROJ_HEAD(eqearth, "Equal Earth") "\n\tPCyl, Sph&Ell";
 
 /* A1..A4, polynomial coefficients */
 #define A1 1.340264
@@ -62,7 +62,7 @@ static XY e_forward (LP lp, PJ *P) {           /* Ellipsoidal/spheroidal, forwar
 
     xy.x = lp.lam * cos(psi) / (M * (A1 + 3 * A2 * psi2 + psi6 * (7 * A3 + 9 * A4 * psi2)));
     xy.y = psi * (A1 + A2 * psi2 + psi6 * (A3 + A4 * psi2));
-    
+
     /* Adjusting x and y for authalic radius */
     xy.x *= Q->rqda;
     xy.y *= Q->rqda;

--- a/src/PJ_fahey.c
+++ b/src/PJ_fahey.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(fahey, "Fahey") "\n\tPcyl, Sph.";
+PROJ_HEAD(fahey, "Fahey") "\n\tPcyl, Sph";
 
 #define TOL 1e-6
 

--- a/src/PJ_fouc_s.c
+++ b/src/PJ_fouc_s.c
@@ -6,7 +6,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(fouc_s, "Foucaut Sinusoidal") "\n\tPCyl., Sph.";
+PROJ_HEAD(fouc_s, "Foucaut Sinusoidal") "\n\tPCyl, Sph";
 
 #define MAX_ITER    10
 #define LOOP_TOL    1e-7

--- a/src/PJ_gins8.c
+++ b/src/PJ_gins8.c
@@ -1,7 +1,7 @@
 #define PJ_LIB__
 #include "projects.h"
 
-PROJ_HEAD(gins8, "Ginsburg VIII (TsNIIGAiK)") "\n\tPCyl, Sph., no inv.";
+PROJ_HEAD(gins8, "Ginsburg VIII (TsNIIGAiK)") "\n\tPCyl, Sph, no inv";
 
 #define Cl 0.000952426
 #define Cp 0.162388

--- a/src/PJ_gn_sinu.c
+++ b/src/PJ_gn_sinu.c
@@ -6,10 +6,10 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(gn_sinu, "General Sinusoidal Series") "\n\tPCyl, Sph.\n\tm= n=";
+PROJ_HEAD(gn_sinu, "General Sinusoidal Series") "\n\tPCyl, Sph\n\tm= n=";
 PROJ_HEAD(sinu, "Sinusoidal (Sanson-Flamsteed)") "\n\tPCyl, Sph&Ell";
-PROJ_HEAD(eck6, "Eckert VI") "\n\tPCyl, Sph.";
-PROJ_HEAD(mbtfps, "McBryde-Thomas Flat-Polar Sinusoidal") "\n\tPCyl, Sph.";
+PROJ_HEAD(eck6, "Eckert VI") "\n\tPCyl, Sph";
+PROJ_HEAD(mbtfps, "McBryde-Thomas Flat-Polar Sinusoidal") "\n\tPCyl, Sph";
 
 #define EPS10    1e-10
 #define MAX_ITER 8

--- a/src/PJ_gnom.c
+++ b/src/PJ_gnom.c
@@ -7,7 +7,7 @@
 #include "projects.h"
 #include "proj_math.h"
 
-PROJ_HEAD(gnom, "Gnomonic") "\n\tAzi, Sph.";
+PROJ_HEAD(gnom, "Gnomonic") "\n\tAzi, Sph";
 
 #define EPS10  1.e-10
 

--- a/src/PJ_goode.c
+++ b/src/PJ_goode.c
@@ -6,7 +6,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(goode, "Goode Homolosine") "\n\tPCyl, Sph.";
+PROJ_HEAD(goode, "Goode Homolosine") "\n\tPCyl, Sph";
 
 #define Y_COR   0.05280
 #define PHI_LIM 0.71093078197902358062

--- a/src/PJ_hatano.c
+++ b/src/PJ_hatano.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(hatano, "Hatano Asymmetrical Equal Area") "\n\tPCyl, Sph.";
+PROJ_HEAD(hatano, "Hatano Asymmetrical Equal Area") "\n\tPCyl, Sph";
 
 #define NITER   20
 #define EPS 1e-7

--- a/src/PJ_healpix.c
+++ b/src/PJ_healpix.c
@@ -37,8 +37,8 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(healpix, "HEALPix") "\n\tSph., Ellps.";
-PROJ_HEAD(rhealpix, "rHEALPix") "\n\tSph., Ellps.\n\tnorth_square= south_square=";
+PROJ_HEAD(healpix, "HEALPix") "\n\tSph&Ell";
+PROJ_HEAD(rhealpix, "rHEALPix") "\n\tSph&Ell\n\tnorth_square= south_square=";
 
 /* Matrix for counterclockwise rotation by pi/2: */
 # define R1 {{ 0,-1},{ 1, 0}}

--- a/src/PJ_igh.c
+++ b/src/PJ_igh.c
@@ -5,7 +5,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(igh, "Interrupted Goode Homolosine") "\n\tPCyl, Sph.";
+PROJ_HEAD(igh, "Interrupted Goode Homolosine") "\n\tPCyl, Sph";
 
 C_NAMESPACE PJ *pj_sinu(PJ *), *pj_moll(PJ *);
 

--- a/src/PJ_krovak.c
+++ b/src/PJ_krovak.c
@@ -82,7 +82,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(krovak, "Krovak") "\n\tPCyl., Ellps.";
+PROJ_HEAD(krovak, "Krovak") "\n\tPCyl, Ell";
 
 #define EPS 1e-15
 #define UQ  1.04216856380474   /* DU(2, 59, 42, 42.69689) */

--- a/src/PJ_larr.c
+++ b/src/PJ_larr.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(larr, "Larrivee") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(larr, "Larrivee") "\n\tMisc Sph, no inv";
 
 #define SIXTH .16666666666666666
 

--- a/src/PJ_lask.c
+++ b/src/PJ_lask.c
@@ -1,7 +1,7 @@
 #define PJ_LIB__
 #include "projects.h"
 
-PROJ_HEAD(lask, "Laskowski") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(lask, "Laskowski") "\n\tMisc Sph, no inv";
 
 #define a10  0.975534
 #define a12 -0.119161

--- a/src/PJ_mbt_fps.c
+++ b/src/PJ_mbt_fps.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(mbt_fps, "McBryde-Thomas Flat-Pole Sine (No. 2)") "\n\tCyl., Sph.";
+PROJ_HEAD(mbt_fps, "McBryde-Thomas Flat-Pole Sine (No. 2)") "\n\tCyl, Sph";
 
 #define MAX_ITER    10
 #define LOOP_TOL    1e-7

--- a/src/PJ_mbtfpp.c
+++ b/src/PJ_mbtfpp.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(mbtfpp, "McBride-Thomas Flat-Polar Parabolic") "\n\tCyl., Sph.";
+PROJ_HEAD(mbtfpp, "McBride-Thomas Flat-Polar Parabolic") "\n\tCyl, Sph";
 
 #define CS  .95257934441568037152
 #define FXC .92582009977255146156

--- a/src/PJ_mbtfpq.c
+++ b/src/PJ_mbtfpq.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(mbtfpq, "McBryde-Thomas Flat-Polar Quartic") "\n\tCyl., Sph.";
+PROJ_HEAD(mbtfpq, "McBryde-Thomas Flat-Polar Quartic") "\n\tCyl, Sph";
 
 #define NITER   20
 #define EPS 1e-7

--- a/src/PJ_moll.c
+++ b/src/PJ_moll.c
@@ -5,9 +5,9 @@
 
 #include "projects.h"
 
-PROJ_HEAD(moll, "Mollweide") "\n\tPCyl., Sph.";
-PROJ_HEAD(wag4, "Wagner IV") "\n\tPCyl., Sph.";
-PROJ_HEAD(wag5, "Wagner V") "\n\tPCyl., Sph.";
+PROJ_HEAD(moll, "Mollweide") "\n\tPCyl, Sph";
+PROJ_HEAD(wag4, "Wagner IV") "\n\tPCyl, Sph";
+PROJ_HEAD(wag5, "Wagner V") "\n\tPCyl, Sph";
 
 #define MAX_ITER    10
 #define LOOP_TOL    1e-7

--- a/src/PJ_natearth.c
+++ b/src/PJ_natearth.c
@@ -18,7 +18,7 @@ Port to PROJ.4 by Bernhard Jenny, 6 June 2011
 
 #include "projects.h"
 
-PROJ_HEAD(natearth, "Natural Earth") "\n\tPCyl., Sph.";
+PROJ_HEAD(natearth, "Natural Earth") "\n\tPCyl, Sph";
 
 #define A0 0.8707
 #define A1 -0.131979

--- a/src/PJ_natearth2.c
+++ b/src/PJ_natearth2.c
@@ -11,7 +11,7 @@ Port to PROJ.4 by Bojan Savric, 4 April 2016
 
 #include "projects.h"
 
-PROJ_HEAD(natearth2, "Natural Earth 2") "\n\tPCyl., Sph.";
+PROJ_HEAD(natearth2, "Natural Earth 2") "\n\tPCyl, Sph";
 
 #define A0 0.84719
 #define A1 -0.13063

--- a/src/PJ_nell.c
+++ b/src/PJ_nell.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(nell, "Nell") "\n\tPCyl., Sph.";
+PROJ_HEAD(nell, "Nell") "\n\tPCyl, Sph";
 
 #define MAX_ITER 10
 #define LOOP_TOL 1e-7

--- a/src/PJ_nell_h.c
+++ b/src/PJ_nell_h.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(nell_h, "Nell-Hammer") "\n\tPCyl., Sph.";
+PROJ_HEAD(nell_h, "Nell-Hammer") "\n\tPCyl, Sph";
 
 #define NITER 9
 #define EPS 1e-7

--- a/src/PJ_nocol.c
+++ b/src/PJ_nocol.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(nicol, "Nicolosi Globular") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(nicol, "Nicolosi Globular") "\n\tMisc Sph, no inv";
 
 #define EPS 1e-10
 

--- a/src/PJ_ortho.c
+++ b/src/PJ_ortho.c
@@ -5,7 +5,7 @@
 #include "proj_math.h"
 #include "projects.h"
 
-PROJ_HEAD(ortho, "Orthographic") "\n\tAzi, Sph.";
+PROJ_HEAD(ortho, "Orthographic") "\n\tAzi, Sph";
 
 enum Mode {
     N_POLE = 0,

--- a/src/PJ_patterson.c
+++ b/src/PJ_patterson.c
@@ -44,7 +44,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(patterson, "Patterson Cylindrical") "\n\tCyl.";
+PROJ_HEAD(patterson, "Patterson Cylindrical") "\n\tCyl";
 
 #define K1 1.0148
 #define K2 0.23185

--- a/src/PJ_putp2.c
+++ b/src/PJ_putp2.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(putp2, "Putnins P2") "\n\tPCyl., Sph.";
+PROJ_HEAD(putp2, "Putnins P2") "\n\tPCyl, Sph";
 
 #define C_x	1.89490
 #define C_y	1.71848

--- a/src/PJ_putp3.c
+++ b/src/PJ_putp3.c
@@ -6,8 +6,8 @@ struct pj_opaque {
     double  A;
 };
 
-PROJ_HEAD(putp3, "Putnins P3") "\n\tPCyl., Sph.";
-PROJ_HEAD(putp3p, "Putnins P3'") "\n\tPCyl., Sph.";
+PROJ_HEAD(putp3, "Putnins P3") "\n\tPCyl, Sph";
+PROJ_HEAD(putp3p, "Putnins P3'") "\n\tPCyl, Sph";
 
 #define C       0.79788456
 #define RPISQ   0.1013211836

--- a/src/PJ_putp4p.c
+++ b/src/PJ_putp4p.c
@@ -9,8 +9,8 @@ struct pj_opaque {
     double C_x, C_y;
 };
 
-PROJ_HEAD(putp4p, "Putnins P4'") "\n\tPCyl., Sph.";
-PROJ_HEAD(weren, "Werenskiold I") "\n\tPCyl., Sph.";
+PROJ_HEAD(putp4p, "Putnins P4'") "\n\tPCyl, Sph";
+PROJ_HEAD(weren, "Werenskiold I") "\n\tPCyl, Sph";
 
 
 static XY s_forward (LP lp, PJ *P) {           /* Spheroidal, forward */

--- a/src/PJ_putp5.c
+++ b/src/PJ_putp5.c
@@ -9,8 +9,8 @@ struct pj_opaque {
     double  A, B;
 };
 
-PROJ_HEAD(putp5, "Putnins P5") "\n\tPCyl., Sph.";
-PROJ_HEAD(putp5p, "Putnins P5'") "\n\tPCyl., Sph.";
+PROJ_HEAD(putp5, "Putnins P5") "\n\tPCyl, Sph";
+PROJ_HEAD(putp5p, "Putnins P5'") "\n\tPCyl, Sph";
 
 #define C 1.01346
 #define D 1.2158542

--- a/src/PJ_putp6.c
+++ b/src/PJ_putp6.c
@@ -9,8 +9,8 @@ struct pj_opaque {
     double C_x, C_y, A, B, D;
 };
 
-PROJ_HEAD(putp6, "Putnins P6") "\n\tPCyl., Sph.";
-PROJ_HEAD(putp6p, "Putnins P6'") "\n\tPCyl., Sph.";
+PROJ_HEAD(putp6, "Putnins P6") "\n\tPCyl, Sph";
+PROJ_HEAD(putp6p, "Putnins P6'") "\n\tPCyl, Sph";
 
 #define EPS      1e-10
 #define NITER    10

--- a/src/PJ_qsc.c
+++ b/src/PJ_qsc.c
@@ -62,7 +62,7 @@ struct pj_opaque {
         double one_minus_f;
         double one_minus_f_squared;
 };
-PROJ_HEAD(qsc, "Quadrilateralized Spherical Cube") "\n\tAzi, Sph.";
+PROJ_HEAD(qsc, "Quadrilateralized Spherical Cube") "\n\tAzi, Sph";
 
 #define EPS10 1.e-10
 

--- a/src/PJ_robin.c
+++ b/src/PJ_robin.c
@@ -4,7 +4,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(robin, "Robinson") "\n\tPCyl., Sph.";
+PROJ_HEAD(robin, "Robinson") "\n\tPCyl, Sph";
 
 #define V(C,z) (C.c0 + z * (C.c1 + z * (C.c2 + z * C.c3)))
 #define DV(C,z) (C.c1 + z * (C.c2 + C.c2 + z * 3. * C.c3))

--- a/src/PJ_rpoly.c
+++ b/src/PJ_rpoly.c
@@ -13,7 +13,7 @@ struct pj_opaque {
 };
 
 PROJ_HEAD(rpoly, "Rectangular Polyconic")
-    "\n\tConic, Sph., no inv.\n\tlat_ts=";
+    "\n\tConic, Sph, no inv\n\tlat_ts=";
 
 #define EPS 1e-9
 

--- a/src/PJ_sts.c
+++ b/src/PJ_sts.c
@@ -5,10 +5,10 @@
 
 #include "projects.h"
 
-PROJ_HEAD(kav5,    "Kavraisky V")         "\n\tPCyl., Sph.";
-PROJ_HEAD(qua_aut, "Quartic Authalic")    "\n\tPCyl., Sph.";
-PROJ_HEAD(fouc,    "Foucaut")             "\n\tPCyl., Sph.";
-PROJ_HEAD(mbt_s,   "McBryde-Thomas Flat-Polar Sine (No. 1)") "\n\tPCyl., Sph.";
+PROJ_HEAD(kav5,    "Kavraisky V")         "\n\tPCyl, Sph";
+PROJ_HEAD(qua_aut, "Quartic Authalic")    "\n\tPCyl, Sph";
+PROJ_HEAD(fouc,    "Foucaut")             "\n\tPCyl, Sph";
+PROJ_HEAD(mbt_s,   "McBryde-Thomas Flat-Polar Sine (No. 1)") "\n\tPCyl, Sph";
 
 
 struct pj_opaque {

--- a/src/PJ_tcc.c
+++ b/src/PJ_tcc.c
@@ -5,7 +5,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(tcc, "Transverse Central Cylindrical") "\n\tCyl, Sph, no inv.";
+PROJ_HEAD(tcc, "Transverse Central Cylindrical") "\n\tCyl, Sph, no inv";
 
 #define EPS10 1.e-10
 

--- a/src/PJ_urm5.c
+++ b/src/PJ_urm5.c
@@ -6,7 +6,7 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(urm5, "Urmaev V") "\n\tPCyl., Sph., no inv.\n\tn= q= alpha=";
+PROJ_HEAD(urm5, "Urmaev V") "\n\tPCyl, Sph, no inv\n\tn= q= alpha=";
 
 struct pj_opaque {
     double m, rmn, q3, n;

--- a/src/PJ_urmfps.c
+++ b/src/PJ_urmfps.c
@@ -6,8 +6,8 @@
 #include "proj.h"
 #include "projects.h"
 
-PROJ_HEAD(urmfps, "Urmaev Flat-Polar Sinusoidal") "\n\tPCyl, Sph.\n\tn=";
-PROJ_HEAD(wag1, "Wagner I (Kavraisky VI)") "\n\tPCyl, Sph.";
+PROJ_HEAD(urmfps, "Urmaev Flat-Polar Sinusoidal") "\n\tPCyl, Sph\n\tn=";
+PROJ_HEAD(wag1, "Wagner I (Kavraisky VI)") "\n\tPCyl, Sph";
 
 struct pj_opaque {
     double  n, C_y;

--- a/src/PJ_vandg2.c
+++ b/src/PJ_vandg2.c
@@ -9,8 +9,8 @@ struct pj_opaque {
     int vdg3;
 };
 
-PROJ_HEAD(vandg2, "van der Grinten II") "\n\tMisc Sph, no inv.";
-PROJ_HEAD(vandg3, "van der Grinten III") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(vandg2, "van der Grinten II") "\n\tMisc Sph, no inv";
+PROJ_HEAD(vandg3, "van der Grinten III") "\n\tMisc Sph, no inv";
 
 #define TOL    1e-10
 

--- a/src/PJ_vandg4.c
+++ b/src/PJ_vandg4.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(vandg4, "van der Grinten IV") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(vandg4, "van der Grinten IV") "\n\tMisc Sph, no inv";
 
 #define TOL 1e-10
 

--- a/src/PJ_wag2.c
+++ b/src/PJ_wag2.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(wag2, "Wagner II") "\n\tPCyl., Sph.";
+PROJ_HEAD(wag2, "Wagner II") "\n\tPCyl, Sph";
 
 #define C_x 0.92483
 #define C_y 1.38725

--- a/src/PJ_wag3.c
+++ b/src/PJ_wag3.c
@@ -5,7 +5,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(wag3, "Wagner III") "\n\tPCyl., Sph.\n\tlat_ts=";
+PROJ_HEAD(wag3, "Wagner III") "\n\tPCyl, Sph\n\tlat_ts=";
 
 #define TWOTHIRD 0.6666666666666666666667
 

--- a/src/PJ_wag7.c
+++ b/src/PJ_wag7.c
@@ -4,7 +4,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(wag7, "Wagner VII") "\n\tMisc Sph, no inv.";
+PROJ_HEAD(wag7, "Wagner VII") "\n\tMisc Sph, no inv";
 
 
 

--- a/src/PJ_wink1.c
+++ b/src/PJ_wink1.c
@@ -5,7 +5,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(wink1, "Winkel I") "\n\tPCyl., Sph.\n\tlat_ts=";
+PROJ_HEAD(wink1, "Winkel I") "\n\tPCyl, Sph\n\tlat_ts=";
 
 struct pj_opaque {
 	double	cosphi1;

--- a/src/PJ_wink2.c
+++ b/src/PJ_wink2.c
@@ -5,7 +5,7 @@
 
 #include "projects.h"
 
-PROJ_HEAD(wink2, "Winkel II") "\n\tPCyl., Sph., no inv.\n\tlat_1=";
+PROJ_HEAD(wink2, "Winkel II") "\n\tPCyl, Sph, no inv\n\tlat_1=";
 
 struct pj_opaque { double	cosphi1; };
 

--- a/src/proj_rouss.c
+++ b/src/proj_rouss.c
@@ -39,7 +39,7 @@ struct pj_opaque {
     double D1, D2, D3, D4, D5, D6, D7, D8, D9, D10, D11;
     void *en;
 };
-PROJ_HEAD(rouss, "Roussilhe Stereographic") "\n\tAzi., Ellps.";
+PROJ_HEAD(rouss, "Roussilhe Stereographic") "\n\tAzi, Ell";
 
 
 static XY e_forward (LP lp, PJ *P) {          /* Ellipsoidal, forward */


### PR DESCRIPTION
While working with proj.4 I've noticed that the output of descriptions from `proj -lP` is not very uniform: some of the projections have periods in their descriptions, i.e. 'Cyl., Sph.' while others don't (and the split is approximately half/half). It does not look very good, so I've decided to fix it and make it more uniform with this commit. I've dropped the dots from 'Cyl.', 'Sph.' and 'inv.' and applied a couple of other minor changes, like 'Ellps. -> Ell' in one or two cases.
