### PR TITLE
pkg-config: add datadir to proj.pc

### DIFF
--- a/proj.pc.in
+++ b/proj.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+datadir=@datadir@/@PACKAGE@
 
 Name: proj
 Description: Cartographic Projections Library.


### PR DESCRIPTION
Convenience variable pkgdatadir not available at the time this is
configured, datadir/PACKAGE is its value.

Query with:
pkg-config --variable=datadir proj