### PR TITLE
Make sure that ISO19111 C++ code sets pj_errno on errors

### DIFF
--- a/src/apps/gie.cpp
+++ b/src/apps/gie.cpp
@@ -1151,6 +1151,7 @@ static const struct errno_vs_err_const lookup[] = {
     {"pjd_err_invalid_arg"              ,  -58},
     {"pjd_err_inconsistent_unit"        ,  -59},
     {"pjd_err_mutually_exclusive_args"  ,  -60},
+    {"pjd_err_generic_error"            ,  -61},
     {"pjd_err_dont_skip"                ,  5555},
     {"pjd_err_unknown"                  ,  9999},
     {"pjd_err_enomem"                   ,  ENOMEM},

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -77,6 +77,11 @@ static void PROJ_NO_INLINE proj_log_error(PJ_CONTEXT *ctx, const char *function,
     msg += ": ";
     msg += text;
     ctx->logger(ctx->logger_app_data, PJ_LOG_ERROR, msg.c_str());
+    auto previous_errno = pj_ctx_get_errno(ctx);
+    if (previous_errno == 0) {
+        // only set errno if it wasn't set deeper down the call stack
+        pj_ctx_set_errno(ctx, PJD_ERR_GENERIC_ERROR);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -679,6 +679,7 @@ struct FACTORS {
 #define PJD_ERR_INVALID_ARG             -58
 #define PJD_ERR_INCONSISTENT_UNIT       -59
 #define PJD_ERR_MUTUALLY_EXCLUSIVE_ARGS -60
+#define PJD_ERR_GENERIC_ERROR           -61
 /* NOTE: Remember to update src/strerrno.cpp, src/apps/gie.cpp and transient_error in */
 /* src/transform.cpp when adding new value */
 

--- a/src/strerrno.cpp
+++ b/src/strerrno.cpp
@@ -70,6 +70,7 @@ pj_err_list[] = {
     "argument not numerical or out of range",                          /* -58 */
     "inconsistent unit type between input and output",                 /* -59 */
     "arguments are mutually exclusive",                                /* -60 */
+    "generic error of unknow origin",                                  /* -61 */
 
     /* When adding error messages, remember to update ID defines in
        projects.h, and transient_error array in pj_transform                  */

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -465,4 +465,11 @@ accept      0 0 1000
 expect      0 0 1
 roundtrip   1
 
+-------------------------------------------------------------------------------
+Check that proj_create() returns a generic error when an exception is caught
+in the creation of a PJ object.
+-------------------------------------------------------------------------------
+operation   this is a bogus CRS meant to trigger a generic error in proj_create()
+expect      failure   errno generic error
+
 </gie>


### PR DESCRIPTION
As mentioned on the mailing list, `proj_create()` doesn't set the error number when an error is created. This also applies to many other functions in `src\iso19111\c_api.cpp`. Fixed in this PR.

I've added a new error code, `PJD_ERR_GENERIC_ERROR`, which will be set if no other errno is applied when an exception is raised. This applies to all functions in `src\iso19111\c_api.cpp` that calls `proj_log_error()` (which btw is badly named since it is not publicly accessible - should be `pj_log_error()`).