### PR TITLE
cmake: detect PTHREAD_MUTEX_RECURSIVE by compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,6 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package (Threads)
 
 include(CheckIncludeFiles)
-include(CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(PTHREAD_MUTEX_RECURSIVE pthread.h HAVE_PTHREAD_MUTEX_RECURSIVE_DEFN)
-if (HAVE_PTHREAD_MUTEX_RECURSIVE_DEFN)
-    add_definitions(-DHAVE_PTHREAD_MUTEX_RECURSIVE=1)
-endif()
 
 include (CheckCSourceCompiles)
 if (MSVC)
@@ -110,6 +105,22 @@ if (C99_MATH)
   add_definitions (-DHAVE_C99_MATH=1)
 else ()
   add_definitions (-DHAVE_C99_MATH=0)
+endif ()
+
+if (Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
+  set (CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}")
+  check_c_source_compiles("
+#include <pthread.h>
+
+int main(int argc, char* argv[]) {
+  (void)PTHREAD_MUTEX_RECURSIVE;
+  (void)argv;
+  return argc;
+}
+  " HAVE_PTHREAD_MUTEX_RECURSIVE_DEFN)
+  if (HAVE_PTHREAD_MUTEX_RECURSIVE_DEFN)
+    add_definitions(-DHAVE_PTHREAD_MUTEX_RECURSIVE=1)
+  endif()
 endif ()
 
 boost_report_value(PROJ_PLATFORM_NAME)


### PR DESCRIPTION
The `check_symbol_exists` cannot detect `#define symbol 1` because it
takes the address of the symbol to detect it, but the address of a
literal is not allowed. Some platforms define `PTHREAD_MUTEX_RECURSIVE`
by such a literal.

Fixes #1158 

---
Cc: @kbevers 