### PR TITLE
CMake warning about removing second proj_config.h

### DIFF
--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -37,6 +37,14 @@ set(PACKAGE_TARNAME "proj")
 set(PACKAGE_URL "https://proj4.org")
 set(PACKAGE_VERSION "${${PROJECT_INTERN_NAME}_VERSION}")
 
-configure_file(cmake/proj_config.cmake.in src/proj_config.h)
+# check if a second proj_config.h exists (created by ./configure)
+# as this is within CMake's C_INCLUDES / CXX_INCLUDES
+set(AUTOCONF_PROJ_CONFIG_H "${CMAKE_SOURCE_DIR}/src/proj_config.h")
+if(EXISTS ${AUTOCONF_PROJ_CONFIG_H})
+    message(WARNING "Autoconf's ${AUTOCONF_PROJ_CONFIG_H} may interfere "
+                    "with this CMake build. Run 'make distclean' in the "
+                    "source directory before CMake's build.")
+endif()
 
+configure_file(cmake/proj_config.cmake.in src/proj_config.h)
 


### PR DESCRIPTION
As discovered / discussed in #1269

The behaviour here is to first warn about removing a second `proj_config.h` file, suggesting also run `make distclean`, then remove the file. This file may not be removed successfully in strange scenarios where the file permissions to the source directory are different.