### PR TITLE
Fix data path used by cli tests

### DIFF
--- a/test/cli/Makefile.am
+++ b/test/cli/Makefile.am
@@ -1,5 +1,5 @@
 # Executables paths passed to test scripts
-DATAPATH = ../../data
+PROJ_LIB ?= ../../data
 THIS_DIR = $(top_srcdir)/test/cli
 EXEPATH = ../../src
 PROJEXE = $(EXEPATH)/proj
@@ -27,7 +27,7 @@ EXTRA_DIST = pj_out27.dist pj_out83.dist td_out.dist \
 		CMakeLists.txt
 
 testprojinfo-check:
-	PROJ_LIB=$(DATAPATH) $(TESTPROJINFO) $(PROJINFOEXE)
+	PROJ_LIB=$(PROJ_LIB) $(TESTPROJINFO) $(PROJINFOEXE)
 
 test27-check:
 	$(TEST27) $(PROJEXE)
@@ -36,24 +36,24 @@ test83-check:
 	$(TEST83) $(PROJEXE)
 
 testvarious-check:
-	PROJ_LIB=$(DATAPATH) $(TESTVARIOUS) $(CS2CSEXE)
+	PROJ_LIB=$(PROJ_LIB) $(TESTVARIOUS) $(CS2CSEXE)
 
 testdatumfile-check:
-	@if [ -f $(DATAPATH)/conus -a -f $(DATAPATH)/ntv1_can.dat -a -f $(DATAPATH)/MD -a -f $(DATAPATH)/ntf_r93.gsb ]; then \
-	  PROJ_LIB=$(DATAPATH) $(TESTDATUMFILE) $(CS2CSEXE) ; \
+	@if [ -f $(PROJ_LIB)/conus -a -f $(PROJ_LIB)/ntv1_can.dat -a -f $(PROJ_LIB)/MD -a -f $(PROJ_LIB)/ntf_r93.gsb ]; then \
+	  PROJ_LIB=$(PROJ_LIB) $(TESTDATUMFILE) $(CS2CSEXE) ; \
 	fi
 
 testign-check:
-	@if [ -f $(DATAPATH)/ntf_r93.gsb ] ; then \
-	  PROJ_LIB=$(DATAPATH) $(TESTIGN) $(CS2CSEXE) ; \
+	@if [ -f $(PROJ_LIB)/ntf_r93.gsb ] ; then \
+	  PROJ_LIB=$(PROJ_LIB) $(TESTIGN) $(CS2CSEXE) ; \
 	fi
 
 testntv2-check:
-	@if [ -f $(DATAPATH)/ntv2_0.gsb ] ; then \
-	  PROJ_LIB=$(DATAPATH) $(TESTNTV2) $(CS2CSEXE) ; \
+	@if [ -f $(PROJ_LIB)/ntv2_0.gsb ] ; then \
+	  PROJ_LIB=$(PROJ_LIB) $(TESTNTV2) $(CS2CSEXE) ; \
 	fi
 
 testcct-check:
-	PROJ_LIB=$(DATAPATH) $(TESTCCT) $(CCTEXE)
+	PROJ_LIB=$(PROJ_LIB) $(TESTCCT) $(CCTEXE)
 
 check-local: testprojinfo-check test27-check test83-check testvarious-check testdatumfile-check testign-check testntv2-check testcct-check

--- a/test/cli/test27
+++ b/test/cli/test27
@@ -7,7 +7,6 @@
 #   Mercator due to greater precision of meridional distance function.
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()
@@ -26,12 +25,16 @@ if test ! -x ${EXE}; then
     exit 1
 fi
 
+if test -z "${PROJ_LIB}"; then
+    export PROJ_LIB="`dirname $0`/../../data"
+fi
+
 echo "============================================"
 echo "Running ${0} using ${EXE}:"
 echo "============================================"
 
 OUT=proj_out27
-INIT_FILE=${DATA_DIR}/nad27
+INIT_FILE=${PROJ_LIB}/nad27
 #
 echo "doing tests into file ${OUT}, please wait"
 #

--- a/test/cli/test83
+++ b/test/cli/test83
@@ -8,7 +8,6 @@
 #   Mercator due to greater precision of meridional distance function.
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()
@@ -27,12 +26,16 @@ if test ! -x ${EXE}; then
     exit 1
 fi
 
+if test -z "${PROJ_LIB}"; then
+    export PROJ_LIB="`dirname $0`/../../data"
+fi
+
 echo "============================================"
 echo "Running ${0} using ${EXE}:"
 echo "============================================"
 
 OUT=proj_out83
-INIT_FILE=${DATA_DIR}/nad83
+INIT_FILE=${PROJ_LIB}/nad83
 #
 echo "doing tests into file ${OUT}, please wait"
 #

--- a/test/cli/testIGNF
+++ b/test/cli/testIGNF
@@ -12,7 +12,6 @@
 #               the gsb grid is still ok
 
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()
@@ -32,7 +31,7 @@ if test ! -x ${EXE}; then
 fi
 
 if test -z "${PROJ_LIB}"; then
-    export PROJ_LIB=${DATA_DIR}
+    export PROJ_LIB="`dirname $0`/../../data"
 fi
 
 echo "============================================"

--- a/test/cli/testcct
+++ b/test/cli/testcct
@@ -2,7 +2,6 @@
 # Test cct
 
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()

--- a/test/cli/testdatumfile
+++ b/test/cli/testdatumfile
@@ -4,7 +4,6 @@
 #
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()

--- a/test/cli/testflaky
+++ b/test/cli/testflaky
@@ -4,7 +4,6 @@
 #
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()

--- a/test/cli/testntv2
+++ b/test/cli/testntv2
@@ -4,7 +4,6 @@
 #
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -2,7 +2,6 @@
 # Test projinfo
 
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -4,7 +4,6 @@
 #
 #
 TEST_CLI_DIR=`dirname $0`
-DATA_DIR=`dirname $0`/../../data
 EXE=$1
 
 usage()
@@ -24,7 +23,7 @@ if test ! -x ${EXE}; then
 fi
 
 if test -z "${PROJ_LIB}"; then
-    export PROJ_LIB=$DATA_DIR
+    export PROJ_LIB="`dirname $0`/../../data"
 fi
 
 # Would be great to have a universale way of selecting a locale with


### PR DESCRIPTION
All other tests use `PROJ_LIB`, and allow it to be overridden from the command-line, so do the same here.