### PR TITLE
pj_strerrno: enable system error messages

### DIFF
--- a/src/strerrno.cpp
+++ b/src/strerrno.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "proj.h"
+#include "proj_config.h"
 #include "proj_internal.h"
 
 static const char * const

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -69,6 +69,8 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${SQLITE3_INCLUDE_DIR})
+# Add the directory containing proj_config.h
+include_directories(${CMAKE_BINARY_DIR}/src)
 
 add_executable(proj_pj_transform_test
   main.cpp

--- a/test/unit/proj_errno_string_test.cpp
+++ b/test/unit/proj_errno_string_test.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 
 #include "proj.h"
+#include "proj_config.h"
 
 #include "gtest_include.h"
 


### PR DESCRIPTION
HAVE_STRERROR is defined in proj_config.h.

---

Missed this one last time. Don't have a simple example, caught it from pyproj.