### PR TITLE
Port custom ellipsoid definitions from QGIS

### DIFF
--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -36,3 +36,19 @@ INSERT INTO authority_to_authority_preference(source_auth_name, target_auth_name
 
 INSERT INTO authority_to_authority_preference(source_auth_name, target_auth_name, allowed_authorities) VALUES
     ('ESRI', 'EPSG', 'PROJ,ESRI,EPSG' );
+
+-- Custom ellipsoids (from proj -le)
+
+INSERT INTO "ellipsoid" VALUES('PROJ','ANDREA','Andrae 1876 (Den., Iclnd.)',NULL,'PROJ','EARTH',6377104.43,'EPSG','9001',300.0,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','CPM','Comm. des Poids et Mesures 1799',NULL,'PROJ','EARTH',6375738.7,'EPSG','9001',334.29,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','DELMBR','Delambre 1810 (Belgium)',NULL,'PROJ','EARTH',6376428.0,'EPSG','9001',311.5,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','KAULA','Kaula 1961',NULL,'PROJ','EARTH',6378163.0,'EPSG','9001',298.24,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','LERCH','Lerch 1979',NULL,'PROJ','EARTH',6378139.0,'EPSG','9001',298.257,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','MERIT','MERIT 1983',NULL,'PROJ','EARTH',6378137.0,'EPSG','9001',298.257,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','MPRTS','Maupertius 1738',NULL,'PROJ','EARTH',6397300.0,'EPSG','9001',191.0,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','NEW_INTL','New International 1967',NULL,'PROJ','EARTH',6378157.5,'EPSG','9001',NULL,6356772.2,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','WGS60','WGS 60',NULL,'PROJ','EARTH',6378165.0,'EPSG','9001',298.3,NULL,0);
+
+-- Custom ellipsoids (ported from QGIS - original source unknown)
+
+INSERT INTO "ellipsoid" VALUES('PROJ','EARTH2000','Earth2000',NULL,'PROJ','EARTH',6378140.0,'EPSG','9001',NULL,6356750.0,0);

--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -39,8 +39,8 @@ INSERT INTO authority_to_authority_preference(source_auth_name, target_auth_name
 
 -- Custom ellipsoids (from proj -le)
 
-INSERT INTO "ellipsoid" VALUES('PROJ','ANDREA','Andrae 1876 (Den., Iclnd.)',NULL,'PROJ','EARTH',6377104.43,'EPSG','9001',300.0,NULL,0);
-INSERT INTO "ellipsoid" VALUES('PROJ','CPM','Comm. des Poids et Mesures 1799',NULL,'PROJ','EARTH',6375738.7,'EPSG','9001',334.29,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','ANDRAE','Andrae 1876 (Denmark, Iceland)',NULL,'PROJ','EARTH',6377104.43,'EPSG','9001',300.0,NULL,0);
+INSERT INTO "ellipsoid" VALUES('PROJ','CPM','Comité international des poids et mesures 1799',NULL,'PROJ','EARTH',6375738.7,'EPSG','9001',334.29,NULL,0);
 INSERT INTO "ellipsoid" VALUES('PROJ','DELMBR','Delambre 1810 (Belgium)',NULL,'PROJ','EARTH',6376428.0,'EPSG','9001',311.5,NULL,0);
 INSERT INTO "ellipsoid" VALUES('PROJ','KAULA','Kaula 1961',NULL,'PROJ','EARTH',6378163.0,'EPSG','9001',298.24,NULL,0);
 INSERT INTO "ellipsoid" VALUES('PROJ','LERCH','Lerch 1979',NULL,'PROJ','EARTH',6378139.0,'EPSG','9001',298.257,NULL,0);
@@ -49,6 +49,6 @@ INSERT INTO "ellipsoid" VALUES('PROJ','MPRTS','Maupertius 1738',NULL,'PROJ','EAR
 INSERT INTO "ellipsoid" VALUES('PROJ','NEW_INTL','New International 1967',NULL,'PROJ','EARTH',6378157.5,'EPSG','9001',NULL,6356772.2,0);
 INSERT INTO "ellipsoid" VALUES('PROJ','WGS60','WGS 60',NULL,'PROJ','EARTH',6378165.0,'EPSG','9001',298.3,NULL,0);
 
--- Custom ellipsoids (ported from QGIS - original source unknown)
+-- Extra ellipsoids from IAU2000 dictionary (see https://github.com/USGS-Astrogeology/GDAL_scripts/blob/master/OGC_IAU2000_WKT_v2/naifcodes_radii_m_wAsteroids_IAU2000.csv)
 
 INSERT INTO "ellipsoid" VALUES('PROJ','EARTH2000','Earth2000',NULL,'PROJ','EARTH',6378140.0,'EPSG','9001',NULL,6356750.0,0);


### PR DESCRIPTION
As discussed on the mailing list, this PR introduces a number of custom ellipsoid definitions under the PROJ authority. Most of these match the current output from proj -le, but the Earth2000 ellipsoid is ported from QGIS and of unknown origin.

Sponsored by ICSM