### PR TITLE
Add proj_normalize_for_visualization()

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -152,6 +152,8 @@ class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
 
     PROJ_DLL static const std::string OPERATION_VERSION_KEY;
 
+    PROJ_DLL CoordinateOperationNNPtr normalizeForVisualization() const;
+
   protected:
     PROJ_INTERNAL CoordinateOperation();
     PROJ_INTERNAL CoordinateOperation(const CoordinateOperation &other);

--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -126,6 +126,10 @@ class PROJ_GCC_DLL CRS : public common::ObjectUsage {
     PROJ_FOR_TEST CRSNNPtr
     alterCSLinearUnit(const common::UnitOfMeasure &unit) const;
 
+    PROJ_INTERNAL bool mustAxisOrderBeSwitchedForVisualization() const;
+
+    PROJ_INTERNAL CRSNNPtr normalizeForVisualization() const;
+
     //! @endcond
 
   protected:

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -6767,3 +6767,35 @@ int proj_cs_get_axis_info(PJ_CONTEXT *ctx, const PJ *cs, int index,
     }
     return true;
 }
+
+// ---------------------------------------------------------------------------
+
+/** \brief Returns a PJ* object whose axis order is the one expected for
+ * visualization purposes.
+ *
+ * The input object must be a coordinate operation, that has been created with
+ * proj_create_crs_to_crs().
+ * If the axis order of its source or target CRS is northing,easting, then an
+ * axis swap operation will be inserted.
+ *
+ * @param ctx PROJ context, or NULL for default context
+ * @param obj Object of type CoordinateOperation,
+ * created with proj_create_crs_to_crs() (must not be NULL)
+ * @return a new PJ* object to free with proj_destroy() in case of success, or
+ * nullptr in case of error
+ */
+PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj) {
+    auto co = dynamic_cast<const CoordinateOperation *>(obj->iso_obj.get());
+    if (!co) {
+        proj_log_error(ctx, __FUNCTION__, "Object is not a CoordinateOperation "
+                                          "created with "
+                                          "proj_create_crs_to_crs");
+        return nullptr;
+    }
+    try {
+        return pj_obj_create(ctx, co->normalizeForVisualization());
+    } catch (const std::exception &e) {
+        proj_log_debug(ctx, __FUNCTION__, e.what());
+        return nullptr;
+    }
+}

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -591,6 +591,104 @@ CRSNNPtr CRS::alterId(const std::string &authName,
 
 // ---------------------------------------------------------------------------
 
+//! @cond Doxygen_Suppress
+
+static bool isAxisListNorthEast(
+    const std::vector<cs::CoordinateSystemAxisNNPtr> &axisList) {
+    const auto &dir0 = axisList[0]->direction();
+    const auto &dir1 = axisList[1]->direction();
+    return (&dir0 == &cs::AxisDirection::NORTH &&
+            &dir1 == &cs::AxisDirection::EAST);
+}
+// ---------------------------------------------------------------------------
+
+bool CRS::mustAxisOrderBeSwitchedForVisualization() const {
+
+    const CompoundCRS *compoundCRS = dynamic_cast<const CompoundCRS *>(this);
+    if (compoundCRS) {
+        const auto &comps = compoundCRS->componentReferenceSystems();
+        if (!comps.empty()) {
+            return comps[0]->mustAxisOrderBeSwitchedForVisualization();
+        }
+    }
+
+    const GeographicCRS *geogCRS = dynamic_cast<const GeographicCRS *>(this);
+    if (geogCRS) {
+        return isAxisListNorthEast(geogCRS->coordinateSystem()->axisList());
+    }
+
+    const ProjectedCRS *projCRS = dynamic_cast<const ProjectedCRS *>(this);
+    if (projCRS) {
+        return isAxisListNorthEast(projCRS->coordinateSystem()->axisList());
+    }
+
+    return false;
+}
+
+//! @endcond
+
+// ---------------------------------------------------------------------------
+
+//! @cond Doxygen_Suppress
+
+CRSNNPtr CRS::normalizeForVisualization() const {
+    auto props = util::PropertyMap().set(
+        common::IdentifiedObject::NAME_KEY,
+        nameStr() + " (with axis order normalized for visualization)");
+
+    const CompoundCRS *compoundCRS = dynamic_cast<const CompoundCRS *>(this);
+    if (compoundCRS) {
+        const auto &comps = compoundCRS->componentReferenceSystems();
+        if (!comps.empty()) {
+            std::vector<CRSNNPtr> newComps;
+            newComps.emplace_back(comps[0]->normalizeForVisualization());
+            for (size_t i = 1; i < comps.size(); i++) {
+                newComps.emplace_back(comps[i]);
+            }
+            return util::nn_static_pointer_cast<CRS>(
+                CompoundCRS::create(props, newComps));
+        }
+    }
+
+    const GeographicCRS *geogCRS = dynamic_cast<const GeographicCRS *>(this);
+    if (geogCRS) {
+        const auto &axisList = geogCRS->coordinateSystem()->axisList();
+        if (isAxisListNorthEast(axisList)) {
+            auto cs = axisList.size() == 2
+                          ? cs::EllipsoidalCS::create(util::PropertyMap(),
+                                                      axisList[1], axisList[0])
+                          : cs::EllipsoidalCS::create(util::PropertyMap(),
+                                                      axisList[1], axisList[0],
+                                                      axisList[2]);
+            return util::nn_static_pointer_cast<CRS>(GeographicCRS::create(
+                props, geogCRS->datum(), geogCRS->datumEnsemble(), cs));
+        }
+    }
+
+    const ProjectedCRS *projCRS = dynamic_cast<const ProjectedCRS *>(this);
+    if (projCRS) {
+        const auto &axisList = projCRS->coordinateSystem()->axisList();
+        if (isAxisListNorthEast(axisList)) {
+            auto cs =
+                axisList.size() == 2
+                    ? cs::CartesianCS::create(util::PropertyMap(), axisList[1],
+                                              axisList[0])
+                    : cs::CartesianCS::create(util::PropertyMap(), axisList[1],
+                                              axisList[0], axisList[2]);
+            return util::nn_static_pointer_cast<CRS>(
+                ProjectedCRS::create(props, projCRS->baseCRS(),
+                                     projCRS->derivingConversionRef(), cs));
+        }
+    }
+
+    return NN_NO_CHECK(
+        std::static_pointer_cast<CRS>(shared_from_this().as_nullable()));
+}
+
+//! @endcond
+
+// ---------------------------------------------------------------------------
+
 /** \brief Identify the CRS with reference CRSs.
  *
  * The candidate CRSs are either hard-coded, or looked in the database when

--- a/src/proj.h
+++ b/src/proj.h
@@ -356,6 +356,7 @@ int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_leg
 PJ PROJ_DLL *proj_create (PJ_CONTEXT *ctx, const char *definition);
 PJ PROJ_DLL *proj_create_argv (PJ_CONTEXT *ctx, int argc, char **argv);
 PJ PROJ_DLL *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area);
+PJ PROJ_DLL *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj);
 PJ PROJ_DLL *proj_destroy (PJ *P);
 
 

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -3220,4 +3220,31 @@ TEST_F(CApi, proj_get_crs_info_list_from_database) {
         proj_crs_info_list_destroy(list);
     }
 }
+
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_normalize_for_visualization) {
+
+    {
+        auto P = proj_create(m_ctxt, "+proj=utm +zone=31 +ellps=WGS84");
+        ObjectKeeper keeper_P(P);
+        ASSERT_NE(P, nullptr);
+        auto Pnormalized = proj_normalize_for_visualization(m_ctxt, P);
+        ObjectKeeper keeper_Pnormalized(Pnormalized);
+        EXPECT_EQ(Pnormalized, nullptr);
+    }
+
+    auto P = proj_create_crs_to_crs(m_ctxt, "EPSG:4326", "EPSG:32631", nullptr);
+    ObjectKeeper keeper_P(P);
+    ASSERT_NE(P, nullptr);
+    auto Pnormalized = proj_normalize_for_visualization(m_ctxt, P);
+    ObjectKeeper keeper_Pnormalized(Pnormalized);
+    ASSERT_NE(Pnormalized, nullptr);
+    auto projstr = proj_as_proj_string(m_ctxt, Pnormalized, PJ_PROJ_5, nullptr);
+    ASSERT_NE(projstr, nullptr);
+    EXPECT_EQ(std::string(projstr),
+              "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
+              "+step +proj=utm +zone=31 +ellps=WGS84");
+}
+
 } // namespace


### PR DESCRIPTION
Fixes #1301

This function takes the output PJ from proj_create_crs_to_crs(),
and add (or undo) the needed axis swap operations so that the
object returned by proj_normalize_for_visualization() has the usual
GIS axis order.
In this implementation, this does something only if the coordinate
 system of the source or target CRS, geographic or projected, has
NORTH, EAST ordering.
CompoundCRS wrapping those objects are also handled.

Question: should this be backported to 6.0.x ?