### PR TITLE
Fix a couple issues with default context fallback

### DIFF
--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -491,9 +491,7 @@ void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf) {
     passed as first arg at each call to the logger
 ******************************************************************************/
     if (nullptr==ctx)
-        pj_get_default_ctx ();
-    if (nullptr==ctx)
-        return;
+        ctx = pj_get_default_ctx ();
     ctx->logger_app_data = app_data;
     if (nullptr!=logf)
         ctx->logger = logf;

--- a/src/open_lib.cpp
+++ b/src/open_lib.cpp
@@ -194,10 +194,10 @@ pj_open_lib_ex(projCtx ctx, const char *name, const char *mode,
             sysname = name;
 
         /* or try to use application provided file finder */
-        else if( ctx && ctx->file_finder != nullptr && (sysname = ctx->file_finder( ctx, name, ctx->file_finder_user_data )) != nullptr )
+        else if( ctx->file_finder != nullptr && (sysname = ctx->file_finder( ctx, name, ctx->file_finder_user_data )) != nullptr )
             ;
 
-        else if( ctx && ctx->file_finder_legacy != nullptr && (sysname = ctx->file_finder_legacy( name )) != nullptr )
+        else if( ctx->file_finder_legacy != nullptr && (sysname = ctx->file_finder_legacy( name )) != nullptr )
             ;
 
         /* or is environment PROJ_LIB defined */
@@ -234,7 +234,7 @@ pj_open_lib_ex(projCtx ctx, const char *name, const char *mode,
         }
 
         /* If none of those work and we have a search path, try it */
-        if (!fid && ctx && !ctx->search_paths.empty() )
+        if( !fid && !ctx->search_paths.empty() )
         {
             for( const auto& path: ctx->search_paths ) {
                 try {


### PR DESCRIPTION
The first is this null pointer dereference warning:
```
open_lib.cpp: In function 'int* pj_open_lib_ex(projCtx, const char*, const char*, char*, size_t)':
open_lib.cpp:263:18: warning: null pointer dereference [-Wnull-dereference]
  263 |         if( ctx->last_errno == 0 && errno != 0 )
      |             ~~~~~^~~~~~~~~~
```
g++ is confused because of all the other checks for `ctx != nullptr`, and thinks that this one line should also have one, but [either `ctx != nullptr` or `ctx = pj_get_default_ctx()`](https://github.com/OSGeo/proj.4/blob/38f7a68edbb0a5d4a64d98b8297f4281a5d400d0/src/open_lib.cpp#L172-L174) so there really should be no checks at all.

Second, the fallback in `proj_log_func` didn't do anything since it wasn't re-assigning the variable.