### PR TITLE
Build: automatically enable system error messages

### DIFF
--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -25,6 +25,7 @@ check_include_files(unistd.h HAVE_UNISTD_H)
 check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
 
 check_function_exists(localeconv HAVE_LOCALECONV)
+check_function_exists(strerror HAVE_STRERROR)
 
 # check libm need on unix
 check_library_exists(m ceil "" HAVE_LIBM)

--- a/cmake/proj_config.cmake.in
+++ b/cmake/proj_config.cmake.in
@@ -22,6 +22,9 @@
 /* Define to 1 if you have the <stdlib.h> header file. */
 #cmakedefine HAVE_STDLIB_H 1
 
+/* Define to 1 if you have the `strerror' function. */
+#cmakedefine HAVE_STRERROR 1
+
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,7 @@ CFLAGS="$save_CFLAGS $C99_MATH"
 AC_SEARCH_LIBS([sqrt], [m])
 
 AC_CHECK_FUNC(localeconv, [AC_DEFINE(HAVE_LOCALECONV,1,[Define to 1 if you have localeconv])])
+AC_CHECK_FUNCS([strerror])
 
 dnl ---------------------------------------------------------------------------
 dnl Check for JNI support.

--- a/src/apps/emess.cpp
+++ b/src/apps/emess.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "proj_api.h"
+#include "proj_config.h"
 #define EMESS_ROUTINE
 #include "emess.h"
 


### PR DESCRIPTION
Define HAVE_STRERROR from configure.

Before:
```
$ cs2cs +proj=latlong +to +proj=latlong dummy
<cs2cs>:
Sys errno: 2: <system mess. texts unavail.>
dummy
```
After:
```
$ cs2cs +proj=latlong +to +proj=latlong dummy
<cs2cs>:
Sys errno: 2: No such file or directory
dummy
```
---

Tested against 6.0.0, and 5.2.0.
