### PR TITLE
Fix some issues raised by latest cppcheck

### DIFF
--- a/include/proj/internal/coordinateoperation_internal.hpp
+++ b/include/proj/internal/coordinateoperation_internal.hpp
@@ -253,7 +253,7 @@ class PROJBasedOperation : public SingleOperation {
     gridsNeeded(const io::DatabaseContextPtr &databaseContext) const override;
 
   protected:
-    PROJBasedOperation(const OperationMethodNNPtr &methodIn);
+    explicit PROJBasedOperation(const OperationMethodNNPtr &methodIn);
 
     void _exportToPROJString(io::PROJStringFormatter *formatter)
         const override; // throw(FormattingException)

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -22,7 +22,6 @@
 
 static PJ *Proj;
 static union {
-    PJ_UV (*generic)(PJ_UV, PJ *);
     PJ_XY (*fwd)(PJ_LP, PJ *);
     PJ_LP (*inv)(PJ_XY, PJ *);
 } proj;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -673,8 +673,8 @@ pj_init_ctx_with_allow_init_epsg(projCtx ctx, int argc, char **argv, int allow_i
             if (PJD_ERR_MAJOR_AXIS_NOT_GIVEN==proj_errno (PIN))
                 proj_errno_reset (PIN);
             PIN->f = 1.0/298.257223563;
-            PIN->a_orig  = PIN->a  = 6378137.0;
-            PIN->es_orig = PIN->es = PIN->f*(2-PIN->f);
+            PIN->a  = 6378137.0;
+            PIN->es = PIN->f*(2-PIN->f);
         }
     }
     PIN->a_orig = PIN->a;

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -2096,7 +2096,6 @@ void VerticalCRS::addLinearUnitConvert(
     auto &axisList = coordinateSystem()->axisList();
 
     if (!axisList.empty()) {
-        auto projUnit = axisList[0]->unit().exportToPROJString();
         if (axisList[0]->unit().conversionToSI() != 1.0) {
             formatter->addStep("unitconvert");
             formatter->addParam("z_in", "m");

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -783,7 +783,7 @@ bool Ellipsoid::lookForProjWellKnownEllps(std::string &projEllpsName,
                 if (::fabs(b - b_iter) < 1e-10 * b_iter) {
                     projEllpsName = proj_ellps[i].id;
                     ellpsName = proj_ellps[i].name;
-                    if (ellpsName.find("GRS 1980") == 0) {
+                    if (starts_with(ellpsName, "GRS 1980")) {
                         ellpsName = "GRS 1980";
                     }
                     return true;
@@ -794,7 +794,7 @@ bool Ellipsoid::lookForProjWellKnownEllps(std::string &projEllpsName,
                 if (::fabs(rf - rf_iter) < 1e-10 * rf_iter) {
                     projEllpsName = proj_ellps[i].id;
                     ellpsName = proj_ellps[i].name;
-                    if (ellpsName.find("GRS 1980") == 0) {
+                    if (starts_with(ellpsName, "GRS 1980")) {
                         ellpsName = "GRS 1980";
                     }
                     return true;

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -1186,7 +1186,7 @@ struct WKTParser::Private {
     buildPrimeMeridian(const WKTNodeNNPtr &node,
                        const UnitOfMeasure &defaultAngularUnit);
 
-    optional<std::string> getAnchor(const WKTNodeNNPtr &node);
+    static optional<std::string> getAnchor(const WKTNodeNNPtr &node);
 
     static void parseDynamic(const WKTNodeNNPtr &dynamicNode,
                              double &frameReferenceEpoch,
@@ -6545,9 +6545,9 @@ PROJStringParser::Private::processAxisSwap(Step &step,
                                ? AxisDirection::NORTH
                                : (axisType == AxisType::NORTH_POLE)
                                      ? AxisDirection::SOUTH
-                                     : (axisType == AxisType::SOUTH_POLE)
-                                           ? AxisDirection::NORTH
-                                           : AxisDirection::NORTH;
+                                     /*: (axisType == AxisType::SOUTH_POLE)
+                                           ? AxisDirection::NORTH*/
+                                     : AxisDirection::NORTH;
     CoordinateSystemAxisNNPtr north = createAxis(
         northName, northAbbev, northDir, unit,
         (!isGeographic && axisType == AxisType::NORTH_POLE)

--- a/src/projections/aeqd.cpp
+++ b/src/projections/aeqd.cpp
@@ -310,7 +310,6 @@ PJ *PROJECTION(aeqd) {
                 break;
             case EQUIT:
             case OBLIQ:
-                P->inv = e_inverse; P->fwd = e_forward;
                 Q->N1 = 1. / sqrt(1. - P->es * Q->sinph0 * Q->sinph0);
                 Q->G = Q->sinph0 * (Q->He = P->e / sqrt(P->one_es));
                 Q->He *= Q->cosph0;

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -1051,14 +1051,6 @@ PJ *PROJECTION(isea) {
         Q->dgg.o_lat = pj_param(P->ctx,P->params, "rlat_0").f;
     }
 
-    if (pj_param(P->ctx,P->params, "taperture").i) {
-        Q->dgg.aperture = pj_param(P->ctx,P->params, "iaperture").i;
-    }
-
-    if (pj_param(P->ctx,P->params, "tresolution").i) {
-        Q->dgg.resolution = pj_param(P->ctx,P->params, "iresolution").i;
-    }
-
     opt = pj_param(P->ctx,P->params, "smode").s;
     if (opt) {
         if (!strcmp(opt, "plane")) {

--- a/src/projections/mod_ster.cpp
+++ b/src/projections/mod_ster.cpp
@@ -72,7 +72,6 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         z = 2. * atan(.5 * rh);
         sinz = sin(z);
         cosz = cos(z);
-        lp.lam = P->lam0;
         if (fabs(rh) <= EPSLN) {
             /* if we end up here input coordinates were (0,0).
              * pj_inv() adds P->lam0 to lp.lam, this way we are

--- a/src/projections/stere.cpp
+++ b/src/projections/stere.cpp
@@ -165,7 +165,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
         break;
     }
 
-    for (i = NITER;  i--;  phi_l = lp.phi) {
+    for (i = NITER;  i--; ) {
         sinphi = P->e * sin(phi_l);
         lp.phi = 2. * atan (tp * pow ((1.+sinphi)/(1.-sinphi), halfe)) - halfpi;
         if (fabs (phi_l - lp.phi) < CONV) {
@@ -174,6 +174,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
             lp.lam = (xy.x == 0. && xy.y == 0.) ? 0. : atan2 (xy.x, xy.y);
             return lp;
         }
+        phi_l = lp.phi;
     }
 
     proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);


### PR DESCRIPTION
- coordinateoperation_internal.hpp: missing 'explicit' keyword
- proj.cpp: unused 'generic' member in enumeration
- init.cpp: useless assignment to a_orig and es_orig, because done again a
            few lines below.
- crs.cpp: unused variable
- datum.cpp: inefficient use of find() function
- io.cpp:
  * missing 'static' qualifier for method
  * useles ternary test (left and right have same value)
- aeqd.cpp: useless assignment of inv and fwd, snice done again a few lines
            below
- isea.cpp: useless assignment of resolution and aperture since done again a
            few lines below, and with default values when params are absent
- mod_ster.cpp: useless assignment of lp.lam, overriden in below code paths.
- stere.cpp: false positive, but better not modify another variable than the
             iterator in a for() loop.