### PR TITLE
More updates to references

### DIFF
--- a/docs/source/bibstyle.py
+++ b/docs/source/bibstyle.py
@@ -1,5 +1,6 @@
 ###############################################################################
 #
+#  Project:  PROJ
 #  Purpose: Configure custom bibliography style for sphinxcontrib-bibtex
 #  Author:  Mike Toews <mwtoews at gmail.com>
 #
@@ -53,11 +54,15 @@ class LinkLabelStyle(LabelStyle):
 
 class CustomStyle(UnsrtStyle):
     """Citation style in the References section"""
+    # TODO: Make more Harvard-like, i.e. year after name(s)
 
     default_label_style = 'linklabel'
     default_name_style = 'lastfirst'
     default_sorting_style = 'author_year_title'
-    # TODO: Make more Harvard-like, i.e. year after name(s)
+
+    def __init__(self, **kwargs):
+        kwargs['abbreviate_names'] = True
+        UnsrtStyle.__init__(self, **kwargs)
 
 
 register_plugin('pybtex.style.labels', 'linklabel', LinkLabelStyle)

--- a/docs/source/operations/projections/tobmerc.rst
+++ b/docs/source/operations/projections/tobmerc.rst
@@ -66,7 +66,7 @@ Mathematical definition
 #######################
 
 The formulas describing the Tobler-Mercator are taken from Waldo Tobler's
-article :cite:`Tobler2017`
+article :cite:`Tobler2018`
 
 Spherical form
 **************

--- a/docs/source/operations/transformations/geogoffset.rst
+++ b/docs/source/operations/transformations/geogoffset.rst
@@ -21,11 +21,11 @@ latitude coordinates, and an offset to the ellipsoidal height.
 
 This method is normally only used when low accuracy is tolerated. It is documented
 as coordinate operation method code 9619 (for geographic 2D) and 9660 (for
-geographic 3D) in the EPSG dataset (:cite:`EPSGGuidanceNumber7Part2`)
+geographic 3D) in the EPSG dataset (:cite:`IOGP2018`)
 
 It can also be used to implement the method Geographic2D with Height Offsets
 (code 9618) by noting that the input vertical component is a gravity-related
-height and the output vertical component is the ellispoid height (dh being
+height and the output vertical component is the ellipsoid height (dh being
 the geoid undulation).
 
 It can also be used to implement the method Vertical offset (code 9616)

--- a/docs/source/operations/transformations/horner.rst
+++ b/docs/source/operations/transformations/horner.rst
@@ -28,7 +28,7 @@ space used.
 
 PROJ implements two versions of the Horner evaluation scheme: Real and complex
 polynomial evaluation. Below both are briefly described. For more details consult
-:cite:`Ruffhead2016` and :cite:`EPSGGuidanceNumber7Part2`.
+:cite:`Ruffhead2016` and :cite:`IOGP2018`.
 
 The polynomial evaluation in real number space is defined by the following equations:
 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -4,7 +4,7 @@
 
 @Article{Altamimi2002,
   Title                    = {{ITRF2000}: A new release of the {International Terrestrial Reference Frame} for earth science applications},
-  Author                   = {Z. Altamimi and P. Sillard and C. Boucher},
+  Author                   = {Zuheir Altamimi and Patrick Sillard and Claude Boucher},
   Journal                  = {Journal of Geophysical Research: Solid Earth},
   Year                     = {2002},
   Number                   = {B10},
@@ -22,12 +22,13 @@
   Pages                    = {241--254},
   Volume                   = {4},
 
-  Url                      = {https://arxiv.org/abs/0908.1824}
+  Archiveprefix            = {arXiv},
+  Eprint                   = {0908.1824}
 }
 
 @Article{CalabrettaGreisen2002,
   Title                    = {Representations of celestial coordinates in {FITS}},
-  Author                   = {Calabretta, M. R. and Greisen, E. W.},
+  Author                   = {M. R. Calabretta and E. W. Greisen},
   Journal                  = {Astronomy \& Astrophysics},
   Year                     = {2002},
   Number                   = {3},
@@ -39,7 +40,7 @@
 
 @TechReport{ChanONeil1975,
   Title                    = {Feasibility Study of a Quadrilateralized Spherical Cube Earth Data Base},
-  Author                   = {Chan, F. K. and O'Neill, E. M.},
+  Author                   = {F. K. Chan and E. M. O'Neill},
   Institution              = {Computer Sciences Corporation, System Sciences Division},
   Year                     = {1975},
 
@@ -68,12 +69,14 @@
   Institution              = {Department of Mathematical and Geospatial Sciences, RMIT University},
   Year                     = {2004},
 
+  Address                  = {Melborne, Australia},
+
   Url                      = {http://www.mygeodesy.id.au/documents/Molodensky%20V2.pdf}
 }
 
 @Article{EberHewitt1979,
   Title                    = {Conversion algorithms for the {CalCOFI} station grid},
-  Author                   = {L. E. Eber and R. P. Hewitt},
+  Author                   = {L. E. Eber and Roger P. Hewitt},
   Journal                  = {California Cooperative Oceanic Fisheries Investigations Reports},
   Year                     = {1979},
   Pages                    = {135--137},
@@ -84,7 +87,7 @@
 
 @Manual{Evenden2005,
   Title                    = {libproj4: A Comprehensive Library of Cartographic Projection Functions (Preliminary Draft)},
-  Author                   = {G. I. Evenden},
+  Author                   = {Gerald I. Evenden},
   Year                     = {2005},
 
   Url                      = {https://github.com/OSGeo/proj.4/blob/master/docs/old/libproj.pdf}
@@ -92,7 +95,7 @@
 
 @Manual{Evenden1995,
   Title                    = {Cartographic Projection Procedures for the {UNIX} Environment --- {A} User's Manual},
-  Author                   = {G. I. Evenden},
+  Author                   = {Gerald I. Evenden},
   Year                     = {1995},
 
   Url                      = {https://pubs.usgs.gov/of/1990/of90-284/ofr90-284.pdf}
@@ -100,9 +103,11 @@
 
 @InProceedings{EversKnudsen2017,
   Title                    = {Transformation pipelines for {PROJ.4}},
-  Author                   = {K. Evers and T. Knudsen},
+  Author                   = {Kristian Evers and Thomas Knudsen},
   Booktitle                = {FIG Working Week 2017 Proceedings},
   Year                     = {2017},
+
+  Address                  = {Helsinki, Finland},
 
   Url                      = {http://www.fig.net/resources/proceedings/fig_proceedings/fig2017/papers/iss6b/ISS6B_evers_knudsen_9156.pdf}
 }
@@ -134,17 +139,30 @@
 
 @InProceedings{Hensley2002,
   Title                    = {Improved Processing of {AIRSAR} Data Based on the {GeoSAR} Processor},
-  Author                   = {S. Hensley and E. Chapin and A. Freedman and T. Michel},
+  Author                   = {Scott Hensley and Elaine Chapin and Adam Freedman and Thierry Michel},
   Booktitle                = {AIRSAR Earth Science and Application Workshop},
   Year                     = {2002},
+
+  Address                  = {Pasadena, California},
   Organization             = {Jet Propulsion Laboratory},
 
   Url                      = {https://airsar.jpl.nasa.gov/documents/workshop2002/papers/T3.pdf}
 }
 
+@TechReport{IOGP2018,
+  Title                    = {Geomatics Guidance Note 7, part 2: Coordinate Conversions \& Transformations including Formulas},
+  Author                   = {IOGP},
+  Institution              = {International Association For Oil And Gas Producers},
+  Year                     = {2018},
+  Number                   = {373-7-2},
+  Type                     = {IOGP Publication},
+
+  Url                      = {https://www.iogp.org/bookstore/product/coordinate-conversions-and-transformation-including-formulas/}
+}
+
 @Article{Jenny2015,
   Title                    = {A compromise aspect-adaptive cylindrical projection for world maps},
-  Author                   = {B. Jenny and B. Šavrič and T. Patterson},
+  Author                   = {Bernhard Jenny and Bojan Šavrič and Tom Patterson},
   Journal                  = {International Journal of Geographical Information Science},
   Year                     = {2015},
   Number                   = {6},
@@ -157,7 +175,7 @@
 
 @Article{Karney2013,
   Title                    = {Algorithms for geodesics},
-  Author                   = {C. F. F. Karney},
+  Author                   = {Charles F. F. Karney},
   Journal                  = {Journal of Geodesy},
   Year                     = {2013},
   Number                   = {1},
@@ -169,7 +187,7 @@
 
 @Article{Karney2011,
   Title                    = {Geodesics on an ellipsoid of revolution},
-  Author                   = {C. F. F. Karney},
+  Author                   = {Charles F. F. Karney},
   Journal                  = {ArXiv e-prints},
   Year                     = {2011},
 
@@ -180,7 +198,7 @@
 
 @Article{Komsta2016,
   Title                    = {{ATPOL} geobotanical grid revisited -- a proposal of coordinate conversion algorithms},
-  Author                   = {Ł. Komsta},
+  Author                   = {Łukasz Komsta},
   Journal                  = {Annales UMCS Sectio E Agricultura},
   Year                     = {2016},
   Number                   = {1},
@@ -190,10 +208,10 @@
 
 @InProceedings{LambersKolb2012,
   Title                    = {Ellipsoidal Cube Maps for Accurate Rendering of Planetary-Scale Terrain Data},
-  Author                   = {M. Lambers and A. Kolb},
+  Author                   = {Lambers, Martin and Kolb, Andreas},
   Booktitle                = {Pacific Graphics Short Papers},
   Year                     = {2012},
-  Editor                   = {C. Bregler and P. Sander and M. Wimmer},
+  Editor                   = {Chris Bregler and Pedro Sander and Michael Wimmer},
   Publisher                = {The Eurographics Association},
 
   Doi                      = {10.2312/PE/PG/PG2012short/005-010}
@@ -214,7 +232,7 @@
 
 @Article{Patterson2014,
   Title                    = {Introducing the {Patterson} Cylindrical Projection},
-  Author                   = {T. Patterson and B. Šavrič and B. Jenny},
+  Author                   = {Tom Patterson and Bojan Šavrič and Bernhard Jenny},
   Journal                  = {Cartographic Perspectives},
   Year                     = {2014},
   Volume                   = {78},
@@ -224,7 +242,7 @@
 
 @TechReport{Poder1998,
   Title                    = {Some Conformal Mappings and Transformations for Geodesy and Topographic Cartography},
-  Author                   = {K. Poder and K. Engsager},
+  Author                   = {Knud Poder and Karsten Engsager},
   Institution              = {National Survey and Cadastre},
   Year                     = {1998},
 
@@ -240,7 +258,7 @@
 @Misc{Rittri2012,
   Title                    = {New omerc approximations of {Denmark System 34}},
 
-  Author                   = {M. Rittri},
+  Author                   = {Mikael Rittri},
   HowPublished             = {e-mail},
   Year                     = {2012},
 
@@ -253,7 +271,7 @@
   Journal                  = {Survey Review},
   Year                     = {2016},
   Number                   = {358},
-  Pages                    = {82-90},
+  Pages                    = {82--90},
   Volume                   = {50},
 
   Doi                      = {10.1080/00396265.2016.1244143},
@@ -262,10 +280,11 @@
 
 @Article{Savric2018,
   Title                    = {The {Equal Earth} map projection},
-  Author                   = {B. Šavrič and T. Patterson and B. Jenny},
+  Author                   = {Bojan Šavrič and Tom Patterson and Bernhard Jenny},
   Journal                  = {International Journal of Geographical Information Science},
   Year                     = {2018},
   Number                   = {3},
+  Pages                    = {454--465},
   Volume                   = {33},
 
   Doi                      = {10.1080/13658816.2018.1504949},
@@ -274,8 +293,8 @@
 
 @Article{Savric2015,
   Title                    = {The {Natural Earth II} world map projection},
-  Author                   = {B. Šavrič and T. Patterson and B. Jenny},
-  Journal                  = {International Journal of Geographical Information Science},
+  Author                   = {Bojan Šavrič and Tom Patterson and Bernhard Jenny},
+  Journal                  = {International Journal of Cartography},
   Year                     = {2015},
   Number                   = {2},
   Pages                    = {123--133},
@@ -287,14 +306,14 @@
 
 @Book{Snyder1993,
   Title                    = {Flattening the Earth},
-  Author                   = {J. P. Snyder},
+  Author                   = {John P. Snyder},
   Publisher                = {University of Chicago Press},
   Year                     = {1993}
 }
 
 @Article{Snyder1988,
   Title                    = {New Equal-Area Map Projections For Noncircular Regions},
-  Author                   = {J. P. Snyder},
+  Author                   = {John P. Snyder},
   Journal                  = {The American Cartographer},
   Year                     = {1988},
   Number                   = {4},
@@ -307,7 +326,7 @@
 
 @TechReport{Snyder1987,
   Title                    = {Map Projections --- {A} Working Manual},
-  Author                   = {J. P. Snyder},
+  Author                   = {John P. Snyder},
   Institution              = {U.S. Geological Survey},
   Year                     = {1987},
   Number                   = {1395},
@@ -324,11 +343,11 @@
   Edition                  = {15th}
 }
 
-@Article{Tobler2017,
+@Article{Tobler2018,
   Title                    = {A new companion for {Mercator}},
-  Author                   = {W. Tobler},
+  Author                   = {Waldo Tobler},
   Journal                  = {Cartography and Geographic Information Science},
-  Year                     = {2017},
+  Year                     = {2018},
   Number                   = {3},
   Pages                    = {284--285},
   Volume                   = {45},
@@ -363,7 +382,7 @@
 
 @Article{WeberMoore2013,
   Title                    = {Corrected Conversion Algorithms For The {CalCOFI} Station Grid And Their Implementation In Several Computer Languages},
-  Author                   = {E. D. Weber and T. J. Moore},
+  Author                   = {Edward D. Weber and Thomas J. Moore},
   Journal                  = {California Cooperative Oceanic Fisheries Investigations Reports},
   Year                     = {2013},
   Pages                    = {1--10},
@@ -374,7 +393,7 @@
 
 @Article{Zajac1978,
   Title                    = {Atlas of Distribution of Vascular Plants in {Poland} ({ATPOL})},
-  Author                   = {A. Zajaç},
+  Author                   = {Adam Zajaç},
   Journal                  = {Taxon},
   Year                     = {1978},
   Number                   = {5/6},
@@ -382,13 +401,5 @@
   Volume                   = {27},
 
   Doi                      = {10.2307/1219899}
-}
-
-@Manual{EPSGGuidanceNumber7Part2,
-  Title                    = {Geomatics Guidance Note 7, part 2 - Coordinate Conversions \& Transformations including Formulas},
-  Year                     = {2018},
-
-  Institution              = {International Association For Oil And Gas Producers},
-  Url                      = {https://www.iogp.org/bookstore/product/coordinate-conversions-and-transformation-including-formulas/}
 }
 


### PR DESCRIPTION
Source `references.bib` file now has names as published, with modifications to `bibstyle.py` to generate abbreviated names in documentation outputs.

There are several other related modifications, such as correcting the year for `Tobler2018`, and renaming `EPSGGuidanceNumber7Part2` to `IOGP2018`, and changing the entry to a `@TechReport`.