### PR TITLE
Miscellaneous documentation fixes

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -5,6 +5,8 @@ To cite PROJ in publications use:
 
 A BibTeX entry for LaTeX users is
 
+.. code-block:: latex
+
   @Manual{,
     title = {{PROJ} coordinate transformation software library},
     author = {{PROJ contributors}},

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -94,7 +94,7 @@ slightly since not all authors has properly configured their names in git.
 1.4 Update `CITATION`
 -------------------------------------------------------------------------------
 
-If needed, update the year in `CITATION` and `docs/source/about.rst`.
+If needed, update the year in `CITATION`.
 
 *Commit the changes to master.*
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On Windows, one may need to specify generator:
     cmake -G "Visual Studio 15 2017" ..
 
 If the SQLite3 dependency is installed in a custom location, specify the
-paths to the include directory and the library::
+paths to the include directory and the library:
 
     cmake -DSQLITE3_INCLUDE_DIR=/opt/SQLite/include -DSQLITE3_LIBRARY=/opt/SQLite/lib/libsqlite3.so ..
 

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -23,22 +23,9 @@ datums using all but the most obscure geodetic techniques.
 Citation
 -------------------------------------------------------------------------------
 
-To cite PROJ in publications use:
 
-  PROJ contributors (2018). PROJ coordinate transformation software
-  library. Open Source Geospatial Foundation. URL https://proj4.org/.
+.. include:: ../../CITATION
 
-A BibTeX entry for LaTeX users is
-
-.. code-block:: latex
-
-  @Manual{,
-    title = {{PROJ} coordinate transformation software library},
-    author = {{PROJ contributors}},
-    organization = {Open Source Geospatial Foundation},
-    year = {2018},
-    url = {https://proj4.org/},
-  }
 
 License
 -------------------------------------------------------------------------------

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -67,7 +67,7 @@ The following control parameters can appear in any order:
 .. option:: --summary
 
     When listing coordinate operations available between 2 CRS, return the
-    result in a summary format, mentionning only the name of the coordinate
+    result in a summary format, mentioning only the name of the coordinate
     operation, its accuracy and its area of use.
 
     .. note:: only used for coordinate operation computation
@@ -104,7 +104,7 @@ The following control parameters can appear in any order:
 
     Specify how the area of use of coordinate operations found in the database
     are compared to the area of use specified explicitly with :option:`--area` or :option:`--bbox`,
-    or derivedi implictly from the area of use of the source and target CRS.
+    or derived implicitly from the area of use of the source and target CRS.
     By default, projinfo will only keep coordinate operations whose are of use
     is strictly within the area of interest (``contains`` strategy).
     If using the ``intersects`` strategy, the spatial test is relaxed, and any

--- a/docs/source/operations/projections/comill.rst
+++ b/docs/source/operations/projections/comill.rst
@@ -7,7 +7,7 @@ Compact Miller
 The Compact Miller projection is a cylindrical map projection with a
 height-to-width ratio of 0.6:1.
 
-See :cite:`Jenny2014`
+See :cite:`Jenny2015`
 
 +---------------------+----------------------------------------------------------+
 | **Classification**  | Cylindrical                                              |

--- a/docs/source/operations/projections/natearth2.rst
+++ b/docs/source/operations/projections/natearth2.rst
@@ -30,9 +30,9 @@ Natural Earth II
 
 The Natural Earth II projection is intended for making world maps. At high
 latitudes, meridians bend steeply toward short pole lines resulting in a map
-with highly rounded corners that resembles an elongated globe
+with highly rounded corners that resembles an elongated globe.
 
-See :cite:`Savric2016`
+See :cite:`Savric2015`
 
 
 Parameters

--- a/docs/source/operations/projections/patterson.rst
+++ b/docs/source/operations/projections/patterson.rst
@@ -7,7 +7,7 @@ Patterson
 The Patterson projection is a cylindrical map projection designed for
 general-purpose mapmaking.
 
-See :cite:`Patterson2015`
+See :cite:`Patterson2014`
 
 +---------------------+----------------------------------------------------------+
 | **Classification**  | Cylindrical                                              |

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -3,7 +3,7 @@
 
 
 @Article{Altamimi2002,
-  Title                    = {ITRF2000: A new release of the International Terrestrial Reference Frame for earth science applications},
+  Title                    = {{ITRF2000}: A new release of the {International Terrestrial Reference Frame} for earth science applications},
   Author                   = {Z. Altamimi and P. Sillard and C. Boucher},
   Journal                  = {Journal of Geophysical Research: Solid Earth},
   Year                     = {2002},
@@ -73,21 +73,13 @@
 
 @Article{EberHewitt1979,
   Title                    = {Conversion algorithms for the {CalCOFI} station grid},
-  Author                   = {L. E. Eber and R.P. Hewitt},
+  Author                   = {L. E. Eber and R. P. Hewitt},
   Journal                  = {California Cooperative Oceanic Fisheries Investigations Reports},
   Year                     = {1979},
   Pages                    = {135--137},
   Volume                   = {20},
 
   Url                      = {http://www.calcofi.org/publications/calcofireports/v20/Vol_20_Eber___Hewitt.pdf}
-}
-
-@Manual{EPSGGuidanceNumber7Part2,
-  Title                    = {Geomatics Guidance Note 7, part 2 - Coordinate Conversions & Transformations including Formulas},
-  Institution              = {International Association For Oil And Gas Producers},
-  Year                     = {2018},
-
-  Url                      = {https://www.iogp.org/bookstore/product/coordinate-conversions-and-transformation-including-formulas/}
 }
 
 @Manual{Evenden2005,
@@ -140,19 +132,24 @@
   Doi                      = {10.5281/zenodo.32050}
 }
 
-@Article{Hensley2002,
-  Title                    = {Improved Processing of AIRSAR Data Based on the GeoSAR Processor},
-  Author                   = {Scott Hensley and Elaine Chapin and Adam Freedman and Thierry Michel},
-  Journal                  = {Airsar earth science and applications workshop},
+@InProceedings{Hensley2002,
+  Title                    = {Improved Processing of {AIRSAR} Data Based on the {GeoSAR} Processor},
+  Author                   = {S. Hensley and E. Chapin and A. Freedman and T. Michel},
+  Booktitle                = {AIRSAR Earth Science and Application Workshop},
   Year                     = {2002},
+  Organization             = {Jet Propulsion Laboratory},
+
   Url                      = {https://airsar.jpl.nasa.gov/documents/workshop2002/papers/T3.pdf}
 }
 
-@Article{Jenny2014,
+@Article{Jenny2015,
   Title                    = {A compromise aspect-adaptive cylindrical projection for world maps},
-  Author                   = {Bernhard Jenny, Bojan Šavrič, Tom Patterson},
+  Author                   = {B. Jenny and B. Šavrič and T. Patterson},
   Journal                  = {International Journal of Geographical Information Science},
-  Year                     = {2014},
+  Year                     = {2015},
+  Number                   = {6},
+  Pages                    = {935--952},
+  Volume                   = {29},
 
   Doi                      = {10.1080/13658816.2014.997734},
   Url                      = {http://www.cartography.oregonstate.edu/pdf/2015_Jenny_etal_ACompromiseAspect-adaptiveCylindricalProjectionForWorldMaps.pdf}
@@ -215,47 +212,77 @@
   Url                      = {https://archive.org/details/DTIC_ADA026294}
 }
 
-@techreport{Poder1998,
-  author       = {Knud Poder and Karsten Engsager},
-  year         = {1998},
-  title        = {Some Conformal Mappings and Transformations for Geodesy
-                  and Topographic Cartography},
-  address      = {Copenhagen, Denmark},
-  institution  = {National Survey and Cadastre},
-  type         = {National Survey and Cadastre Publications},
-  series       = {4},
-  volume       = {6},
-  isbn         = {87-7866-085-8},
-  pages        = {63}
-}
-
-@Article{Patterson2015,
-  Title                    = {Introducing the Patterson Cylindrical Projection},
-  Author                   = {Tom Patterson, Bojan Šavrič, Bernhard Jenny},
+@Article{Patterson2014,
+  Title                    = {Introducing the {Patterson} Cylindrical Projection},
+  Author                   = {T. Patterson and B. Šavrič and B. Jenny},
   Journal                  = {Cartographic Perspectives},
-  Year                     = {2015},
-  Number                   = {78},
+  Year                     = {2014},
+  Volume                   = {78},
 
   Doi                      = {10.14714/CP78.1270}
 }
 
-@Misc{Rittri2012,
-    author = {Mikael Rittri},
-    title  = {New omerc approximations of Denmark System 34},
-    year   = {2012},
-    url    = {https://lists.osgeo.org/pipermail/proj/2012-June/005926.html}
+@TechReport{Poder1998,
+  Title                    = {Some Conformal Mappings and Transformations for Geodesy and Topographic Cartography},
+  Author                   = {K. Poder and K. Engsager},
+  Institution              = {National Survey and Cadastre},
+  Year                     = {1998},
+
+  Address                  = {Copenhagen, Denmark},
+  Type                     = {National Survey and Cadastre Publications},
+
+  ISBN                     = {87-7866-085-8},
+  Pages                    = {63},
+  Series                   = {4},
+  Volume                   = {6}
 }
 
-@article{Ruffhead2016,
-    author = {A. C. Ruffhead},
-    title = {Introduction to multiple regression equations in datum transformations and their reversibility},
-    journal = {Survey Review},
-    volume = {50},
-    number = {358},
-    pages = {82-90},
-    year  = {2016},
-    publisher = {Taylor & Francis},
-    doi = {10.1080/00396265.2016.1244143},
+@Misc{Rittri2012,
+  Title                    = {New omerc approximations of {Denmark System 34}},
+
+  Author                   = {M. Rittri},
+  HowPublished             = {e-mail},
+  Year                     = {2012},
+
+  Url                      = {https://lists.osgeo.org/pipermail/proj/2012-June/005926.html}
+}
+
+@Article{Ruffhead2016,
+  Title                    = {Introduction to multiple regression equations in datum transformations and their reversibility},
+  Author                   = {A. C. Ruffhead},
+  Journal                  = {Survey Review},
+  Year                     = {2016},
+  Number                   = {358},
+  Pages                    = {82-90},
+  Volume                   = {50},
+
+  Doi                      = {10.1080/00396265.2016.1244143},
+  Publisher                = {Taylor \& Francis}
+}
+
+@Article{Savric2018,
+  Title                    = {The {Equal Earth} map projection},
+  Author                   = {B. Šavrič and T. Patterson and B. Jenny},
+  Journal                  = {International Journal of Geographical Information Science},
+  Year                     = {2018},
+  Number                   = {3},
+  Volume                   = {33},
+
+  Doi                      = {10.1080/13658816.2018.1504949},
+  Url                      = {https://www.researchgate.net/publication/326879978_The_Equal_Earth_map_projection}
+}
+
+@Article{Savric2015,
+  Title                    = {The {Natural Earth II} world map projection},
+  Author                   = {B. Šavrič and T. Patterson and B. Jenny},
+  Journal                  = {International Journal of Geographical Information Science},
+  Year                     = {2015},
+  Number                   = {2},
+  Pages                    = {123--133},
+  Volume                   = {1},
+
+  Doi                      = {10.1080/23729333.2015.1093312},
+  Url                      = {https://www.researchgate.net/publication/290447301_The_Natural_Earth_II_world_map_projection}
 }
 
 @Book{Snyder1993,
@@ -265,39 +292,18 @@
   Year                     = {1993}
 }
 
-@Article{Savric2016,
-  Title                    = {The Natural Earth II world map projection},
-  Author                   = {Bojan Šavrič, Tom Patterson, Bernhard Jenny},
-  Journal                  = {International Journal of Geographical Information Science},
-  Year                     = {2016},
-
-  Doi                      = {10.1080/23729333.2015.1093312},
-  Url                      = {http://berniejenny.info/pdf/2016_Savric_etal_NaturalEarthII.pdf}
-}
-
-@Article{Savric2018,
-  Author                   = {B. Šavrič and T. Patterson and B. Jenny},
-  Title                    = {The Equal Earth map projection},
-  Journal                  = {International Journal of Geographical Information Science},
-  Year                     = {2018},
-  Publisher                = {Taylor & Francis},
-  Doi                      = {10.1080/13658816.2018.1504949},
-  Url                      = {https://www.researchgate.net/profile/Bojan_Savric2/publication/326879978_The_Equal_Earth_map_projection/links/5b69d0ae299bf14c6d951b77/The-Equal-Earth-map-projection.pdf}
-}
-
 @Article{Snyder1988,
-  Author                   = {J. P. Snyder },
   Title                    = {New Equal-Area Map Projections For Noncircular Regions},
+  Author                   = {J. P. Snyder},
   Journal                  = {The American Cartographer},
-  Volume                   = {15},
-  Number                   = {4},
-  Pages                    = {341-356},
   Year                     = {1988},
-  Publisher                = {Taylor and Francis},
+  Number                   = {4},
+  Pages                    = {341--356},
+  Volume                   = {15},
 
-  Doi                      = {10.1559/152304088783886784}
+  Doi                      = {10.1559/152304088783886784},
+  Publisher                = {Taylor and Francis}
 }
-
 
 @TechReport{Snyder1987,
   Title                    = {Map Projections --- {A} Working Manual},
@@ -319,15 +325,16 @@
 }
 
 @Article{Tobler2017,
+  Title                    = {A new companion for {Mercator}},
   Author                   = {W. Tobler},
-  Title                    = {A new companion for Mercator},
   Journal                  = {Cartography and Geographic Information Science},
-  Volume                   = {45},
-  Number                   = {3},
-  Pages                    = {284-285},
-  Publisher                = {Taylor & Francis},
   Year                     = {2017},
+  Number                   = {3},
+  Pages                    = {284--285},
+  Volume                   = {45},
+
   Doi                      = {10.1080/15230406.2017.1308837},
+  Publisher                = {Taylor \& Francis}
 }
 
 @Article{Verey2017,
@@ -375,5 +382,13 @@
   Volume                   = {27},
 
   Doi                      = {10.2307/1219899}
+}
+
+@Manual{EPSGGuidanceNumber7Part2,
+  Title                    = {Geomatics Guidance Note 7, part 2 - Coordinate Conversions \& Transformations including Formulas},
+  Year                     = {2018},
+
+  Institution              = {International Association For Oil And Gas Producers},
+  Url                      = {https://www.iogp.org/bookstore/product/coordinate-conversions-and-transformation-including-formulas/}
 }
 


### PR DESCRIPTION
Notably a few corrections to the BibTeX references, which is fussy format regarding title case, name formats, and other subtle details. Some years were corrected (based on the publisher's info), or volumes/numbers/pages added. The .bib file was normalized (re-saved) with JabRef, which sorts these by last name.