### PR TITLE
Add proj_get_crs_info_list_from_database()

### DIFF
--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -888,6 +888,38 @@ class PROJ_GCC_DLL AuthorityFactory {
 
     PROJ_DLL std::string getDescriptionText(const std::string &code) const;
 
+    /** CRS information */
+    struct CRSInfo {
+        /** Authority name */
+        std::string authName{};
+        /** Code */
+        std::string code{};
+        /** Name */
+        std::string name{};
+        /** Type */
+        ObjectType type{ObjectType::CRS};
+        /** Whether the object is deprecated */
+        bool deprecated{};
+        /** Whereas the west_lon_degree, south_lat_degree, east_lon_degree and
+        * north_lat_degree fields are valid. */
+        bool bbox_valid{};
+        /** Western-most longitude of the area of use, in degrees. */
+        double west_lon_degree{};
+        /** Southern-most latitude of the area of use, in degrees. */
+        double south_lat_degree{};
+        /** Eastern-most longitude of the area of use, in degrees. */
+        double east_lon_degree{};
+        /** Northern-most latitude of the area of use, in degrees. */
+        double north_lat_degree{};
+        /** Name of the area of use. */
+        std::string areaName{};
+        /** Name of the projection method for a projected CRS. Might be empty
+         * even for projected CRS in some cases. */
+        std::string projectionMethodName{};
+    };
+
+    PROJ_DLL std::list<CRSInfo> getCRSInfoList() const;
+
     // non-standard
     PROJ_DLL static AuthorityFactoryNNPtr
     create(const DatabaseContextNNPtr &context,

--- a/src/proj.h
+++ b/src/proj.h
@@ -645,6 +645,74 @@ typedef enum
     PJ_CS_TYPE_TEMPORALMEASURE
 } PJ_COORDINATE_SYSTEM_TYPE;
 
+/** \brief Structure given overall description of a CRS.
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ */
+typedef struct
+{
+    /** Authority name. */
+    char* auth_name;
+    /** Object code. */
+    char* code;
+    /** Object name. */
+    char* name;
+    /** Object type. */
+    PJ_TYPE type;
+    /** Whether the object is deprecated */
+    int deprecated;
+    /** Whereas the west_lon_degree, south_lat_degree, east_lon_degree and
+     * north_lat_degree fields are valid. */
+    int bbox_valid;
+    /** Western-most longitude of the area of use, in degrees. */
+    double west_lon_degree;
+    /** Southern-most latitude of the area of use, in degrees. */
+    double south_lat_degree;
+    /** Eastern-most longitude of the area of use, in degrees. */
+    double east_lon_degree;
+    /** Northern-most latitude of the area of use, in degrees. */
+    double north_lat_degree;
+    /** Name of the area of use. */
+    char* area_name;
+    /** Name of the projection method for a projected CRS. Might be NULL even
+     *for projected CRS in some cases. */
+    char* projection_method_name;
+} PROJ_CRS_INFO;
+
+/** \brief Structure describing optional parameters for proj_get_crs_list();
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ */
+typedef struct
+{
+    /** Array of allowed object types. Should be NULL if all types are allowed*/
+    const PJ_TYPE* types;
+    /** Size of types. Should be 0 if all types are allowed*/
+    size_t typesCount;
+
+    /** If TRUE and bbox_valid == TRUE, then only CRS whose area of use
+     * entirely contains the specified bounding box will be returned.
+     * If FALSE and bbox_valid == TRUE, then only CRS whose area of use
+     * intersects the specified bounding box will be returned.
+     */
+    int crs_area_of_use_contains_bbox;
+    /** To set to TRUE so that west_lon_degree, south_lat_degree,
+     * east_lon_degree and north_lat_degree fields are taken into account. */
+    int bbox_valid;
+    /** Western-most longitude of the area of use, in degrees. */
+    double west_lon_degree;
+    /** Southern-most latitude of the area of use, in degrees. */
+    double south_lat_degree;
+    /** Eastern-most longitude of the area of use, in degrees. */
+    double east_lon_degree;
+    /** Northern-most latitude of the area of use, in degrees. */
+    double north_lat_degree;
+
+    /** Whether deprecated objects are allowed. Default to FALSE. */
+    int allow_deprecated;
+} PROJ_CRS_LIST_PARAMETERS;
 
 
 /**@}*/
@@ -773,6 +841,19 @@ PROJ_STRING_LIST PROJ_DLL proj_get_codes_from_database(PJ_CONTEXT *ctx,
                                              const char *auth_name,
                                              PJ_TYPE type,
                                              int allow_deprecated);
+
+PROJ_CRS_LIST_PARAMETERS PROJ_DLL *proj_get_crs_list_parameters_create(void);
+
+void PROJ_DLL proj_get_crs_list_parameters_destroy(
+                                        PROJ_CRS_LIST_PARAMETERS* params);
+
+PROJ_CRS_INFO PROJ_DLL **proj_get_crs_info_list_from_database(
+                                      PJ_CONTEXT *ctx,
+                                      const char *auth_name,
+                                      const PROJ_CRS_LIST_PARAMETERS* params,
+                                      int *out_result_count);
+
+void PROJ_DLL proj_crs_list_destroy(PROJ_CRS_INFO** list);
 
 /* ------------------------------------------------------------------------- */
 

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -3022,4 +3022,210 @@ TEST_F(CApi, proj_create_cartesian_2D_cs) {
     }
 }
 
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_get_crs_info_list_from_database) {
+    { proj_crs_list_destroy(nullptr); }
+
+    { proj_get_crs_list_parameters_destroy(nullptr); }
+
+    // All null parameters
+    {
+        auto list = proj_get_crs_info_list_from_database(nullptr, nullptr,
+                                                         nullptr, nullptr);
+        ASSERT_NE(list, nullptr);
+        ASSERT_NE(list[0], nullptr);
+        EXPECT_NE(list[0]->auth_name, nullptr);
+        EXPECT_NE(list[0]->code, nullptr);
+        EXPECT_NE(list[0]->name, nullptr);
+        proj_crs_list_destroy(list);
+    }
+
+    // Default parameters
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        proj_get_crs_list_parameters_destroy(params);
+        ASSERT_NE(list, nullptr);
+        EXPECT_GT(result_count, 1);
+        EXPECT_EQ(list[result_count], nullptr);
+        bool found4326 = false;
+        bool found4978 = false;
+        bool found4979 = false;
+        bool found32631 = false;
+        bool found3855 = false;
+        bool found3901 = false;
+        for (int i = 0; i < result_count; i++) {
+            auto code = std::string(list[i]->code);
+            if (code == "4326") {
+                found4326 = true;
+                EXPECT_EQ(std::string(list[i]->auth_name), "EPSG");
+                EXPECT_EQ(std::string(list[i]->name), "WGS 84");
+                EXPECT_EQ(list[i]->type, PJ_TYPE_GEOGRAPHIC_2D_CRS);
+                EXPECT_EQ(list[i]->deprecated, 0);
+                EXPECT_EQ(list[i]->bbox_valid, 1);
+                EXPECT_EQ(list[i]->west_lon_degree, -180.0);
+                EXPECT_EQ(list[i]->south_lat_degree, -90.0);
+                EXPECT_EQ(list[i]->east_lon_degree, 180.0);
+                EXPECT_EQ(list[i]->north_lat_degree, 90.0);
+                EXPECT_EQ(std::string(list[i]->area_name), "World");
+                EXPECT_EQ(list[i]->projection_method_name, nullptr);
+            } else if (code == "4978") {
+                found4978 = true;
+                EXPECT_EQ(list[i]->type, PJ_TYPE_GEOCENTRIC_CRS);
+            } else if (code == "4979") {
+                found4979 = true;
+                EXPECT_EQ(list[i]->type, PJ_TYPE_GEOGRAPHIC_3D_CRS);
+            } else if (code == "32631") {
+                found32631 = true;
+                EXPECT_EQ(list[i]->type, PJ_TYPE_PROJECTED_CRS);
+                EXPECT_EQ(std::string(list[i]->projection_method_name),
+                          "Transverse Mercator");
+            } else if (code == "3855") {
+                found3855 = true;
+                EXPECT_EQ(list[i]->type, PJ_TYPE_VERTICAL_CRS);
+            } else if (code == "3901") {
+                found3901 = true;
+                EXPECT_EQ(list[i]->type, PJ_TYPE_COMPOUND_CRS);
+            }
+            EXPECT_EQ(list[i]->deprecated, 0);
+        }
+        EXPECT_TRUE(found4326);
+        EXPECT_TRUE(found4978);
+        EXPECT_TRUE(found4979);
+        EXPECT_TRUE(found32631);
+        EXPECT_TRUE(found3855);
+        EXPECT_TRUE(found3901);
+        proj_crs_list_destroy(list);
+    }
+
+    // Filter on only geodetic crs
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        params->typesCount = 1;
+        auto type = PJ_TYPE_GEODETIC_CRS;
+        params->types = &type;
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        bool foundGeog2D = false;
+        bool foundGeog3D = false;
+        bool foundGeocentric = false;
+        for (int i = 0; i < result_count; i++) {
+            foundGeog2D |= list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS;
+            foundGeog3D |= list[i]->type == PJ_TYPE_GEOGRAPHIC_3D_CRS;
+            foundGeocentric |= list[i]->type == PJ_TYPE_GEOCENTRIC_CRS;
+            EXPECT_TRUE(list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS ||
+                        list[i]->type == PJ_TYPE_GEOGRAPHIC_3D_CRS ||
+                        list[i]->type == PJ_TYPE_GEOCENTRIC_CRS);
+        }
+        EXPECT_TRUE(foundGeog2D);
+        EXPECT_TRUE(foundGeog3D);
+        EXPECT_TRUE(foundGeocentric);
+        proj_get_crs_list_parameters_destroy(params);
+        proj_crs_list_destroy(list);
+    }
+
+    // Filter on only geographic crs
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        params->typesCount = 1;
+        auto type = PJ_TYPE_GEOGRAPHIC_CRS;
+        params->types = &type;
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        bool foundGeog2D = false;
+        bool foundGeog3D = false;
+        for (int i = 0; i < result_count; i++) {
+            foundGeog2D |= list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS;
+            foundGeog3D |= list[i]->type == PJ_TYPE_GEOGRAPHIC_3D_CRS;
+            EXPECT_TRUE(list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS ||
+                        list[i]->type == PJ_TYPE_GEOGRAPHIC_3D_CRS);
+        }
+        EXPECT_TRUE(foundGeog2D);
+        EXPECT_TRUE(foundGeog3D);
+        proj_get_crs_list_parameters_destroy(params);
+        proj_crs_list_destroy(list);
+    }
+
+    // Filter on only geographic 2D crs and projected CRS
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        params->typesCount = 2;
+        const PJ_TYPE types[] = {PJ_TYPE_GEOGRAPHIC_2D_CRS,
+                                 PJ_TYPE_PROJECTED_CRS};
+        params->types = types;
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        bool foundGeog2D = false;
+        bool foundProjected = false;
+        for (int i = 0; i < result_count; i++) {
+            foundGeog2D |= list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS;
+            foundProjected |= list[i]->type == PJ_TYPE_PROJECTED_CRS;
+            EXPECT_TRUE(list[i]->type == PJ_TYPE_GEOGRAPHIC_2D_CRS ||
+                        list[i]->type == PJ_TYPE_PROJECTED_CRS);
+        }
+        EXPECT_TRUE(foundGeog2D);
+        EXPECT_TRUE(foundProjected);
+        proj_get_crs_list_parameters_destroy(params);
+        proj_crs_list_destroy(list);
+    }
+
+    // Filter on bbox (inclusion)
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        params->bbox_valid = 1;
+        params->west_lon_degree = 2;
+        params->south_lat_degree = 49;
+        params->east_lon_degree = 2.1;
+        params->north_lat_degree = 49.1;
+        params->typesCount = 1;
+        auto type = PJ_TYPE_PROJECTED_CRS;
+        params->types = &type;
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        ASSERT_NE(list, nullptr);
+        EXPECT_GT(result_count, 1);
+        for (int i = 0; i < result_count; i++) {
+            EXPECT_LE(list[i]->west_lon_degree, params->west_lon_degree);
+            EXPECT_LE(list[i]->south_lat_degree, params->south_lat_degree);
+            EXPECT_GE(list[i]->east_lon_degree, params->east_lon_degree);
+            EXPECT_GE(list[i]->north_lat_degree, params->north_lat_degree);
+        }
+        proj_get_crs_list_parameters_destroy(params);
+        proj_crs_list_destroy(list);
+    }
+
+    // Filter on bbox (intersection)
+    {
+        int result_count = 0;
+        auto params = proj_get_crs_list_parameters_create();
+        params->bbox_valid = 1;
+        params->west_lon_degree = 2;
+        params->south_lat_degree = 49;
+        params->east_lon_degree = 2.1;
+        params->north_lat_degree = 49.1;
+        params->crs_area_of_use_contains_bbox = 0;
+        params->typesCount = 1;
+        auto type = PJ_TYPE_PROJECTED_CRS;
+        params->types = &type;
+        auto list = proj_get_crs_info_list_from_database(m_ctxt, "EPSG", params,
+                                                         &result_count);
+        ASSERT_NE(list, nullptr);
+        EXPECT_GT(result_count, 1);
+        for (int i = 0; i < result_count; i++) {
+            EXPECT_LE(list[i]->west_lon_degree, params->east_lon_degree);
+            EXPECT_LE(list[i]->south_lat_degree, params->north_lat_degree);
+            EXPECT_GE(list[i]->east_lon_degree, params->west_lon_degree);
+            EXPECT_GE(list[i]->north_lat_degree, params->south_lat_degree);
+        }
+        proj_get_crs_list_parameters_destroy(params);
+        proj_crs_list_destroy(list);
+    }
+}
 } // namespace

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2810,4 +2810,103 @@ TEST(factory, listAreaOfUseFromName) {
     }
 }
 
+// ---------------------------------------------------------------------------
+
+TEST(factory, getCRSInfoList) {
+    auto ctxt = DatabaseContext::create();
+    {
+        auto factory = AuthorityFactory::create(ctxt, std::string());
+        auto list = factory->getCRSInfoList();
+        EXPECT_GT(list.size(), 1U);
+        bool foundEPSG = false;
+        bool foundIGNF = true;
+        bool found4326 = false;
+        for (const auto &info : list) {
+            foundEPSG |= info.authName == "EPSG";
+            foundIGNF |= info.authName == "IGNF";
+            if (info.authName == "EPSG" && info.code == "4326") {
+                found4326 = true;
+            }
+        }
+        EXPECT_TRUE(foundEPSG);
+        EXPECT_TRUE(foundIGNF);
+        EXPECT_TRUE(found4326);
+    }
+    {
+        auto factory = AuthorityFactory::create(ctxt, "EPSG");
+        auto list = factory->getCRSInfoList();
+        EXPECT_GT(list.size(), 1U);
+        bool found4326 = false;
+        bool found4978 = false;
+        bool found4979 = false;
+        bool found32631 = false;
+        bool found3855 = false;
+        bool found6871 = false;
+        for (const auto &info : list) {
+            EXPECT_EQ(info.authName, "EPSG");
+            if (info.code == "4326") {
+                EXPECT_EQ(info.name, "WGS 84");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::GEOGRAPHIC_2D_CRS);
+                EXPECT_EQ(info.deprecated, false);
+                EXPECT_EQ(info.bbox_valid, true);
+                EXPECT_EQ(info.west_lon_degree, -180.0);
+                EXPECT_EQ(info.south_lat_degree, -90.0);
+                EXPECT_EQ(info.east_lon_degree, 180.0);
+                EXPECT_EQ(info.north_lat_degree, 90.0);
+                EXPECT_EQ(info.areaName, "World");
+                EXPECT_TRUE(info.projectionMethodName.empty());
+                found4326 = true;
+            } else if (info.code == "4296") { // Soudan - deprecated
+                EXPECT_EQ(info.bbox_valid, false);
+                EXPECT_EQ(info.west_lon_degree, 0.0);
+                EXPECT_EQ(info.south_lat_degree, 0.0);
+                EXPECT_EQ(info.east_lon_degree, 0.0);
+                EXPECT_EQ(info.north_lat_degree, 0.0);
+            } else if (info.code == "4978") {
+                EXPECT_EQ(info.name, "WGS 84");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::GEOCENTRIC_CRS);
+                found4978 = true;
+            } else if (info.code == "4979") {
+                EXPECT_EQ(info.name, "WGS 84");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::GEOGRAPHIC_3D_CRS);
+                found4979 = true;
+            } else if (info.code == "32631") {
+                EXPECT_EQ(info.name, "WGS 84 / UTM zone 31N");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::PROJECTED_CRS);
+                EXPECT_EQ(info.deprecated, false);
+                EXPECT_EQ(info.bbox_valid, true);
+                EXPECT_EQ(info.west_lon_degree, 0.0);
+                EXPECT_EQ(info.south_lat_degree, 0.0);
+                EXPECT_EQ(info.east_lon_degree, 6.0);
+                EXPECT_EQ(info.north_lat_degree, 84.0);
+                EXPECT_EQ(info.areaName, "World - N hemisphere - 0\xC2\xB0"
+                                         "E to 6\xC2\xB0"
+                                         "E - by country");
+                EXPECT_EQ(info.projectionMethodName, "Transverse Mercator");
+                found32631 = true;
+            } else if (info.code == "3855") {
+                EXPECT_EQ(info.name, "EGM2008 height");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::VERTICAL_CRS);
+                found3855 = true;
+            } else if (info.code == "6871") {
+                EXPECT_EQ(info.name,
+                          "WGS 84 / Pseudo-Mercator +  EGM2008 geoid height");
+                EXPECT_EQ(info.type,
+                          AuthorityFactory::ObjectType::COMPOUND_CRS);
+                found6871 = true;
+            }
+        }
+        EXPECT_TRUE(found4326);
+        EXPECT_TRUE(found4978);
+        EXPECT_TRUE(found4979);
+        EXPECT_TRUE(found32631);
+        EXPECT_TRUE(found3855);
+        EXPECT_TRUE(found6871);
+    }
+}
 } // namespace


### PR DESCRIPTION
This method is intended to be used typically by GUI that lists all possible CRS.

What is does could be done by previously existing functions, but it is much faster.
It typically runs in less than 0.1s (hot run) versus ~0.5s with the method that
consists in enumerating all codes and instanciating a PJ object for each of them.