### PR TITLE
Doc: Be consistent in use of +opts

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -13,7 +13,7 @@ cct
 Synopsis
 ********
 
-    **cct** [ **-cIostvz** [ args ] ] *+opts[=arg]* file[s]
+    **cct** [**-cIostvz** [args]] *+opt[=arg]* ... file ...
 
 Description
 ***********
@@ -70,7 +70,7 @@ The following control parameters can appear in any order:
 
     Print version number.
 
-The *+args* arguments are associated with coordinate operation parameters.
+The *+opt* arguments are associated with coordinate operation parameters.
 Usage varies with operation.
 
 .. only:: html

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -11,11 +11,11 @@ cs2cs
 Synopsis
 ********
 
-    **cs2cs** [ **-eEfIlrstvwW** [ args ] ] [ *+opts[=arg]* ] [ +to [*+opts[=arg]*] ] file[s]
+    **cs2cs** [**-eEfIlrstvwW** [args]] [*+opt[=arg]* ...] [+to *+opt[=arg]* ...] file ...
 
 or
 
-    **cs2cs** [ **-eEfIlrstvwW** [ args ] ] {source_crs} +to {target_crs} file[s]
+    **cs2cs** [**-eEfIlrstvwW** [args]] {source_crs} +to {target_crs} file ...
 
     where {source_crs} or {target_crs} is a PROJ string, a WKT string or a AUTHORITY:CODE
     (where AUTHORITY is the name of a CRS authority and CODE the code of a CRS
@@ -25,7 +25,7 @@ or
 
 or
 
-    **cs2cs** [ **-eEfIlrstvwW** [ args ] ] {source_crs} {target_crs}
+    **cs2cs** [**-eEfIlrstvwW** [args]] {source_crs} {target_crs}
 
 .. versionadded:: 6.0.0
 
@@ -132,12 +132,12 @@ The following control parameters can appear in any order:
 
 .. only:: man
 
-    The *+args* run-line arguments are associated with cartographic
+    The *+opt* run-line arguments are associated with cartographic
     parameters.
 
 .. only:: html
 
-    The *+args* run-line arguments are associated with cartographic
+    The *+opt* run-line arguments are associated with cartographic
     parameters. Usage varies with projection and for a complete description
     consult the :ref:`projection pages <projections>`.
 

--- a/docs/source/apps/geod.rst
+++ b/docs/source/apps/geod.rst
@@ -7,9 +7,9 @@ geod
 Synopsis
 ********
 
-    **geod** *+ellps=<ellipse>* [ **-afFIlptwW** [ args ] ] [ *+args* ] file[s]
+    **geod** *+ellps=<ellipse>* [**-afFIlptwW** [args]] [*+opt[=arg]* ...] file ...
 
-    **invgeod** *+ellps=<ellipse>* [ **-afFIlptwW** [ args ] ] [ *+args* ] file[s]
+    **invgeod** *+ellps=<ellipse>* [**-afFIlptwW** [args]] [*+opt[=arg]* ...] file ...
 
 Description
 ***********
@@ -85,7 +85,7 @@ The following command-line options can appear in any order:
     This option causes the azimuthal values to be output as unsigned DMS
     numbers between 0 and 360 degrees. Also note :option:`-f`.
 
-The *+args* command-line options are associated with geodetic
+The *+opt* command-line options are associated with geodetic
 parameters for specifying the ellipsoidal or sphere to use.
 controls. The options are processed in left to right order
 from the command line. Reentry of an option is ignored with

--- a/docs/source/apps/proj.rst
+++ b/docs/source/apps/proj.rst
@@ -12,9 +12,9 @@ proj
 
 Synopsis
 ********
-    **proj** [ **-beEfiIlmorsStTvVwW** ] [ args ] ] [ *+args* ] file[s]
+    **proj** [**-beEfiIlmorsStTvVwW**] [args]] [*+opt[=arg]* ...] file ...
 
-    **invproj** [ **-beEfiIlmorsStTvVwW** ] [ args ] ] [ *+args* ] file[s]
+    **invproj** [**-beEfiIlmorsStTvVwW**] [args]] [*+opt[=arg]* ...] file ...
 
 
 Description
@@ -156,7 +156,7 @@ The following control parameters can appear in any order
     the projected point. :option:`-v` is implied with this option.
 
 
-The *+args* run-line arguments are associated with cartographic parameters.
+The *+opt* run-line arguments are associated with cartographic parameters.
 Additional projection control parameters may be contained in two auxiliary
 control files: the first is optionally referenced with the
 *+init=file:id* and the second is always processed after the name of the
@@ -167,7 +167,7 @@ also used for supporting files like datum shift files.
 
 .. only:: html
 
-    Usage of *+args* varies with projection and for a complete description
+    Usage of *+opt* varies with projection and for a complete description
     consult the :ref:`projection pages <projections>`.
 
 

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -68,8 +68,8 @@ static const char *oform =
 static char oform_buffer[16]; /* buffer for oform when using -d */
 static const char *oterr = "*\t*"; /* output line for unprojectable input */
 static const char *usage =
-    "%s\nusage: %s [ -dDeEfIlrstvwW [args] ] [ +opts[=arg] ]\n"
-    "                   [+to [+opts[=arg] [ files ]\n";
+    "%s\nusage: %s [-dDeEfIlrstvwW [args]] [+opt[=arg] ...]\n"
+    "                   [+to +opt[=arg] ...] [file ...]\n";
 
 static double (*informat)(const char *,
                           char **); /* input data deformatter function */

--- a/src/apps/geod.cpp
+++ b/src/apps/geod.cpp
@@ -22,7 +22,7 @@ static const char *osform = "%.3f"; /* output format for S */
 
 static char pline[50];              /* work string */
 static const char *usage =
-"%s\nusage: %s [ -afFIlptwW [args] ] [ +opts[=arg] ] [ files ]\n";
+"%s\nusage: %s [-afFIlptwW [args]] [+opt[=arg] ...] [file ...]\n";
 
 	static void
 printLL(double p, double l) {

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -45,7 +45,7 @@ static char oform_buffer[16];   /* Buffer for oform when using -d */
 
 static const char
     *oterr = "*\t*",    /* output line for unprojectable input */
-    *usage = "%s\nusage: %s [ -bdeEfiIlmorsStTvVwW [args] ] [ +opts[=arg] ] [ files ]\n";
+    *usage = "%s\nusage: %s [-bdeEfiIlmorsStTvVwW [args]] [+opt[=arg] ...] [file ...]\n";
 
 static PJ_FACTORS facs;
 


### PR DESCRIPTION
Apps use the form [ +opts[=arg] ] in the help they print to stderr, some
man pages do so in the summary but not in the text. This renames the
instances of +args to +opts.

---

Being consistent seems important but I don't have an opinion on which should be used (easier to change docs than code) - please check.
