### PR TITLE
Address issue #801: set CMake ${PROJ4_LIBRARIES} to PROJ4::proj

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -20,7 +20,7 @@ set (@PROJECT_NAME@_INCLUDE_DIRS "${_ROOT}/@INCLUDEDIR@")
 set (@PROJECT_NAME@_LIBRARY_DIRS "${_ROOT}/@LIBDIR@")
 set (@PROJECT_NAME@_BINARY_DIRS "${_ROOT}/@BINDIR@")
 
-set (@PROJECT_NAME@_LIBRARIES proj)
+set (@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::proj)
 # Read in the exported definition of the library
 include ("${_DIR}/@PROJECT_NAME_LOWER@-targets.cmake")
 include ("${_DIR}/@PROJECT_NAME_LOWER@-namespace-targets.cmake")


### PR DESCRIPTION
This is following the roll out plan given in #789

In a year or two (this is *now*): Two targets, proj and PROJ4::proj, are defined;
PROJ4_LIBRARIES = PROJ4::proj.