### PR TITLE
Fix cross-compilation detection

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -4,6 +4,12 @@
 # be relocated.)
 file(RELATIVE_PATH PROJECT_ROOT_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKECONFIGDIR} ${CMAKE_INSTALL_PREFIX})
 
+if (CMAKE_CROSSCOMPILING)
+  set (CMAKE_CROSSCOMPILING_STR "ON")
+else ()
+  set (CMAKE_CROSSCOMPILING_STR "OFF")
+endif ()
+
 string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 configure_file (project-config.cmake.in project-config.cmake @ONLY)
 configure_file (project-config-version.cmake.in

--- a/cmake/project-config-version.cmake.in
+++ b/cmake/project-config-version.cmake.in
@@ -5,6 +5,12 @@ set (PACKAGE_VERSION_MAJOR "@PROJ_VERSION_MAJOR@")
 set (PACKAGE_VERSION_MINOR "@PROJ_VERSION_MINOR@")
 set (PACKAGE_VERSION_PATCH "@PROJ_VERSION_PATCH@")
 
+if (CMAKE_CROSSCOMPILING)
+  set (CMAKE_CROSSCOMPILING_STR "ON")
+else ()
+  set (CMAKE_CROSSCOMPILING_STR "OFF")
+endif ()
+
 if (NOT PACKAGE_FIND_NAME STREQUAL "@PROJECT_NAME@")
   # Check package name (in particular, because of the way cmake finds
   # package config files, the capitalization could easily be "wrong").
@@ -22,7 +28,7 @@ elseif (MSVC AND NOT MSVC_VERSION STREQUAL "@MSVC_VERSION@")
   # Reject if there's a mismatch in MSVC compiler versions
   set (REASON "_MSC_VER = @MSVC_VERSION@")
   set (PACKAGE_VERSION_UNSUITABLE TRUE)
-elseif (NOT CMAKE_CROSSCOMPILING STREQUAL "@CMAKE_CROSSCOMPILING@")
+elseif (NOT CMAKE_CROSSCOMPILING_STR STREQUAL "@CMAKE_CROSSCOMPILING_STR@")
   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}
   set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")
   set (PACKAGE_VERSION_UNSUITABLE TRUE)
@@ -46,3 +52,5 @@ endif ()
 if (PACKAGE_VERSION_UNSUITABLE)
   set (PACKAGE_VERSION "${PACKAGE_VERSION} (${REASON})")
 endif ()
+
+unset(CMAKE_CROSSCOMPILING_STR)


### PR DESCRIPTION
Currently, cross compilation detection requires that the variable `CMAKE_CROSSCOMPILING` in the consuming project be an exact string match for that during compilation. This can cause a problem if there is a mismatch (for example if `CMAKE_CROSSCOMPILING` is set to `FALSE` in the consuming project rather than `OFF`). 

This can cause a `find_project(PROJ4 ...)` call to fail erroneously when using the config file.

This PR fixes this issue by converting a boolean evaluation to `ON` or `OFF`. 

While this seems like a bit of an estoric edge case, this situation occurs when using `vcpkg` to build and consume proj4.