### PR TITLE
[WIP] Pass coordinates by reference in 3D and 4D functions

### DIFF
--- a/src/apps/gie.cpp
+++ b/src/apps/gie.cpp
@@ -874,7 +874,7 @@ static int expect_failure_with_errno_message (int expected, int got) {
 
 /* For test purposes, we want to call a transformation of the same */
 /* dimensionality as the number of dimensions given in accept */
-static PJ_COORD expect_trans_n_dim (PJ_COORD ci) {
+static PJ_COORD expect_trans_n_dim (const PJ_COORD& ci) {
     if (4==T.dimensions_given_at_last_accept)
         return proj_trans (T.P, T.dir, ci);
 

--- a/src/conversions/axisswap.cpp
+++ b/src/conversions/axisswap.cpp
@@ -104,7 +104,7 @@ static PJ_LP reverse_2d(PJ_XY xy, PJ *P) {
 }
 
 
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD out, in;
@@ -118,7 +118,7 @@ static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
     return out.xyz;
 }
 
-static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& xyz, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD in, out;
@@ -133,7 +133,7 @@ static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
 }
 
 
-static PJ_COORD forward_4d(PJ_COORD coo, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD out;
@@ -147,7 +147,7 @@ static PJ_COORD forward_4d(PJ_COORD coo, PJ *P) {
 }
 
 
-static PJ_COORD reverse_4d(PJ_COORD coo, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& coo, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     unsigned int i;
     PJ_COORD out;

--- a/src/conversions/cart.cpp
+++ b/src/conversions/cart.cpp
@@ -131,7 +131,7 @@ static double geocentric_radius (double a, double b, double phi) {
 
 
 /*********************************************************************/
-static PJ_XYZ cartesian (PJ_LPZ geod,  PJ *P) {
+static PJ_XYZ cartesian (const PJ_LPZ& geod,  PJ *P) {
 /*********************************************************************/
     double N, cosphi = cos(geod.phi);
     PJ_XYZ xyz;
@@ -148,7 +148,7 @@ static PJ_XYZ cartesian (PJ_LPZ geod,  PJ *P) {
 
 
 /*********************************************************************/
-static PJ_LPZ geodetic (PJ_XYZ cart,  PJ *P) {
+static PJ_LPZ geodetic (const PJ_XYZ& cart,  PJ *P) {
 /*********************************************************************/
     double N, p, theta, c, s;
     PJ_LPZ lpz;

--- a/src/conversions/geoc.cpp
+++ b/src/conversions/geoc.cpp
@@ -37,12 +37,12 @@
 PROJ_HEAD(geoc, "Geocentric Latitude");
 
 /* Geographical to geocentric */
-static PJ_COORD forward(PJ_COORD coo, PJ *P) {
+static PJ_COORD forward(const PJ_COORD& coo, PJ *P) {
     return pj_geocentric_latitude (P, PJ_FWD, coo);
 }
 
 /* Geocentric to geographical */
-static PJ_COORD inverse(PJ_COORD coo, PJ *P) {
+static PJ_COORD inverse(const PJ_COORD& coo, PJ *P) {
     return pj_geocentric_latitude (P, PJ_INV, coo);
 }
 

--- a/src/conversions/unitconvert.cpp
+++ b/src/conversions/unitconvert.cpp
@@ -313,7 +313,7 @@ static PJ_LP reverse_2d(PJ_XY xy, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
 /************************************************************************
     Forward unit conversions the vertical component
 ************************************************************************/
@@ -330,7 +330,7 @@ static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
 }
 
 /***********************************************************************/
-static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& xyz, PJ *P) {
 /************************************************************************
     Reverse unit conversions the vertical component
 ************************************************************************/
@@ -348,7 +348,7 @@ static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& obs, PJ *P) {
 /************************************************************************
     Forward conversion of time units
 ************************************************************************/
@@ -368,7 +368,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& obs, PJ *P) {
 /************************************************************************
     Reverse conversion of time units
 ************************************************************************/

--- a/src/fwd.cpp
+++ b/src/fwd.cpp
@@ -197,7 +197,8 @@ PJ_XY pj_fwd(PJ_LP lp, PJ *P) {
 }
 
 
-
+// public interface defined in proj_api.h for now
+// cppcheck-suppress passedByValue
 PJ_XYZ pj_fwd3d(PJ_LPZ lpz, PJ *P) {
     int last_errno;
     PJ_COORD coo = {{0,0,0,0}};
@@ -232,7 +233,8 @@ PJ_XYZ pj_fwd3d(PJ_LPZ lpz, PJ *P) {
 
 
 
-PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
+PJ_COORD pj_fwd4d (const PJ_COORD& cooIn, PJ *P) {
+    PJ_COORD coo(cooIn);
     int last_errno = proj_errno_reset(P);
 
     if (!P->skip_fwd_prepare)

--- a/src/inv.cpp
+++ b/src/inv.cpp
@@ -173,8 +173,8 @@ PJ_LP pj_inv(PJ_XY xy, PJ *P) {
     return error_or_coord(P, coo, last_errno).lp;
 }
 
-
-
+// public interface defined in proj_api.h for now
+// cppcheck-suppress passedByValue
 PJ_LPZ pj_inv3d (PJ_XYZ xyz, PJ *P) {
     int last_errno;
     PJ_COORD coo = {{0,0,0,0}};
@@ -209,7 +209,8 @@ PJ_LPZ pj_inv3d (PJ_XYZ xyz, PJ *P) {
 
 
 
-PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
+PJ_COORD pj_inv4d (const PJ_COORD& cooIn, PJ *P) {
+    PJ_COORD coo(cooIn);
     int last_errno = proj_errno_reset(P);
 
     if (!P->skip_inv_prepare)

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -130,22 +130,13 @@ struct pj_opaque_pushpop {
 } // anonymous namespace
 
 
-static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P);
-static PJ_COORD pipeline_reverse_4d (PJ_COORD point, PJ *P);
-static PJ_XYZ    pipeline_forward_3d (PJ_LPZ lpz, PJ *P);
-static PJ_LPZ    pipeline_reverse_3d (PJ_XYZ xyz, PJ *P);
-static PJ_XY     pipeline_forward (PJ_LP lp, PJ *P);
-static PJ_LP     pipeline_reverse (PJ_XY xy, PJ *P);
-
-
-
-
-static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P) {
+static PJ_COORD pipeline_forward_4d (const PJ_COORD& pointIn, PJ *P) {
     int i, first_step, last_step;
 
     first_step = 1;
     last_step  = static_cast<struct pj_opaque*>(P->opaque)->steps + 1;
 
+    PJ_COORD point(pointIn);
     for (i = first_step;  i != last_step;  i++)
         point = proj_trans (static_cast<struct pj_opaque*>(P->opaque)->pipeline[i], PJ_FWD, point);
 
@@ -153,12 +144,13 @@ static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P) {
 }
 
 
-static PJ_COORD pipeline_reverse_4d (PJ_COORD point, PJ *P) {
+static PJ_COORD pipeline_reverse_4d (const PJ_COORD& pointIn, PJ *P) {
     int i, first_step, last_step;
 
     first_step = static_cast<struct pj_opaque*>(P->opaque)->steps;
     last_step  =  0;
 
+    PJ_COORD point(pointIn);
     for (i = first_step;  i != last_step;  i--)
         point = proj_trans (static_cast<struct pj_opaque*>(P->opaque)->pipeline[i], PJ_INV, point);
 
@@ -168,7 +160,7 @@ static PJ_COORD pipeline_reverse_4d (PJ_COORD point, PJ *P) {
 
 
 
-static PJ_XYZ pipeline_forward_3d (PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ pipeline_forward_3d (const PJ_LPZ& lpz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     int i;
     point.lpz = lpz;
@@ -180,7 +172,7 @@ static PJ_XYZ pipeline_forward_3d (PJ_LPZ lpz, PJ *P) {
 }
 
 
-static PJ_LPZ pipeline_reverse_3d (PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ pipeline_reverse_3d (const PJ_XYZ& xyz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     int i;
     point.xyz = xyz;
@@ -570,7 +562,7 @@ PJ *OPERATION(pipeline,0) {
     return P;
 }
 
-static PJ_COORD push(PJ_COORD point, PJ *P) {
+static PJ_COORD push(const PJ_COORD& point, PJ *P) {
     if (P->parent == nullptr)
         return point;
 
@@ -589,7 +581,8 @@ static PJ_COORD push(PJ_COORD point, PJ *P) {
     return point;
 }
 
-static PJ_COORD pop(PJ_COORD point, PJ *P) {
+static PJ_COORD pop(const PJ_COORD& pointIn, PJ *P) {
+    PJ_COORD point(pointIn);
     if (P->parent == nullptr)
         return point;
 

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -193,8 +193,8 @@ struct projCppContext;
 /* not sure why we need to export it, but mingw needs it */
 void PROJ_DLL proj_context_delete_cpp_context(struct projCppContext* cppContext);
 
-PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P);
-PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P);
+PJ_COORD pj_fwd4d (const PJ_COORD& coo, PJ *P);
+PJ_COORD pj_inv4d (const PJ_COORD& coo, PJ *P);
 
 PJ_COORD PROJ_DLL pj_approx_2D_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo);
 PJ_COORD PROJ_DLL pj_approx_3D_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coo);
@@ -291,7 +291,7 @@ PJ_OPERATOR:
 *****************************************************************************/
 typedef    PJ       *(* PJ_CONSTRUCTOR) (PJ *);
 typedef    PJ       *(* PJ_DESTRUCTOR)  (PJ *, int);
-typedef    PJ_COORD  (* PJ_OPERATOR)    (PJ_COORD, PJ *);
+typedef    PJ_COORD  (* PJ_OPERATOR)    (const PJ_COORD&, PJ *);
 /****************************************************************************/
 
 
@@ -352,8 +352,8 @@ struct PJconsts {
 
     PJ_XY  (*fwd)(PJ_LP,    PJ *) = nullptr;
     PJ_LP  (*inv)(PJ_XY,    PJ *) = nullptr;
-    PJ_XYZ (*fwd3d)(PJ_LPZ, PJ *) = nullptr;
-    PJ_LPZ (*inv3d)(PJ_XYZ, PJ *) = nullptr;
+    PJ_XYZ (*fwd3d)(const PJ_LPZ&, PJ *) = nullptr;
+    PJ_LPZ (*inv3d)(const PJ_XYZ&, PJ *) = nullptr;
     PJ_OPERATOR fwd4d = nullptr;
     PJ_OPERATOR inv4d = nullptr;
 

--- a/src/projections/latlong.cpp
+++ b/src/projections/latlong.cpp
@@ -56,7 +56,7 @@ static PJ_LP latlong_inverse(PJ_XY xy, PJ *P) {
 }
 
 
- static PJ_XYZ latlong_forward_3d (PJ_LPZ lpz, PJ *P) {
+ static PJ_XYZ latlong_forward_3d (const PJ_LPZ& lpz, PJ *P) {
     PJ_XYZ xyz = {0,0,0};
     (void) P;
     xyz.x = lpz.lam;
@@ -66,7 +66,7 @@ static PJ_LP latlong_inverse(PJ_XY xy, PJ *P) {
 }
 
 
-static PJ_LPZ latlong_inverse_3d (PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ latlong_inverse_3d (const PJ_XYZ& xyz, PJ *P) {
     PJ_LPZ lpz = {0,0,0};
     (void) P;
     lpz.lam = xyz.x;
@@ -75,13 +75,13 @@ static PJ_LPZ latlong_inverse_3d (PJ_XYZ xyz, PJ *P) {
     return lpz;
 }
 
-static PJ_COORD latlong_forward_4d (PJ_COORD obs, PJ *P) {
+static PJ_COORD latlong_forward_4d (const PJ_COORD& obs, PJ *P) {
     (void) P;
     return obs;
 }
 
 
-static PJ_COORD latlong_inverse_4d (PJ_COORD obs, PJ *P) {
+static PJ_COORD latlong_inverse_4d (const PJ_COORD& obs, PJ *P) {
     (void) P;
     return obs;
 }

--- a/src/projections/sch.cpp
+++ b/src/projections/sch.cpp
@@ -55,7 +55,7 @@ struct pj_opaque {
 
 PROJ_HEAD(sch, "Spherical Cross-track Height") "\n\tMisc\n\tplat_0= plon_0= phdg_0= [h_0=]";
 
-static PJ_LPZ inverse3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ inverse3d(const PJ_XYZ& xyz, PJ *P) {
     PJ_LPZ lpz = {0.0, 0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double temp[3];
@@ -93,7 +93,7 @@ static PJ_LPZ inverse3d(PJ_XYZ xyz, PJ *P) {
     return lpz;
 }
 
-static PJ_XYZ forward3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward3d(const PJ_LPZ& lpz, PJ *P) {
     PJ_XYZ xyz = {0.0, 0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double temp[3];

--- a/src/transformations/affine.cpp
+++ b/src/transformations/affine.cpp
@@ -59,7 +59,7 @@ struct pj_opaque_affine {
 } // anonymous namespace
 
 
-static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& obs, PJ *P) {
     PJ_COORD newObs;
     const struct pj_opaque_affine *Q = (const struct pj_opaque_affine *) P->opaque;
     const struct pj_affine_coeffs *C = &(Q->forward);
@@ -70,7 +70,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     return newObs;
 }
 
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
     return forward_4d(point, P).xyz;
@@ -84,21 +84,21 @@ static PJ_XY forward_2d(PJ_LP lp, PJ *P) {
 }
 
 
-static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& obs, PJ *P) {
     PJ_COORD newObs;
     const struct pj_opaque_affine *Q = (const struct pj_opaque_affine *) P->opaque;
     const struct pj_affine_coeffs *C = &(Q->reverse);
-    obs.xyzt.x -= Q->xoff;
-    obs.xyzt.y -= Q->yoff;
-    obs.xyzt.z -= Q->zoff;
-    newObs.xyzt.x = C->s11 * obs.xyzt.x + C->s12 * obs.xyzt.y + C->s13 * obs.xyzt.z;
-    newObs.xyzt.y = C->s21 * obs.xyzt.x + C->s22 * obs.xyzt.y + C->s23 * obs.xyzt.z;
-    newObs.xyzt.z = C->s31 * obs.xyzt.x + C->s32 * obs.xyzt.y + C->s33 * obs.xyzt.z;
+    const double x = obs.xyzt.x - Q->xoff;
+    const double y = obs.xyzt.y - Q->yoff;
+    const double z = obs.xyzt.z - Q->zoff;
+    newObs.xyzt.x = C->s11 * x + C->s12 * y + C->s13 * z;
+    newObs.xyzt.y = C->s21 * x + C->s22 * y + C->s23 * z;
+    newObs.xyzt.z = C->s31 * x + C->s32 * y + C->s33 * z;
     newObs.xyzt.t = C->tscale * (obs.xyzt.t - Q->toff);
     return newObs;
 }
 
-static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& xyz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
     return reverse_4d(point, P).lpz;

--- a/src/transformations/deformation.cpp
+++ b/src/transformations/deformation.cpp
@@ -72,7 +72,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 /********************************************************************************/
-static PJ_XYZ get_grid_shift(PJ* P, PJ_XYZ cartesian) {
+static PJ_XYZ get_grid_shift(PJ* P, const PJ_XYZ& cartesian) {
 /********************************************************************************
     Read correction values from grid. The cartesian input coordinates are
     converted to geodetic coordinates in order look up the correction values
@@ -122,7 +122,7 @@ static PJ_XYZ get_grid_shift(PJ* P, PJ_XYZ cartesian) {
 }
 
 /********************************************************************************/
-static PJ_XYZ reverse_shift(PJ *P, PJ_XYZ input, double dt) {
+static PJ_XYZ reverse_shift(PJ *P, const PJ_XYZ& input, double dt) {
 /********************************************************************************
     Iteratively determine the reverse grid shift correction values.
 *********************************************************************************/
@@ -163,7 +163,7 @@ static PJ_XYZ reverse_shift(PJ *P, PJ_XYZ input, double dt) {
     return out;
 }
 
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     PJ_COORD out, in;
     PJ_XYZ shift;
@@ -186,7 +186,7 @@ static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
 }
 
 
-static PJ_COORD forward_4d(PJ_COORD in, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     double dt;
     PJ_XYZ shift;
@@ -209,7 +209,7 @@ static PJ_COORD forward_4d(PJ_COORD in, PJ *P) {
 }
 
 
-static PJ_LPZ reverse_3d(PJ_XYZ in, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     PJ_COORD out;
     out.xyz = in;
@@ -225,7 +225,7 @@ static PJ_LPZ reverse_3d(PJ_XYZ in, PJ *P) {
     return out.lpz;
 }
 
-static PJ_COORD reverse_4d(PJ_COORD in, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& in, PJ *P) {
     struct pj_opaque *Q = (struct pj_opaque *) P->opaque;
     PJ_COORD out = in;
     double dt;

--- a/src/transformations/helmert.cpp
+++ b/src/transformations/helmert.cpp
@@ -59,8 +59,8 @@ Last update: 2018-10-26
 PROJ_HEAD(helmert, "3(6)-, 4(8)- and 7(14)-parameter Helmert shift");
 PROJ_HEAD(molobadekas, "Molodensky-Badekas transformation");
 
-static PJ_XYZ helmert_forward_3d (PJ_LPZ lpz, PJ *P);
-static PJ_LPZ helmert_reverse_3d (PJ_XYZ xyz, PJ *P);
+static PJ_XYZ helmert_forward_3d (const PJ_LPZ& lpz, PJ *P);
+static PJ_LPZ helmert_reverse_3d (const PJ_XYZ& xyz, PJ *P);
 
 
 
@@ -362,7 +362,7 @@ static PJ_LP helmert_reverse (PJ_XY xy, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_XYZ helmert_forward_3d (PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ helmert_forward_3d (const PJ_LPZ& lpz, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
     PJ_COORD point = {{0,0,0,0}};
@@ -402,7 +402,7 @@ static PJ_XYZ helmert_forward_3d (PJ_LPZ lpz, PJ *P) {
 
 
 /***********************************************************************/
-static PJ_LPZ helmert_reverse_3d (PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ helmert_reverse_3d (const PJ_XYZ& xyz, PJ *P) {
 /***********************************************************************/
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
     PJ_COORD point = {{0,0,0,0}};
@@ -438,7 +438,7 @@ static PJ_LPZ helmert_reverse_3d (PJ_XYZ xyz, PJ *P) {
 }
 
 
-static PJ_COORD helmert_forward_4d (PJ_COORD point, PJ *P) {
+static PJ_COORD helmert_forward_4d (const PJ_COORD& point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
@@ -450,13 +450,15 @@ static PJ_COORD helmert_forward_4d (PJ_COORD point, PJ *P) {
         build_rot_matrix(P);
     }
 
-    point.xyz = helmert_forward_3d (point.lpz, P);
+    PJ_COORD pointOut;
+    pointOut.xyz = helmert_forward_3d (point.lpz, P);
+    pointOut.xyzt.t = point.lpzt.t;
 
-    return point;
+    return pointOut;
 }
 
 
-static PJ_COORD helmert_reverse_4d (PJ_COORD point, PJ *P) {
+static PJ_COORD helmert_reverse_4d (const PJ_COORD& point, PJ *P) {
     struct pj_opaque_helmert *Q = (struct pj_opaque_helmert *) P->opaque;
 
     /* We only need to rebuild the rotation matrix if the
@@ -468,9 +470,11 @@ static PJ_COORD helmert_reverse_4d (PJ_COORD point, PJ *P) {
         build_rot_matrix(P);
     }
 
-    point.lpz = helmert_reverse_3d (point.xyz, P);
+    PJ_COORD pointOut;
+    pointOut.lpz = helmert_reverse_3d (point.xyz, P);
+    pointOut.lpzt.t = point.xyzt.t;
 
-    return point;
+    return pointOut;
 }
 
 /* Arcsecond to radians */

--- a/src/transformations/hgridshift.cpp
+++ b/src/transformations/hgridshift.cpp
@@ -17,7 +17,7 @@ struct pj_opaque_hgridshift {
 };
 } // anonymous namespace
 
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
 
@@ -31,7 +31,7 @@ static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
 }
 
 
-static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& xyz, PJ *P) {
     PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
 
@@ -44,7 +44,7 @@ static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
     return point.lpz;
 }
 
-static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& obs, PJ *P) {
     struct pj_opaque_hgridshift *Q = (struct pj_opaque_hgridshift *) P->opaque;
     PJ_COORD point = obs;
 
@@ -62,7 +62,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     return point;
 }
 
-static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& obs, PJ *P) {
     struct pj_opaque_hgridshift *Q = (struct pj_opaque_hgridshift *) P->opaque;
     PJ_COORD point = obs;
 

--- a/src/transformations/horner.cpp
+++ b/src/transformations/horner.cpp
@@ -116,7 +116,7 @@ struct horner {
 } // anonymous namespace
 
 typedef struct horner HORNER;
-static PJ_UV   horner_func (const HORNER *transformation, PJ_DIRECTION direction, PJ_UV position);
+static PJ_UV   horner_func (const HORNER *transformation, PJ_DIRECTION direction, const PJ_UV& position);
 static HORNER *horner_alloc (size_t order, int complex_polynomia);
 static void    horner_free (HORNER *h);
 
@@ -182,7 +182,7 @@ static HORNER *horner_alloc (size_t order, int complex_polynomia) {
 
 
 /**********************************************************************/
-static PJ_UV horner_func (const HORNER *transformation, PJ_DIRECTION direction, PJ_UV position) {
+static PJ_UV horner_func (const HORNER *transformation, PJ_DIRECTION direction, const PJ_UV& position) {
 /***********************************************************************
 
 A reimplementation of the classic Engsager/Poder 2D Horner polynomial
@@ -284,11 +284,11 @@ summing the tiny high order elements first.
             E = n*E + v;
         }
 
-        position.u = E;
-        position.v = N;
+        PJ_UV out;
+        out.u = E;
+        out.v = N;
+        return out;
     }
-
-    return position;
 }
 
 
@@ -297,21 +297,23 @@ summing the tiny high order elements first.
 
 
 
-static PJ_COORD horner_forward_4d (PJ_COORD point, PJ *P) {
-    point.uv = horner_func ((HORNER *) P->opaque, PJ_FWD, point.uv);
-    return point;
+static PJ_COORD horner_forward_4d (const PJ_COORD& point, PJ *P) {
+    PJ_COORD pointOut(point);
+    pointOut.uv = horner_func ((HORNER *) P->opaque, PJ_FWD, point.uv);
+    return pointOut;
 }
 
-static PJ_COORD horner_reverse_4d (PJ_COORD point, PJ *P) {
-    point.uv = horner_func ((HORNER *) P->opaque, PJ_INV, point.uv);
-    return point;
+static PJ_COORD horner_reverse_4d (const PJ_COORD& point, PJ *P) {
+    PJ_COORD pointOut(point);
+    pointOut.uv = horner_func ((HORNER *) P->opaque, PJ_INV, point.uv);
+    return pointOut;
 }
 
 
 
 
 /**********************************************************************/
-static PJ_UV complex_horner (const HORNER *transformation, PJ_DIRECTION direction, PJ_UV position) {
+static PJ_UV complex_horner (const HORNER *transformation, PJ_DIRECTION direction, const PJ_UV& position) {
 /***********************************************************************
 
 A reimplementation of a classic Engsager/Poder Horner complex
@@ -380,21 +382,24 @@ polynomial evaluation engine.
         E = w;
     }
 
-    position.u = E;
-    position.v = N;
-    return position;
+    PJ_UV out;
+    out.u = E;
+    out.v = N;
+    return out;
 }
 
 
 
-static PJ_COORD complex_horner_forward_4d (PJ_COORD point, PJ *P) {
-    point.uv = complex_horner ((HORNER *) P->opaque, PJ_FWD, point.uv);
-    return point;
+static PJ_COORD complex_horner_forward_4d (const PJ_COORD& point, PJ *P) {
+    PJ_COORD pointOut(point);
+    pointOut.uv = complex_horner ((HORNER *) P->opaque, PJ_FWD, point.uv);
+    return pointOut;
 }
 
-static PJ_COORD complex_horner_reverse_4d (PJ_COORD point, PJ *P) {
-    point.uv = complex_horner ((HORNER *) P->opaque, PJ_INV, point.uv);
-    return point;
+static PJ_COORD complex_horner_reverse_4d (const PJ_COORD& point, PJ *P) {
+    PJ_COORD pointOut(point);
+    pointOut.uv = complex_horner ((HORNER *) P->opaque, PJ_INV, point.uv);
+    return pointOut;
 }
 
 

--- a/src/transformations/vgridshift.cpp
+++ b/src/transformations/vgridshift.cpp
@@ -18,7 +18,7 @@ struct pj_opaque_vgridshift {
 };
 } // anonymous namespace
 
-static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ forward_3d(const PJ_LPZ& lpz, PJ *P) {
     struct pj_opaque_vgridshift *Q = (struct pj_opaque_vgridshift *) P->opaque;
     PJ_COORD point = {{0,0,0,0}};
     point.lpz = lpz;
@@ -33,7 +33,7 @@ static PJ_XYZ forward_3d(PJ_LPZ lpz, PJ *P) {
 }
 
 
-static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ reverse_3d(const PJ_XYZ& xyz, PJ *P) {
     struct pj_opaque_vgridshift *Q = (struct pj_opaque_vgridshift *) P->opaque;
     PJ_COORD point = {{0,0,0,0}};
     point.xyz = xyz;
@@ -48,7 +48,7 @@ static PJ_LPZ reverse_3d(PJ_XYZ xyz, PJ *P) {
 }
 
 
-static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD forward_4d(const PJ_COORD& obs, PJ *P) {
     struct pj_opaque_vgridshift *Q = (struct pj_opaque_vgridshift *) P->opaque;
     PJ_COORD point = obs;
 
@@ -66,7 +66,7 @@ static PJ_COORD forward_4d(PJ_COORD obs, PJ *P) {
     return point;
 }
 
-static PJ_COORD reverse_4d(PJ_COORD obs, PJ *P) {
+static PJ_COORD reverse_4d(const PJ_COORD& obs, PJ *P) {
     struct pj_opaque_vgridshift *Q = (struct pj_opaque_vgridshift *) P->opaque;
     PJ_COORD point = obs;
 


### PR DESCRIPTION
This fixes cppcheck master warnings.
This could have a (likely tiny) performance advantage by saving useless
copies of the xyz/xyzt argument.

I should probably look at the differences in machine code in optimized builds. Passing by value as done currently might not perhaps be that bad on x86_64 if, as I presume values, might be stored in SSE registers and not passed on the stack.