### PR TITLE
Move struct definitions for proj_list_* functions to proj.h

### DIFF
--- a/docs/source/development/reference/datatypes.rst
+++ b/docs/source/development/reference/datatypes.rst
@@ -472,12 +472,12 @@ List structures
     .. code-block:: C
 
         struct PJ_OPERATIONS {
-            char    *id;                 /* operation keyword */
-            PJ *(*proj)(PJ *);           /* operation  entry point */
-            char    * const *descr;      /* description text */
+            const char  *id;            /* operation keyword */
+            PJ *(*proj)(PJ *);          /* operation  entry point */
+            char    * const *descr;     /* description text */
         };
 
-    .. c:member:: char *id
+    .. c:member:: const char *id
 
         Operation keyword.
 
@@ -497,25 +497,25 @@ List structures
     .. code-block:: C
 
         struct PJ_ELLPS {
-            char    *id;
-            char    *major;
-            char    *ell;
-            char    *name;
+            const char  *id;
+            const char  *major;
+            const char  *ell;
+            const char  *name;
         };
 
-    .. c:member:: char *id
+    .. c:member:: const char *id
 
         Keyword name of the ellipsoid.
 
-    .. c:member:: char *major
+    .. c:member:: const char *major
 
         Semi-major axis of the ellipsoid, or radius in case of a sphere.
 
-    .. c:member:: char *ell
+    .. c:member:: const char *ell
 
         Elliptical parameter, e.g. `rf=298.257` or `b=6356772.2`.
 
-    .. c:member:: char *name
+    .. c:member:: const char *name
 
         Name of the ellipsoid
 
@@ -526,21 +526,21 @@ List structures
     .. code-block:: C
 
         struct PJ_UNITS {
-            char    *id;           /* units keyword */
-            char    *to_meter;     /* multiply by value to get meters */
-            char    *name;         /* comments */
-            double   factor;       /* to_meter factor in actual numbers */
+            const char  *id;        /* units keyword */
+            const char  *to_meter;  /* multiply by value to get meters */
+            const char  *name;      /* comments */
+            double      factor;     /* to_meter factor in actual numbers */
         };
 
-    .. c:member:: char *id
+    .. c:member:: const char *id
 
         Keyword for the unit.
 
-    .. c:member:: char *to_meter
+    .. c:member:: const char *to_meter
 
         Text representation of the factor that converts a given unit to meters
 
-    .. c:member:: char *name
+    .. c:member:: const char *name
 
         Name of the unit.
 
@@ -555,15 +555,15 @@ List structures
     .. code-block:: C
 
         struct PJ_PRIME_MERIDIANS {
-            char    *id;
-            char    *defn;
+            const char  *id;
+            const char  *defn;
         };
 
-    .. c:member:: char *id
+    .. c:member:: const char *id
 
         Keyword for the prime meridian
 
-    .. c:member:: char *def
+    .. c:member:: const char *def
 
         Offset from Greenwich in DMS format.
 

--- a/src/PJ_unitconvert.c
+++ b/src/PJ_unitconvert.c
@@ -401,17 +401,20 @@ static double get_unit_conversion_factor(const char* name,
 /***********************************************************************/
     int i;
     const char* s;
+    const PJ_UNITS *units;
+
+    units = proj_list_units();
 
     /* Try first with linear units */
-    for (i = 0; (s = pj_units[i].id) ; ++i) {
+    for (i = 0; (s = units[i].id) ; ++i) {
         if ( strcmp(s, name) == 0 ) {
             if( p_normalized_name ) {
-                *p_normalized_name = pj_units[i].name;
+                *p_normalized_name = units[i].name;
             }
             if( p_is_linear ) {
                 *p_is_linear = 1;
             }
-            return pj_units[i].factor;
+            return units[i].factor;
         }
     }
 

--- a/src/cs2cs.c
+++ b/src/cs2cs.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
                     /* list projections */
                     const struct PJ_LIST *lp;
                     int do_long = arg[1] == 'P', c;
-                    char *str;
+                    const char *str;
 
                     for (lp = proj_list_operations() ; lp->id ; ++lp) {
                         (void)printf("%s : ", lp->id);

--- a/src/geod_set.c
+++ b/src/geod_set.c
@@ -32,7 +32,7 @@ geod_set(int argc, char **argv) {
 	if (pj_ell_set(pj_get_default_ctx(),start, &geod_a, &es)) emess(1,"ellipse setup failure");
 	/* set units */
 	if ((name = pj_param(NULL,start, "sunits").s) != NULL) {
-		char *s;
+		const char *s;
                 const struct PJ_UNITS *unit_list = proj_list_units();
 		for (i = 0; (s = unit_list[i].id) && strcmp(name, s) ; ++i) ;
 		if (!s)

--- a/src/pj_datums.c
+++ b/src/pj_datums.c
@@ -93,11 +93,6 @@ C_NAMESPACE_VAR const struct PJ_PRIME_MERIDIANS pj_prime_meridians[] = {
     {NULL,        NULL}
 };
 
-struct PJ_PRIME_MERIDIANS *pj_get_prime_meridians_ref()
-{
-    return (struct PJ_PRIME_MERIDIANS *)pj_prime_meridians;
-}
-
 const PJ_PRIME_MERIDIANS *proj_list_prime_meridians(void)
 {
     return pj_prime_meridians;

--- a/src/pj_ell_set.c
+++ b/src/pj_ell_set.c
@@ -424,15 +424,19 @@ static char *pj_param_value (paralist *list) {
 
 static const PJ_ELLPS *pj_find_ellps (char *name) {
     int i;
-    char *s;
+    const char *s;
+    const PJ_ELLPS *ellps;
+
     if (0==name)
         return 0;
 
+    ellps = proj_list_ellps();
+
     /* Search through internal ellipsoid list for name */
-    for (i = 0; (s = pj_ellps[i].id) && strcmp(name, s) ; ++i);
+    for (i = 0; (s = ellps[i].id) && strcmp(name, s) ; ++i);
     if (0==s)
         return 0;
-    return pj_ellps + i;
+    return ellps + i;
 }
 
 

--- a/src/pj_ellps.c
+++ b/src/pj_ellps.c
@@ -3,8 +3,6 @@
 #include <stddef.h>
 
 #include "proj.h"
-
-#define PJ_ELLPS__
 #include "projects.h"
 
 C_NAMESPACE_VAR const struct PJ_ELLPS
@@ -57,11 +55,6 @@ pj_ellps[] = {
 {"sphere",	"a=6370997.0",		"b=6370997.0",		"Normal Sphere (r=6370997)"},
 {NULL,		NULL,			NULL,			NULL}
 };
-
-struct PJ_ELLPS *pj_get_ellps_ref()
-{
-    return (struct PJ_ELLPS *)pj_ellps;
-}
 
 const PJ_ELLPS *proj_list_ellps(void)
 {

--- a/src/pj_list.c
+++ b/src/pj_list.c
@@ -14,7 +14,7 @@
 #undef PROJ_HEAD
 
 /* Generate extern declarations for description strings */
-#define PROJ_HEAD(id, name) extern char * const pj_s_##id;
+#define PROJ_HEAD(id, name) extern const char * const pj_s_##id;
 #include "pj_list.h"
 #undef PROJ_HEAD
 
@@ -22,15 +22,10 @@
 #define PROJ_HEAD(id, name) {#id, pj_##id, &pj_s_##id},
 const struct PJ_LIST pj_list[] = {
 #include "pj_list.h"
-		{0,     0,  0},
-	};
+    {0,     0,  0},
+};
 #undef PROJ_HEAD
 
-
-struct PJ_LIST *pj_get_list_ref()
-{
-    return (struct PJ_LIST *)pj_list;
-}
 
 const PJ_OPERATIONS *proj_list_operations(void) {
     return pj_list;

--- a/src/pj_param.c
+++ b/src/pj_param.c
@@ -9,7 +9,7 @@
 #include "projects.h"
 
 /* create parameter list entry */
-paralist *pj_mkparam(char *str) {
+paralist *pj_mkparam(const char *str) {
     paralist *newitem;
 
     if((newitem = (paralist *)pj_malloc(sizeof(paralist) + strlen(str))) != NULL) {
@@ -24,7 +24,7 @@ paralist *pj_mkparam(char *str) {
 
 
 /* As pj_mkparam, but payload ends at first whitespace, rather than at end of <str> */
-paralist *pj_mkparam_ws (char *str) {
+paralist *pj_mkparam_ws (const char *str) {
     paralist *newitem;
     size_t len = 0;
 

--- a/src/pj_units.c
+++ b/src/pj_units.c
@@ -36,11 +36,6 @@ pj_units[] = {
     {NULL,      NULL,                   NULL,                           0.0}
 };
 
-struct PJ_UNITS *pj_get_units_ref()
-{
-    return (struct PJ_UNITS *)pj_units;
-}
-
 const PJ_UNITS *proj_list_units()
 {
     return pj_units;

--- a/src/proj.c
+++ b/src/proj.c
@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
                     /* list projections */
                     const struct PJ_LIST *lp;
                     int do_long = arg[1] == 'P', c;
-                    char *str;
+                    const char *str;
 
                     for (lp = proj_list_operations() ; lp->id ; ++lp) {
                         if( strcmp(lp->id,"latlong") == 0

--- a/src/proj.def
+++ b/src/proj.def
@@ -26,11 +26,7 @@ EXPORTS
     pj_datum_transform              @24
     pj_set_searchpath               @25
     dmstor                          @26
-    pj_get_ellps_ref                @27
     pj_get_datums_ref               @28
-    pj_get_units_ref                @29
-    pj_get_list_ref                 @30
-    pj_get_prime_meridians_ref      @31
     rtodms                          @32
     set_rtodms                      @33
     pj_factors                      @34

--- a/src/proj.h
+++ b/src/proj.h
@@ -180,16 +180,34 @@ struct PJ_INIT_INFO;
 typedef struct PJ_INIT_INFO PJ_INIT_INFO;
 
 /* Data types for list of operations, ellipsoids, datums and units used in PROJ.4 */
-struct PJ_LIST;
+struct PJ_LIST {
+    const char  *id;                /* projection keyword */
+    PJ          *(*proj)(PJ *);     /* projection entry point */
+    const char  * const *descr;     /* description text */
+};
+
 typedef struct PJ_LIST PJ_OPERATIONS;
 
-struct PJ_ELLPS;
+struct PJ_ELLPS {
+    const char  *id;    /* ellipse keyword name */
+    const char  *major; /* a= value */
+    const char  *ell;   /* elliptical parameter */
+    const char  *name;  /* comments */
+};
 typedef struct PJ_ELLPS PJ_ELLPS;
 
-struct PJ_UNITS;
+struct PJ_UNITS {
+    const char  *id;        /* units keyword */
+    const char  *to_meter;  /* multiply by value to get meters */
+    const char  *name;      /* comments */
+    double      factor;     /* to_meter factor in actual numbers */
+};
 typedef struct PJ_UNITS PJ_UNITS;
 
-struct PJ_PRIME_MERIDIANS;
+struct PJ_PRIME_MERIDIANS {
+    const char  *id;        /* prime meridian keyword */
+    const char  *defn;      /* offset from greenwich in DMS format. */
+};
 typedef struct PJ_PRIME_MERIDIANS PJ_PRIME_MERIDIANS;
 
 

--- a/src/projects.h
+++ b/src/projects.h
@@ -736,8 +736,8 @@ double aacos(projCtx,double), aasin(projCtx,double), asqrt(double), aatan2(doubl
 
 PROJVALUE pj_param(projCtx ctx, paralist *, const char *);
 paralist *pj_param_exists (paralist *list, const char *parameter);
-paralist *pj_mkparam(char *);
-paralist *pj_mkparam_ws (char *str);
+paralist *pj_mkparam(const char *);
+paralist *pj_mkparam_ws (const char *str);
 
 
 int pj_ell_set(projCtx ctx, paralist *, double *, double *);

--- a/src/projects.h
+++ b/src/projects.h
@@ -475,30 +475,11 @@ struct ARG_list {
 typedef union { double  f; int  i; char *s; } PROJVALUE;
 
 
-struct PJ_ELLPS {
-    char    *id;           /* ellipse keyword name */
-    char    *major;        /* a= value */
-    char    *ell;          /* elliptical parameter */
-    char    *name;         /* comments */
-};
-
-struct PJ_UNITS {
-    char    *id;           /* units keyword */
-    char    *to_meter;     /* multiply by value to get meters */
-    char    *name;         /* comments */
-    double   factor;       /* to_meter factor in actual numbers */
-};
-
 struct PJ_DATUMS {
     char    *id;           /* datum keyword */
     char    *defn;         /* ie. "to_wgs84=..." */
     char    *ellipse_id;   /* ie from ellipse table */
     char    *comments;     /* EPSG code, etc */
-};
-
-struct PJ_PRIME_MERIDIANS {
-    char    *id;           /* prime meridian keyword */
-    char    *defn;         /* offset from greenwich in DMS format. */
 };
 
 
@@ -612,29 +593,8 @@ struct projCtx_t {
 
 
 /* Generate pj_list external or make list from include file */
-
-struct PJ_LIST {
-    char    *id;                 /* projection keyword */
-    PJ *(*proj)(PJ *);           /* projection entry point */
-    char    * const *descr;      /* description text */
-};
-
-
-#ifndef USE_PJ_LIST_H
-extern struct PJ_LIST pj_list[];
-#endif
-
-#ifndef PJ_ELLPS__
-extern struct PJ_ELLPS pj_ellps[];
-#endif
-
-#ifndef PJ_UNITS__
-extern struct PJ_UNITS pj_units[];
-#endif
-
 #ifndef PJ_DATUMS__
 extern struct PJ_DATUMS pj_datums[];
-extern struct PJ_PRIME_MERIDIANS pj_prime_meridians[];
 #endif
 
 
@@ -742,7 +702,6 @@ paralist *pj_mkparam_ws (const char *str);
 
 int pj_ell_set(projCtx ctx, paralist *, double *, double *);
 int pj_datum_set(projCtx,paralist *, PJ *);
-int pj_prime_meridian_set(paralist *, PJ *);
 int pj_angular_units_set(paralist *, PJ *);
 
 paralist *pj_clone_paralist( const paralist* );
@@ -854,11 +813,7 @@ LP     pj_inv_gauss(projCtx, LP, const void *);
 
 extern char const pj_release[];
 
-struct PJ_ELLPS            *pj_get_ellps_ref( void );
 struct PJ_DATUMS           *pj_get_datums_ref( void );
-struct PJ_UNITS            *pj_get_units_ref( void );
-struct PJ_LIST             *pj_get_list_ref( void );
-struct PJ_PRIME_MERIDIANS  *pj_get_prime_meridians_ref( void );
 
 void *pj_default_destructor (PJ *P, int errlev);
 


### PR DESCRIPTION
With projects.h not being available to outside users anymore we need to
define PJ_UNITS, PJ_ELLPS, PJ_PRIME_MERIDIANS and PJ_OPERATIONS
elsewhere.

Fixes #1147