### PR TITLE
Improve checks for external deps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,18 +319,40 @@ if test x"$SQLITE3_CHECK" != x"yes" ; then
 fi
 
 dnl ---------------------------------------------------------------------------
+dnl Check for external Google Test
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH(external-gtest,
+            AS_HELP_STRING([--with-external-gtest],
+               [Whether to use external Google Test]),,)
+
+if test "x$with_external_gtest" == "xyes" ; then
+    AC_MSG_RESULT([using external GTest.])
+    PKG_CHECK_MODULES([GTEST], [gtest >= 1.8.0])
+else
+    AC_MSG_RESULT([using internal GTest.])
+    GTEST_CFLAGS="-I\$(top_srcdir)/test/googletest/include"
+    GTEST_LIBS="\$(top_builddir)/test/googletest/libgtest.la"
+fi
+AM_CONDITIONAL(USE_EXTERNAL_GTEST, [test "x$with_external_gtest" == "xyes"])
+AC_SUBST(GTEST_CFLAGS,$GTEST_CFLAGS)
+AC_SUBST(GTEST_LIBS,$GTEST_LIBS)
+
+dnl ---------------------------------------------------------------------------
 dnl Generate files
 dnl ---------------------------------------------------------------------------
 
 AC_CONFIG_FILES([Makefile cmake/Makefile src/Makefile include/Makefile include/proj/Makefile include/proj/internal/Makefile
                  test/Makefile test/cli/Makefile test/gie/Makefile test/gigs/Makefile test/unit/Makefile
-                 test/googletest/Makefile test/googletest/include/Makefile
-                 test/googletest/include/gtest/Makefile
-                 test/googletest/include/gtest/internal/Makefile
-                 test/googletest/include/gtest/internal/custom/Makefile
-                 test/googletest/src/Makefile
                  man/Makefile man/man1/Makefile man/man3/Makefile data/Makefile
                  jniwrap/Makefile jniwrap/org.osgeo.proj/Makefile jniwrap/org.osgeo.proj/org/Makefile jniwrap/org.osgeo.proj/org/proj4/Makefile])
+if ! test "x$with_external_gtest" = "xyes" ; then
+    AC_CONFIG_FILES([test/googletest/Makefile test/googletest/include/Makefile
+                     test/googletest/include/gtest/Makefile
+                     test/googletest/include/gtest/internal/Makefile
+                     test/googletest/include/gtest/internal/custom/Makefile
+                     test/googletest/src/Makefile])
+fi
 AC_CONFIG_FILES([data/install], [chmod +x data/install])
 
 AC_CONFIG_FILES([proj.pc])

--- a/configure.ac
+++ b/configure.ac
@@ -309,37 +309,9 @@ dnl ---------------------------------------------------------------------------
 dnl Check for sqlite3 library and binary
 dnl ---------------------------------------------------------------------------
 
-AC_ARG_WITH(sqlite3-include,
-    [  --with-sqlite3-include=ARG sqlite3 include directory],,,)
-
-if test "x$with_sqlite3_include" = "x" ; then
-SQLITE3_FLAGS=""
-if test -z "`uname | grep Darwin`" ; then
-    AC_CHECK_HEADERS([sqlite3.h])
-    if test "$ac_cv_header_sqlite3_h" = "no" ; then
-        AC_MSG_ERROR([Please install sqlite3 development package.])
-    fi
-fi
-else
-    SQLITE3_FLAGS="-I$with_sqlite3_include"
-fi
-AC_SUBST(SQLITE3_FLAGS,$SQLITE3_FLAGS)
-
-AC_ARG_WITH(sqlite3-ldflags,
-      [  --with-sqlite3-ldflags=ARG   sqlite3 link flags (i.e. -L/xxx -lsqlite3)],,,)
-
-SQLITE3_LDFLAGS=""
-if test "x$with_sqlite3_ldflags" = "x" ; then
-    AC_CHECK_LIB(sqlite3,sqlite3_open,SQLITE3_LIB_FOUND=yes,SQLITE3_LIB_FOUND=no,)
-    if test x"$SQLITE3_LIB_FOUND" != x"yes"; then
-        AC_MSG_ERROR([Please install sqlite3 development package.])
-    fi
-    SQLITE3_LDFLAGS="-lsqlite3"
-else
-    SQLITE3_LDFLAGS="$with_sqlite3_ldflags"
-fi
-AC_SUBST(SQLITE3_LDFLAGS,$SQLITE3_LDFLAGS)
-
+PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.7])
+AC_SUBST(SQLITE3_CFLAGS,$SQLITE3_CFLAGS)
+AC_SUBST(SQLITE3_LIBS,$SQLITE3_LIBS)
 
 AC_CHECK_PROG(SQLITE3_CHECK,sqlite3,yes)
 if test x"$SQLITE3_CHECK" != x"yes" ; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ TESTS = geodtest
 check_PROGRAMS = geodtest
 
 AM_CPPFLAGS =	-DPROJ_LIB=\"$(pkgdatadir)\" \
-		-DMUTEX_@MUTEX_SETTING@ @JNI_INCLUDE@ -I$(top_srcdir)/include @SQLITE3_FLAGS@
+		-DMUTEX_@MUTEX_SETTING@ @JNI_INCLUDE@ -I$(top_srcdir)/include @SQLITE3_CFLAGS@
 AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@ -DPROJ_COMPILATION
 
 include_HEADERS = proj.h proj_experimental.h proj_constants.h proj_api.h geodesic.h \
@@ -45,7 +45,7 @@ geodtest_LDADD = libproj.la
 lib_LTLIBRARIES = libproj.la
 
 libproj_la_LDFLAGS = -no-undefined -version-info 14:1:1
-libproj_la_LIBADD = @SQLITE3_LDFLAGS@
+libproj_la_LIBADD = @SQLITE3_LIBS@
 
 libproj_la_SOURCES = \
 	pj_list.h proj_internal.h proj_math.h \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,4 +7,7 @@ EXTRA_DIST = CMakeLists.txt
 # libtestmain_la_LDFLAGS = -no-undefined
 # libtestmain_la_SOURCES = test_main.cpp
 
-SUBDIRS = cli googletest . gie gigs unit
+if !USE_EXTERNAL_GTEST
+MAYBE_GTEST = googletest
+endif
+SUBDIRS = cli $(MAYBE_GTEST) . gie gigs unit

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,16 @@
 # CMake configuration for PROJ unit tests
 
+option(USE_EXTERNAL_GTEST "Compile against external GTest" OFF)
+
+if (USE_EXTERNAL_GTEST)
+
+message(STATUS "Using external GTest")
+find_package(GTest 1.8.0)
+
+else (USE_EXTERNAL_GTEST)
+
+message(STATUS "Using internal GTest")
+
 # FIXME: Deal with our old-school CMakeLists.txt behaving badly
 set(_save_c_flags "${CMAKE_C_FLAGS}")
 set(_save_cxx_flags "${CMAKE_CXX_FLAGS}")
@@ -46,6 +57,8 @@ set(CMAKE_C_FLAGS "${_save_c_flags}")
 set(CMAKE_CXX_FLAGS "${_save_cxx_flags}")
 unset(_save_c_flags)
 unset(_save_cxx_flags)
+
+endif(USE_EXTERNAL_GTEST)
 
 #
 # Build PROJ unit tests

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = CMakeLists.txt
 
 noinst_HEADERS = gtest_include.h
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_srcdir)/test -I$(top_srcdir)/test/googletest/include @SQLITE3_CFLAGS@
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_srcdir)/test @GTEST_CFLAGS@ @SQLITE3_CFLAGS@
 AM_CXXFLAGS = @CXX_WFLAGS@ @NO_ZERO_AS_NULL_POINTER_CONSTANT_FLAG@
 
 PROJ_LIB ?= ../../data
@@ -19,43 +19,43 @@ noinst_PROGRAMS += gie_self_tests
 noinst_PROGRAMS += include_proj_h_from_c
 
 pj_transform_test_SOURCES = pj_transform_test.cpp main.cpp
-pj_transform_test_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la
+pj_transform_test_LDADD = ../../src/libproj.la @GTEST_LIBS@
 
 pj_transform_test-check: pj_transform_test
 	PROJ_LIB=$(PROJ_LIB) ./pj_transform_test
 
 pj_phi2_test_SOURCES = pj_phi2_test.cpp main.cpp
-pj_phi2_test_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la
+pj_phi2_test_LDADD = ../../src/libproj.la @GTEST_LIBS@
 
 pj_phi2_test-check: pj_phi2_test
 	./pj_phi2_test
 
 proj_errno_string_test_SOURCES = proj_errno_string_test.cpp main.cpp
-proj_errno_string_test_LDADD= ../../src/libproj.la ../../test/googletest/libgtest.la
+proj_errno_string_test_LDADD= ../../src/libproj.la @GTEST_LIBS@
 
 proj_errno_string_test-check: proj_errno_string_test
 	./proj_errno_string_test
 
 proj_angular_io_test_SOURCES = proj_angular_io_test.cpp main.cpp
-proj_angular_io_test_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la
+proj_angular_io_test_LDADD = ../../src/libproj.la @GTEST_LIBS@
 
 proj_angular_io_test-check: proj_angular_io_test
 	./proj_angular_io_test
 
 proj_context_test_SOURCES = proj_context_test.cpp main.cpp
-proj_context_test_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la
+proj_context_test_LDADD = ../../src/libproj.la @GTEST_LIBS@
 
 proj_context_test-check: proj_context_test
 	./proj_context_test
 
 test_cpp_api_SOURCES = test_util.cpp test_common.cpp test_crs.cpp test_metadata.cpp test_io.cpp test_operation.cpp test_datum.cpp test_factory.cpp test_c_api.cpp main.cpp
-test_cpp_api_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LIBS@
+test_cpp_api_LDADD = ../../src/libproj.la @GTEST_LIBS@ @SQLITE3_LIBS@
 
 test_cpp_api-check: test_cpp_api
 	PROJ_LIB=$(PROJ_LIB) ./test_cpp_api
 
 gie_self_tests_SOURCES = gie_self_tests.cpp main.cpp
-gie_self_tests_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LIBS@
+gie_self_tests_LDADD = ../../src/libproj.la @GTEST_LIBS@ @SQLITE3_LIBS@
 
 gie_self_tests-check: gie_self_tests
 	PROJ_LIB=$(PROJ_LIB) ./gie_self_tests

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = CMakeLists.txt
 
 noinst_HEADERS = gtest_include.h
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_srcdir)/test -I$(top_srcdir)/test/googletest/include @SQLITE3_FLAGS@
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_srcdir)/test -I$(top_srcdir)/test/googletest/include @SQLITE3_CFLAGS@
 AM_CXXFLAGS = @CXX_WFLAGS@ @NO_ZERO_AS_NULL_POINTER_CONSTANT_FLAG@
 
 PROJ_LIB ?= ../../data
@@ -49,13 +49,13 @@ proj_context_test-check: proj_context_test
 	./proj_context_test
 
 test_cpp_api_SOURCES = test_util.cpp test_common.cpp test_crs.cpp test_metadata.cpp test_io.cpp test_operation.cpp test_datum.cpp test_factory.cpp test_c_api.cpp main.cpp
-test_cpp_api_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LDFLAGS@
+test_cpp_api_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LIBS@
 
 test_cpp_api-check: test_cpp_api
 	PROJ_LIB=$(PROJ_LIB) ./test_cpp_api
 
 gie_self_tests_SOURCES = gie_self_tests.cpp main.cpp
-gie_self_tests_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LDFLAGS@
+gie_self_tests_LDADD = ../../src/libproj.la ../../test/googletest/libgtest.la @SQLITE3_LIBS@
 
 gie_self_tests-check: gie_self_tests
 	PROJ_LIB=$(PROJ_LIB) ./gie_self_tests

--- a/travis/mingw32/install.sh
+++ b/travis/mingw32/install.sh
@@ -13,15 +13,15 @@ ln -s /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll  $HOME/.wine/drive_c/windo
 # build sqlite3
 wget https://sqlite.org/2018/sqlite-autoconf-3250100.tar.gz
 tar xzf sqlite-autoconf-3250100.tar.gz
-(cd sqlite-autoconf-3250100 &&  CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ./configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install && make -j3 && make install)
-ln -s /tmp/proj_autoconf_install/bin/libsqlite3-0.dll  $HOME/.wine/drive_c/windows
+(cd sqlite-autoconf-3250100 &&  CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 && make -j3 && sudo make install)
+ln -s /usr/x86_64-w64-mingw32/bin/libsqlite3-0.dll  $HOME/.wine/drive_c/windows
 
 # prepare build files
 ./autogen.sh
 # autoconf build
 mkdir build_autoconf
 cd build_autoconf
-CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --with-sqlite3_include=/tmp/proj_autoconf_install/include --with-sqlite3_ldflags="-L/tmp/proj_autoconf_install/lib -lsqlite3" --prefix=/tmp/proj_autoconf_install
+CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install
 make -j3
 make install
 make dist-all
@@ -37,7 +37,7 @@ cd ..
 # autoconf build with grids
 mkdir build_autoconf_grids
 cd build_autoconf_grids
-CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --with-sqlite3_include=/tmp/proj_autoconf_install/include --with-sqlite3_ldflags="-L/tmp/proj_autoconf_install/lib -lsqlite3" --prefix=/tmp/proj_autoconf_install_nad
+CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install_nad
 make -j3
 make install
 find /tmp/proj_autoconf_install_nad


### PR DESCRIPTION
Use pkgconfig to find sqlite3 (only in autotools, as I'm not sure how to get it right for CMake.) This automatically adds override variables, so it really simplifies what needs to be written by hand.

Then add the option of building against external GTest. This is for packagers who want to build against system copies. I was able to do this one for both autotools and cmake.

Both of these could specify a minimum version, but I'm not sure what they should be.