### PR TITLE
Fix doc generation with Breathe 4.12.0

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -63,15 +63,15 @@ namespace operation {
 
 /** \brief Grid description */
 struct GridDescription {
-    std::string shortName{};   /**< Grid short filename */
-    std::string fullName{};    /**< Grid full path name (if found) */
-    std::string packageName{}; /**< Package name (or empty) */
-    std::string url{}; /**< Grid URL (if packageName is empty), or package
+    std::string shortName;   /**< Grid short filename */
+    std::string fullName;    /**< Grid full path name (if found) */
+    std::string packageName; /**< Package name (or empty) */
+    std::string url; /**< Grid URL (if packageName is empty), or package
                             URL (or empty) */
-    bool directDownload = false; /**< Whether url can be fetched directly. */
+    bool directDownload; /**< Whether url can be fetched directly. */
     /** Whether the grid is released with an open license. */
-    bool openLicense = false;
-    bool available = false; /**< Whether GRID is available. */
+    bool openLicense;
+    bool available; /**< Whether GRID is available. */
 
     //! @cond Doxygen_Suppress
     bool operator<(const GridDescription &other) const {

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -891,31 +891,35 @@ class PROJ_GCC_DLL AuthorityFactory {
     /** CRS information */
     struct CRSInfo {
         /** Authority name */
-        std::string authName{};
+        std::string authName;
         /** Code */
-        std::string code{};
+        std::string code;
         /** Name */
-        std::string name{};
+        std::string name;
         /** Type */
-        ObjectType type{ObjectType::CRS};
+        ObjectType type;
         /** Whether the object is deprecated */
-        bool deprecated{};
+        bool deprecated;
         /** Whereas the west_lon_degree, south_lat_degree, east_lon_degree and
         * north_lat_degree fields are valid. */
-        bool bbox_valid{};
+        bool bbox_valid;
         /** Western-most longitude of the area of use, in degrees. */
-        double west_lon_degree{};
+        double west_lon_degree;
         /** Southern-most latitude of the area of use, in degrees. */
-        double south_lat_degree{};
+        double south_lat_degree;
         /** Eastern-most longitude of the area of use, in degrees. */
-        double east_lon_degree{};
+        double east_lon_degree;
         /** Northern-most latitude of the area of use, in degrees. */
-        double north_lat_degree{};
+        double north_lat_degree;
         /** Name of the area of use. */
-        std::string areaName{};
+        std::string areaName;
         /** Name of the projection method for a projected CRS. Might be empty
          * even for projected CRS in some cases. */
-        std::string projectionMethodName{};
+        std::string projectionMethodName;
+
+        //! @cond Doxygen_Suppress
+        CRSInfo();
+        //! @endcond
     };
 
     PROJ_DLL std::list<CRSInfo> getCRSInfoList() const;

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -552,7 +552,16 @@ struct CoordinateOperation::Private {
 
 // ---------------------------------------------------------------------------
 
-GridDescription::GridDescription() = default;
+GridDescription::GridDescription():
+    shortName{},
+    fullName{},
+    packageName{},
+    url{},
+    directDownload(false),
+    openLicense(false),
+    available(false)
+{}
+
 
 GridDescription::~GridDescription() = default;
 

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -1359,6 +1359,25 @@ const DatabaseContextNNPtr &AuthorityFactory::databaseContext() const {
 
 // ---------------------------------------------------------------------------
 
+//! @cond Doxygen_Suppress
+AuthorityFactory::CRSInfo::CRSInfo():
+    authName{},
+    code{},
+    name{},
+    type{ObjectType::CRS},
+    deprecated{},
+    bbox_valid{},
+    west_lon_degree{},
+    south_lat_degree{},
+    east_lon_degree{},
+    north_lat_degree{},
+    areaName{},
+    projectionMethodName{}
+{}
+//! @endcond
+
+// ---------------------------------------------------------------------------
+
 /** \brief Returns an arbitrary object from a code.
  *
  * The returned object will typically be an instance of Datum,


### PR DESCRIPTION
Breathe 4.12.0 (as pulled by MacOSX builds such as
https://travis-ci.com/OSGeo/proj.4/jobs/185395222)
does not seem to like default initialization in documented C++ structs (regression/bug)

```
/Users/travis/build/OSGeo/proj.4/docs/source/development/reference/cpp/io.rst:6:Parsing of expression failed. Using fallback parser. Error was:
Error in postfix expression, expected primary expression or type.
If primary expression:
  Invalid definition: Expected identifier in nested name. [error at 67]
    std::string osgeo::proj::io::AuthorityFactory::CRSInfo::authName = {}
    -------------------------------------------------------------------^
If type:
  Invalid definition: Expected identifier in nested name. [error at 67]
    std::string osgeo::proj::io::AuthorityFactory::CRSInfo::authName = {}
    -------------------------------------------------------------------^
```