### PR TITLE
Doc: rename to ISO-19111:2019

### DIFF
--- a/include/proj/common.hpp
+++ b/include/proj/common.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -291,7 +291,7 @@ using IdentifiedObjectNNPtr = util::nn<IdentifiedObjectPtr>;
 /** \brief Abstract class representating a CRS-related object that has an
  * identification.
  *
- * \remark Implements IdentifiedObject from \ref ISO_19111_2018
+ * \remark Implements IdentifiedObject from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL IdentifiedObject : public util::BaseObject,
                                       public util::IComparable,
@@ -364,7 +364,7 @@ using ObjectDomainNNPtr = util::nn<ObjectDomainPtr>;
 
 /** \brief The scope and validity of a CRS-related object.
  *
- * \remark Implements ObjectDomain from \ref ISO_19111_2018
+ * \remark Implements ObjectDomain from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ObjectDomain : public util::BaseObject,
                                   public util::IComparable {
@@ -419,7 +419,7 @@ using ObjectUsageNNPtr = util::nn<ObjectUsagePtr>;
 
 /** \brief Abstract class of a CRS-related object that has usages.
  *
- * \remark Implements ObjectUsage from \ref ISO_19111_2018
+ * \remark Implements ObjectUsage from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ObjectUsage : public IdentifiedObject {
   public:

--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -113,7 +113,7 @@ using CoordinateOperationNNPtr = util::nn<CoordinateOperationPtr>;
  * (some) entirely different parameter values are needed, a different coordinate
  * operation shall be defined.
  *
- * \remark Implements CoordinateOperation from \ref ISO_19111_2018
+ * \remark Implements CoordinateOperation from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
                                          public io::IPROJStringExportable {
@@ -181,7 +181,7 @@ class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
 /** \brief Abstract class modelling a parameter value (OperationParameter)
  * or group of parameters.
  *
- * \remark Implements GeneralOperationParameter from \ref ISO_19111_2018
+ * \remark Implements GeneralOperationParameter from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL GeneralOperationParameter : public common::IdentifiedObject {
   public:
@@ -225,7 +225,7 @@ using OperationParameterNNPtr = util::nn<OperationParameterPtr>;
  * Most parameter values are numeric, but other types of parameter values are
  * possible.
  *
- * \remark Implements OperationParameter from \ref ISO_19111_2018
+ * \remark Implements OperationParameter from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL OperationParameter final : public GeneralOperationParameter {
   public:
@@ -271,7 +271,7 @@ struct MethodMapping;
 /** \brief Abstract class modelling a parameter value (OperationParameterValue)
  * or group of parameter values.
  *
- * \remark Implements GeneralParameterValue from \ref ISO_19111_2018
+ * \remark Implements GeneralParameterValue from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL GeneralParameterValue : public util::BaseObject,
                                            public io::IWKTExportable,
@@ -325,7 +325,7 @@ using ParameterValueNNPtr = util::nn<ParameterValuePtr>;
  * Most parameter values are numeric, but other types of parameter values are
  * possible.
  *
- * \remark Implements ParameterValue from \ref ISO_19111_2018
+ * \remark Implements ParameterValue from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ParameterValue final : public util::BaseObject,
                                           public io::IWKTExportable,
@@ -400,7 +400,7 @@ using OperationParameterValueNNPtr = util::nn<OperationParameterValuePtr>;
  *
  * This combines a OperationParameter with the corresponding ParameterValue.
  *
- * \remark Implements OperationParameterValue from \ref ISO_19111_2018
+ * \remark Implements OperationParameterValue from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL OperationParameterValue final
     : public GeneralParameterValue {
@@ -463,7 +463,7 @@ using OperationMethodNNPtr = util::nn<OperationMethodPtr>;
  * For a projection method, this contains the name of the projection method
  * and the name of the projection parameters.
  *
- * \remark Implements OperationMethod from \ref ISO_19111_2018
+ * \remark Implements OperationMethod from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL OperationMethod : public common::IdentifiedObject {
   public:
@@ -534,7 +534,7 @@ using SingleOperationNNPtr = util::nn<SingleOperationPtr>;
 /** \brief A single (not concatenated) coordinate operation
  * (CoordinateOperation)
  *
- * \remark Implements SingleOperation from \ref ISO_19111_2018
+ * \remark Implements SingleOperation from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL SingleOperation : virtual public CoordinateOperation {
   public:
@@ -633,7 +633,7 @@ using ConversionNNPtr = util::nn<ConversionPtr>;
  * associations, but through associations from crs::DerivedCRS to
  * crs::SingleCRS.
  *
- * \remark Implements Conversion from \ref ISO_19111_2018
+ * \remark Implements Conversion from \ref ISO_19111_2019
  */
 
 /*!
@@ -1353,7 +1353,7 @@ using TransformationNNPtr = util::nn<TransformationPtr>;
  * coordinates are referenced to different datums (reference frames) will be a
  * coordinate transformation.
  *
- * \remark Implements Transformation from \ref ISO_19111_2018
+ * \remark Implements Transformation from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL Transformation : public SingleOperation {
   public:
@@ -1553,7 +1553,7 @@ using PointMotionOperationNNPtr = util::nn<PointMotionOperationPtr>;
  *
  * The motion is due to tectonic plate movement or deformation.
  *
- * \remark Implements PointMotionOperation from \ref ISO_19111_2018
+ * \remark Implements PointMotionOperation from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL PointMotionOperation : public SingleOperation {
   public:
@@ -1582,7 +1582,7 @@ using ConcatenatedOperationNNPtr = util::nn<ConcatenatedOperationPtr>;
  * the source coordinate reference system of step n+1 shall be the same as
  * the target coordinate reference system of step n.
  *
- * \remark Implements ConcatenatedOperation from \ref ISO_19111_2018
+ * \remark Implements ConcatenatedOperation from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ConcatenatedOperation final : public CoordinateOperation {
   public:

--- a/include/proj/coordinatesystem.hpp
+++ b/include/proj/coordinatesystem.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -51,7 +51,7 @@ namespace cs {
 /** \brief The direction of positive increase in the coordinate value for a
  * coordinate system axis.
  *
- * \remark Implements AxisDirection from \ref ISO_19111_2018
+ * \remark Implements AxisDirection from \ref ISO_19111_2019
  */
 class AxisDirection : public util::CodeList {
   public:
@@ -119,7 +119,7 @@ using MeridianNNPtr = util::nn<MeridianPtr>;
 /** \brief The meridian that the axis follows from the pole, for a coordinate
  * reference system centered on a pole.
  *
- * \note There is no modelling for this concept in \ref ISO_19111_2018
+ * \note There is no modelling for this concept in \ref ISO_19111_2019
  *
  * \remark Implements MERIDIAN from \ref WKT2
  */
@@ -163,7 +163,7 @@ using CoordinateSystemAxisNNPtr = util::nn<CoordinateSystemAxisPtr>;
 
 /** \brief The definition of a coordinate system axis.
  *
- * \remark Implements CoordinateSystemAxis from \ref ISO_19111_2018
+ * \remark Implements CoordinateSystemAxis from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CoordinateSystemAxis final
     : public common::IdentifiedObject {
@@ -233,7 +233,7 @@ class PROJ_GCC_DLL CoordinateSystemAxis final
  * The coordinate values in a coordinate tuple shall be recorded in the order
  * in which the coordinate system axes associations are recorded.
  *
- * \remark Implements CoordinateSystem from \ref ISO_19111_2018
+ * \remark Implements CoordinateSystem from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CoordinateSystem : public common::IdentifiedObject {
   public:
@@ -289,7 +289,7 @@ using SphericalCSNNPtr = util::nn<SphericalCSPtr>;
  * ellipsoid "degenerated" into a sphere. A SphericalCS shall have three
  * axis associations.
  *
- * \remark Implements SphericalCS from \ref ISO_19111_2018
+ * \remark Implements SphericalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL SphericalCS final : public CoordinateSystem {
   public:
@@ -332,7 +332,7 @@ using EllipsoidalCSNNPtr = util::nn<EllipsoidalCSPtr>;
  *
  * An EllipsoidalCS shall have two or three associations.
  *
- * \remark Implements EllipsoidalCS from \ref ISO_19111_2018
+ * \remark Implements EllipsoidalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL EllipsoidalCS final : public CoordinateSystem {
   public:
@@ -411,7 +411,7 @@ using VerticalCSNNPtr = util::nn<VerticalCSPtr>;
  * Such a coordinate system is usually dependent on the Earth's gravity field.
  * A VerticalCS shall have one axis association.
  *
- * \remark Implements VerticalCS from \ref ISO_19111_2018
+ * \remark Implements VerticalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL VerticalCS final : public CoordinateSystem {
   public:
@@ -460,7 +460,7 @@ using CartesianCSNNPtr = util::nn<CartesianCSPtr>;
  * three axis associations; the number of associations shall equal the
  * dimension of the CS.
  *
- * \remark Implements CartesianCS from \ref ISO_19111_2018
+ * \remark Implements CartesianCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CartesianCS final : public CoordinateSystem {
   public:
@@ -529,7 +529,7 @@ using OrdinalCSNNPtr = util::nn<OrdinalCSPtr>;
  * The number of associations shall equal the
  * dimension of the CS.
  *
- * \remark Implements OrdinalCS from \ref ISO_19111_2018
+ * \remark Implements OrdinalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL OrdinalCS final : public CoordinateSystem {
   public:
@@ -565,7 +565,7 @@ using ParametricCSNNPtr = util::nn<ParametricCSPtr>;
 /** \brief one-dimensional coordinate reference system which uses parameter
  * values or functions that may vary monotonically with height.
  *
- * \remark Implements ParametricCS from \ref ISO_19111_2018
+ * \remark Implements ParametricCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ParametricCS final : public CoordinateSystem {
   public:
@@ -603,7 +603,7 @@ using TemporalCSNNPtr = util::nn<TemporalCSPtr>;
  *
  * A TemporalCS shall have one axis association.
  *
- * \remark Implements TemporalCS from \ref ISO_19111_2018
+ * \remark Implements TemporalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL TemporalCS : public CoordinateSystem {
   public:
@@ -637,7 +637,7 @@ using DateTimeTemporalCSNNPtr = util::nn<DateTimeTemporalCSPtr>;
  * axisUnitID; the temporal quantities are defined through the ISO 8601
  * representation.
  *
- * \remark Implements DateTimeTemporalCS from \ref ISO_19111_2018
+ * \remark Implements DateTimeTemporalCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DateTimeTemporalCS final : public TemporalCS {
   public:
@@ -673,7 +673,7 @@ using TemporalCountCSNNPtr = util::nn<TemporalCountCSPtr>;
  *
  * A TemporalCountCS shall have one axis association.
  *
- * \remark Implements TemporalCountCS from \ref ISO_19111_2018
+ * \remark Implements TemporalCountCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL TemporalCountCS final : public TemporalCS {
   public:
@@ -709,7 +709,7 @@ using TemporalMeasureCSNNPtr = util::nn<TemporalMeasureCSPtr>;
  *
  * A TemporalMeasureCS shall have one axis association.
  *
- * \remark Implements TemporalMeasureCS from \ref ISO_19111_2018
+ * \remark Implements TemporalMeasureCS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL TemporalMeasureCS final : public TemporalCS {
   public:

--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -79,7 +79,7 @@ using CRSNNPtr = util::nn<CRSPtr>;
 /** \brief Abstract class modelling a coordinate reference system which is
  * usually single but may be compound.
  *
- * \remark Implements CRS from \ref ISO_19111_2018
+ * \remark Implements CRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CRS : public common::ObjectUsage {
   public:
@@ -149,7 +149,7 @@ class PROJ_GCC_DLL CRS : public common::ObjectUsage {
  * one Coordinate System and either one datum::Datum or one
  * datum::DatumEnsemble.
  *
- * \remark Implements SingleCRS from \ref ISO_19111_2018
+ * \remark Implements SingleCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL SingleCRS : public CRS {
   public:
@@ -204,7 +204,7 @@ using GeodeticCRSNNPtr = util::nn<GeodeticCRSPtr>;
  * association to a velocity model then the geodetic CRS is dynamic, else it
  * is static.
  *
- * \remark Implements GeodeticCRS from \ref ISO_19111_2018
+ * \remark Implements GeodeticCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL GeodeticCRS : virtual public SingleCRS,
                                  public io::IPROJStringExportable {
@@ -312,7 +312,7 @@ class PROJ_GCC_DLL GeodeticCRS : virtual public SingleCRS,
  * association to a velocity model then the geodetic CRS is dynamic, else it is
  * static.
  *
- * \remark Implements GeographicCRS from \ref ISO_19111_2018
+ * \remark Implements GeographicCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL GeographicCRS : public GeodeticCRS {
   public:
@@ -398,7 +398,7 @@ class PROJ_GCC_DLL GeographicCRS : public GeodeticCRS {
  * reference system. They exist only as an inseparable part of a 3D coordinate
  * tuple defined in a geographic 3D coordinate reference system.
  *
- * \remark Implements VerticalCRS from \ref ISO_19111_2018
+ * \remark Implements VerticalCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL VerticalCRS : virtual public SingleCRS,
                                  public io::IPROJStringExportable {
@@ -476,7 +476,7 @@ class PROJ_GCC_DLL VerticalCRS : virtual public SingleCRS,
  * coordinate reference system is implemented using the parameters and
  * formula(s) specified in the definition of the coordinate conversion.
  *
- * \remark Implements DerivedCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DerivedCRS : virtual public SingleCRS {
   public:
@@ -539,7 +539,7 @@ using ProjectedCRSNNPtr = util::nn<ProjectedCRSPtr>;
  * height is passed through unchanged and forms the vertical axis of the
  * projected CRS's Cartesian coordinate system.
  *
- * \remark Implements ProjectedCRS from \ref ISO_19111_2018
+ * \remark Implements ProjectedCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ProjectedCRS final : public DerivedCRS,
                                         public io::IPROJStringExportable {
@@ -612,7 +612,7 @@ using TemporalCRSNNPtr = util::nn<TemporalCRSPtr>;
 /** \brief A coordinate reference system associated with a temporal datum and a
  * one-dimensional temporal coordinate system.
  *
- * \remark Implements TemporalCRS from \ref ISO_19111_2018
+ * \remark Implements TemporalCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL TemporalCRS : virtual public SingleCRS {
   public:
@@ -671,7 +671,7 @@ using EngineeringCRSNNPtr = util::nn<EngineeringCRSPtr>;
  * In \ref WKT2, it maps to a ENGINEERINGCRS / ENGCRS keyword. In \ref WKT1,
  * it maps to a LOCAL_CS keyword.
  *
- * \remark Implements EngineeringCRS from \ref ISO_19111_2018
+ * \remark Implements EngineeringCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL EngineeringCRS : virtual public SingleCRS {
   public:
@@ -725,7 +725,7 @@ using ParametricCRSNNPtr = util::nn<ParametricCRSPtr>;
  * without geodetic corrections, or on moving platforms such as road vehicles
  * vessels, aircraft or spacecraft, or as the internal CRS of an image.
  *
- * \remark Implements ParametricCRS from \ref ISO_19111_2018
+ * \remark Implements ParametricCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ParametricCRS : virtual public SingleCRS {
   public:
@@ -781,11 +781,11 @@ using CompoundCRSNNPtr = util::nn<CompoundCRSPtr>;
  * if coordinate values in one cannot be converted or transformed into
  * coordinate values in the other.
  *
- * \note As a departure to \ref ISO_19111_2018, we allow to build a CompoundCRS
- * from CRS objects, whereas ISO19111:2018 restricts the components to
+ * \note As a departure to \ref ISO_19111_2019, we allow to build a CompoundCRS
+ * from CRS objects, whereas ISO19111:2019 restricts the components to
  * SingleCRS.
  *
- * \remark Implements CompoundCRS from \ref ISO_19111_2018
+ * \remark Implements CompoundCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL CompoundCRS final : public CRS,
                                        public io::IPROJStringExportable {
@@ -857,7 +857,7 @@ class PROJ_GCC_DLL CompoundCRS final : public CRS,
  * present in \ref WKT1.
  *
  * \note Contrary to other CRS classes of this package, there is no
- * \ref ISO_19111_2018 modelling of a BoundCRS.
+ * \ref ISO_19111_2019 modelling of a BoundCRS.
  *
  * \remark Implements BoundCRS from \ref WKT2
  */
@@ -935,7 +935,7 @@ using DerivedGeodeticCRSNNPtr = util::nn<DerivedGeodeticCRSPtr>;
  * inheriting a geodetic reference frame, and associated with a 3D Cartesian
  * or spherical coordinate system.
  *
- * \remark Implements DerivedGeodeticCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedGeodeticCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DerivedGeodeticCRS final : public GeodeticCRS,
                                               public DerivedCRS {
@@ -1010,7 +1010,7 @@ using DerivedGeographicCRSNNPtr = util::nn<DerivedGeographicCRSPtr>;
  * A derived geographic CRS can be based on a geodetic CRS only if that
  * geodetic CRS definition includes an ellipsoid.
  *
- * \remark Implements DerivedGeographicCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedGeographicCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DerivedGeographicCRS final : public GeographicCRS,
                                                 public DerivedCRS {
@@ -1075,7 +1075,7 @@ using DerivedProjectedCRSNNPtr = util::nn<DerivedProjectedCRSPtr>;
  *
  * A DerivedProjectedCRS is not a ProjectedCRS.
  *
- * \remark Implements DerivedProjectedCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedProjectedCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DerivedProjectedCRS final : public DerivedCRS {
   public:
@@ -1129,7 +1129,7 @@ using DerivedVerticalCRSNNPtr = util::nn<DerivedVerticalCRSPtr>;
  * coordinate reference system as its base CRS, thereby inheriting a vertical
  * reference frame, and a vertical coordinate system.
  *
- * \remark Implements DerivedVerticalCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedVerticalCRS from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DerivedVerticalCRS final : public VerticalCRS,
                                               public DerivedCRS {
@@ -1275,7 +1275,7 @@ struct PROJ_GCC_DLL DerivedEngineeringCRSTraits {
  * engineering datum, and is associated with one of the coordinate system
  * types for an EngineeringCRS
  *
- * \remark Implements DerivedEngineeringCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedEngineeringCRS from \ref ISO_19111_2019
  */
 #ifdef DOXYGEN_ENABLED
 class DerivedEngineeringCRS
@@ -1312,7 +1312,7 @@ struct PROJ_GCC_DLL DerivedParametricCRSTraits {
  * coordinate reference system as its base CRS, thereby inheriting a parametric
  * datum, and a parametric coordinate system.
  *
- * \remark Implements DerivedParametricCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedParametricCRS from \ref ISO_19111_2019
  */
 #ifdef DOXYGEN_ENABLED
 class DerivedParametricCRS
@@ -1349,7 +1349,7 @@ struct PROJ_GCC_DLL DerivedTemporalCRSTraits {
  * coordinate reference system as its base CRS, thereby inheriting a temporal
  * datum, and a temporal coordinate system.
  *
- * \remark Implements DerivedTemporalCRS from \ref ISO_19111_2018
+ * \remark Implements DerivedTemporalCRS from \ref ISO_19111_2019
  */
 #ifdef DOXYGEN_ENABLED
 class DerivedTemporalCRS : public DerivedCRSTemplate<DerivedTemporalCRSTraits> {

--- a/include/proj/datum.hpp
+++ b/include/proj/datum.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -59,7 +59,7 @@ namespace datum {
  * subtype can be associated with only specific types of coordinate reference
  * systems.
  *
- * \remark Implements Datum from \ref ISO_19111_2018
+ * \remark Implements Datum from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL Datum : public common::ObjectUsage {
   public:
@@ -115,7 +115,7 @@ using DatumEnsembleNNPtr = util::nn<DatumEnsemblePtr>;
  * Every frame within the datum ensemble must be a realizations of the same
  * Terrestrial Reference System or Vertical Reference System.
  *
- * \remark Implements DatumEnsemble from \ref ISO_19111_2018
+ * \remark Implements DatumEnsemble from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DatumEnsemble final : public common::IdentifiedObject {
   public:
@@ -168,7 +168,7 @@ using PrimeMeridianNNPtr = util::nn<PrimeMeridianPtr>;
  * \note The default value for prime meridian name is "Greenwich". When the
  * default applies, the value for the longitude shall be 0 (degrees).
  *
- * \remark Implements PrimeMeridian from \ref ISO_19111_2018
+ * \remark Implements PrimeMeridian from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL PrimeMeridian final : public common::IdentifiedObject,
                                          public io::IPROJStringExportable {
@@ -240,7 +240,7 @@ using EllipsoidNNPtr = util::nn<EllipsoidPtr>;
  * For the Earth an oblate biaxial ellipsoid is used: in mathematical terms,
  * it is a surface formed by the rotation of an ellipse about its minor axis.
  *
- * \remark Implements Ellipsoid from \ref ISO_19111_2018
+ * \remark Implements Ellipsoid from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL Ellipsoid final : public common::IdentifiedObject,
                                      public io::IPROJStringExportable {
@@ -369,7 +369,7 @@ using GeodeticReferenceFrameNNPtr = util::nn<GeodeticReferenceFramePtr>;
  *
  * \note In \ref ISO_19111_2007, this class was called GeodeticDatum.
  *
- * \remark Implements GeodeticReferenceFrame from \ref ISO_19111_2018
+ * \remark Implements GeodeticReferenceFrame from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL GeodeticReferenceFrame : public Datum {
   public:
@@ -443,7 +443,7 @@ using DynamicGeodeticReferenceFrameNNPtr =
  * For example defining station coordinates having linear velocities to account
  * for crustal motion.
  *
- * \remark Implements DynamicGeodeticReferenceFrame from \ref ISO_19111_2018
+ * \remark Implements DynamicGeodeticReferenceFrame from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DynamicGeodeticReferenceFrame final
     : public GeodeticReferenceFrame {
@@ -498,7 +498,7 @@ class PROJ_GCC_DLL DynamicGeodeticReferenceFrame final
 /** \brief The specification of the method by which the vertical reference frame
  * is realized.
  *
- * \remark Implements RealizationMethod from \ref ISO_19111_2018
+ * \remark Implements RealizationMethod from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL RealizationMethod : public util::CodeList {
   public:
@@ -528,7 +528,7 @@ using VerticalReferenceFrameNNPtr = util::nn<VerticalReferenceFramePtr>;
  *
  * \note In \ref ISO_19111_2007, this class was called VerticalDatum.
 
- * \remark Implements VerticalReferenceFrame from \ref ISO_19111_2018
+ * \remark Implements VerticalReferenceFrame from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL VerticalReferenceFrame : public Datum {
   public:
@@ -585,7 +585,7 @@ using DynamicVerticalReferenceFrameNNPtr =
  * For example defining station heights have velocity to account for
  * post-glacial isostatic rebound motion.
  *
- * \remark Implements DynamicVerticalReferenceFrame from \ref ISO_19111_2018
+ * \remark Implements DynamicVerticalReferenceFrame from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL DynamicVerticalReferenceFrame final
     : public VerticalReferenceFrame {
@@ -645,7 +645,7 @@ using TemporalDatumNNPtr = util::nn<TemporalDatumPtr>;
 /** \brief The definition of the relationship of a temporal coordinate system
  * to an object. The object is normally time on the Earth.
  *
- * \remark Implements TemporalDatum from \ref ISO_19111_2018
+ * \remark Implements TemporalDatum from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL TemporalDatum final : public Datum {
   public:
@@ -698,7 +698,7 @@ using EngineeringDatumNNPtr = util::nn<EngineeringDatumPtr>;
  * point at a construction site), or be a defined point on a moving vehicle
  * (such as on a ship or satellite), or a defined point of an image.
  *
- * \remark Implements EngineeringDatum from \ref ISO_19111_2018
+ * \remark Implements EngineeringDatum from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL EngineeringDatum final : public Datum {
   public:
@@ -742,7 +742,7 @@ using ParametricDatumNNPtr = util::nn<ParametricDatumPtr>;
  * particular reference surface used as the origin of a parametric coordinate
  * system, including its position with respect to the Earth.
  *
- * \remark Implements ParametricDatum from \ref ISO_19111_2018
+ * \remark Implements ParametricDatum from \ref ISO_19111_2019
  */
 class PROJ_GCC_DLL ParametricDatum final : public Datum {
   public:

--- a/include/proj/internal/coordinateoperation_constants.hpp
+++ b/include/proj/internal/coordinateoperation_constants.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/internal/coordinateoperation_internal.hpp
+++ b/include/proj/internal/coordinateoperation_internal.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/internal/coordinatesystem_internal.hpp
+++ b/include/proj/internal/coordinatesystem_internal.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/internal/internal.hpp
+++ b/include/proj/internal/internal.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/internal/io_internal.hpp
+++ b/include/proj/internal/io_internal.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/include/proj/metadata.hpp
+++ b/include/proj/metadata.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -357,7 +357,7 @@ using IdentifierNNPtr = util::nn<IdentifierPtr>;
 
 /** \brief Value uniquely identifying an object within a namespace.
  *
- * \remark Implements Identifier as described in \ref ISO_19111_2018 but which
+ * \remark Implements Identifier as described in \ref ISO_19111_2019 but which
  * originates from \ref ISO_19115
  */
 class PROJ_GCC_DLL Identifier : public util::BaseObject,

--- a/include/proj/util.hpp
+++ b/include/proj/util.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/general_doc.dox
+++ b/src/general_doc.dox
@@ -4,7 +4,7 @@
 
 \section general_api_design General API design
 
-The design of the class hierarchy is strongly derived from \ref ISO_19111_2018.
+The design of the class hierarchy is strongly derived from \ref ISO_19111_2019.
 
 Classes for which the constructors are not directly accessible have their
 instances constructed with create() methods. The returned object is a non-null
@@ -78,13 +78,12 @@ Coordinate Reference Systems (CRS), coordinate systems (CS) and coordinate
 transformation or coordinate conversion between two different coordinate
 reference systems.
 
-\subsubsection ISO_19111_2018 ISO 19111:2018
+\subsubsection ISO_19111_2019 ISO 19111:2019
 
 This is the revision mostly used for PROJ C++ modelling.
 
-[OGC 18-005r1, 2018-04-04, ISO 19111:2018]
-(https://portal.opengeospatial.org/files/?artifact_id=78556)
-(not yet adopted, at time of writing)
+[OGC 18-005r4, 2019-02-08, ISO 19111:2019]
+(http://docs.opengeospatial.org/as/18-005r4/18-005r4.html)
 
 \subsubsection ISO_19111_2007 ISO 19111:2007
 
@@ -111,7 +110,7 @@ PROJ implements the two following revisions of the standard:
 
 \subsubsection WKT2_2015 WKT2:2015
 
-[OGC 12-063r5, 2015-05-01, WKT2-2015]
+[OGC 12-063r5, 2015-05-01, ISO 19162:2015(E), WKT2-2015]
 (http://docs.opengeospatial.org/is/12-063r5/12-063r5.html)
 
 \subsection WKT1 WKT1 specification

--- a/src/iso19111/common.cpp
+++ b/src/iso19111/common.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -641,7 +641,7 @@ const std::string &IdentifiedObject::remarks() PROJ_PURE_DEFN {
 
 /** \brief Return whether the object is deprecated.
  *
- * \remark Extension of \ref ISO_19111_2018
+ * \remark Extension of \ref ISO_19111_2019
  */
 bool IdentifiedObject::isDeprecated() PROJ_PURE_DEFN { return d->isDeprecated; }
 

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/coordinatesystem.cpp
+++ b/src/iso19111/coordinatesystem.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -154,7 +154,7 @@ const util::optional<std::string> &Datum::anchorDefinition() const {
 
 /** \brief Return the date on which the datum definition was published.
  *
- * \note Departure from \ref ISO_19111_2018 : we return a DateTime instead of
+ * \note Departure from \ref ISO_19111_2019 : we return a DateTime instead of
  * a Citation::Date.
  *
  * @return the publication date, or empty.
@@ -1010,7 +1010,7 @@ GeodeticReferenceFrame::primeMeridian() PROJ_PURE_DEFN {
 
 /** \brief Return the Ellipsoid associated with a GeodeticReferenceFrame.
  *
- * \note The \ref ISO_19111_2018 modelling allows (but discourages) a
+ * \note The \ref ISO_19111_2019 modelling allows (but discourages) a
  * GeodeticReferenceFrame
  * to not be associated with a Ellipsoid in the case where it is used by a
  * geocentric crs::GeodeticCRS. We have made the choice of making the ellipsoid
@@ -1223,7 +1223,7 @@ DynamicGeodeticReferenceFrame::frameReferenceEpoch() const {
 
 /** \brief Return the name of the deformation model.
  *
- * @note This is an extension to the \ref ISO_19111_2018 modeling, to
+ * @note This is an extension to the \ref ISO_19111_2019 modeling, to
  * hold the content of the DYNAMIC.MODEL WKT2 node.
  *
  * @return the name of the deformation model.
@@ -1660,7 +1660,7 @@ DynamicVerticalReferenceFrame::frameReferenceEpoch() const {
 
 /** \brief Return the name of the deformation model.
  *
- * @note This is an extension to the \ref ISO_19111_2018 modeling, to
+ * @note This is an extension to the \ref ISO_19111_2019 modeling, to
  * hold the content of the DYNAMIC.MODEL WKT2 node.
  *
  * @return the name of the deformation model.

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/internal.cpp
+++ b/src/iso19111/internal.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/static.cpp
+++ b/src/iso19111/static.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/src/iso19111/util.cpp
+++ b/src/iso19111/util.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  ISO19111:2018 implementation
+ * Purpose:  ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************


### PR DESCRIPTION
And publish link to corresponding promoted and public OGC doc:
http://docs.opengeospatial.org/as/18-005r4/18-005r4.html