### PR TITLE
Make sure that coveralls reports coverage from both c and cpp files

### DIFF
--- a/travis/after_success.sh
+++ b/travis/after_success.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-
 if [ "$BUILD_NAME" != "linux_clang" ]; then
     # coveralls falsely reports .c-files in the build directories as having 100% coverage so we exclude them
-    coveralls --extension .c --exclude build_autoconf --exclude build_cmake
+    coveralls --build-root src --extension .c --extension .cpp \
+        --exclude build_autoconf --exclude build_cmake --exclude test --exclude examples
 fi
 
 echo "$TRAVIS_SECURE_ENV_VARS"

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -83,4 +83,8 @@ make check
 
 if [ "$BUILD_NAME" != "linux_clang" ]; then
     mv src/.libs/*.gc* src
+    mv src/conversions/.libs/*.gc* src/conversions
+    mv src/iso19111/.libs/*.gc* src/iso19111
+    mv src/projections/.libs/*.gc* src/projections
+    mv src/transformations/.libs/*.gc* src/transformations
 fi


### PR DESCRIPTION
Coveralls hasn't been working for a while. I suspect because we've renamed most of the files to `.cpp`.