### PR TITLE
Handle allocation failure in pj_trim_argv

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -602,6 +602,11 @@ PJ *proj_create (PJ_CONTEXT *ctx, const char *definition) {
     }
 
     argv = pj_trim_argv (argc, args);
+    if (!argv) {
+        pj_dealloc(args);
+        proj_context_errno_set(ctx, ENOMEM);
+        return nullptr;
+    }
 
     /* ...and let pj_init_ctx do the hard work */
     /* New interface: forbid init=epsg:XXXX syntax by default */


### PR DESCRIPTION
The function can return nullptr, if calloc fails. If we then use that
nullptr in pj_init_ctx_with_allow_init_epsg, we get a crash.