### PR TITLE
strtod.cpp: remove support for no proj_config.h

### DIFF
--- a/src/strtod.cpp
+++ b/src/strtod.cpp
@@ -33,13 +33,8 @@
 #include <string.h>
 
 #include "proj.h"
-#include "proj_internal.h"
-
-/* Windows nmake build doesn't have a proj_config.h, but HAVE_LOCALECONV */
-/* is defined in the compilation line */
-#ifndef HAVE_LOCALECONV
 #include "proj_config.h"
-#endif
+#include "proj_internal.h"
 
 #define PJ_STRTOD_WORK_BUFFER_SIZE 64
 


### PR DESCRIPTION
The nmake build system has been dropped in favour of CMake which is used
to create proj_config.h.

---

I have successfully built this on 6.0.0 on Linux, haven't tested on Windows.