### PR TITLE
CMake: Remove need to fiddle with CMAKE_C_FLAGS / CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,30 +34,45 @@ message(STATUS "Requiring C++${CMAKE_CXX_STANDARD} - done")
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-# Set warnings
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
-  # Suppress warning 4706 about assignment within conditional expression
-  # Suppress warning 4996 about sprintf, etc., being unsafe
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
-/W4 /wd4706 /wd4996 /D_CRT_SECURE_NO_WARNINGS")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-/EHsc /W4 /wd4706 /wd4996 /D_CRT_SECURE_NO_WARNINGS")
-elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
--Wall -Wextra -Wswitch -Wshadow -Wunused-parameter \
--Wmissing-prototypes -Wmissing-declarations -Wformat -Wformat-security")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
--Wall -Wextra -Wswitch -Wshadow -Wunused-parameter \
--Wmissing-declarations -Wformat -Wformat-security")
+# Set warnings as variables, then store as cache options
+set(PROJ_common_WARN_FLAGS  # common only to GNU/Clang C/C++
+  -Wall
+  -Wextra
+  -Wswitch
+  -Wshadow
+  -Wunused-parameter
+  -Wmissing-declarations
+  -Wformat
+  -Wformat-security
+)
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    -Wmissing-prototypes
+  )
+  set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS})
 elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
--Wall -Wextra -Wswitch -Wshadow -Wunused-parameter \
--Wmissing-prototypes -Wmissing-declarations -Wformat -Wformat-security \
--Wfloat-conversion -Wc99-extensions -Wc11-extensions")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
--Wall -Wextra -Wswitch -Wshadow -Wunused-parameter \
--Wmissing-declarations -Wformat -Wformat-security -Wfloat-conversion")
+  set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    -Wmissing-prototypes
+    -Wfloat-conversion
+    -Wc99-extensions
+    -Wc11-extensions
+  )
+  set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    -Wfloat-conversion
+  )
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  add_definitions(/D_CRT_SECURE_NO_WARNINGS) # Eliminate deprecation warnings
+  set(PROJ_C_WARN_FLAGS
+    /W4
+    /wd4706  # Suppress warning about assignment within conditional expression
+    /wd4996  # Suppress warning about sprintf, etc., being unsafe
+  )
+  set(PROJ_CXX_WARN_FLAGS /EHsc ${PROJ_C_WARN_FLAGS})
 endif()
+set(PROJ_C_WARN_FLAGS "${PROJ_C_WARN_FLAGS}"
+  CACHE STRING "C flags used to compile PROJ targets")
+set(PROJ_CXX_WARN_FLAGS "${PROJ_CXX_WARN_FLAGS}"
+  CACHE STRING "C++ flags used to compile PROJ targets")
 
 # Tell Intel compiler to do arithmetic accurately.  This is needed to
 # stop the compiler from ignoring parentheses in expressions like
@@ -121,10 +136,10 @@ include(CheckIncludeFiles)
 
 include(CheckCSourceCompiles)
 if(MSVC)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX /W4")
 else()
   set(CMAKE_REQUIRED_LIBRARIES m)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
 endif()
 # Check whether the C99 math function: hypot, atanh, etc. are available.
 check_c_source_compiles("

--- a/src/bin_cct.cmake
+++ b/src/bin_cct.cmake
@@ -9,6 +9,8 @@ source_group("Source Files\\Bin" FILES ${CCT_SRC})
 
 add_executable(cct ${CCT_SRC} ${CCT_INCLUDE})
 target_link_libraries(cct ${PROJ_LIBRARIES})
+target_compile_options(cct PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS cct
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/bin_cs2cs.cmake
+++ b/src/bin_cs2cs.cmake
@@ -7,6 +7,8 @@ source_group("Source Files\\Bin" FILES ${CS2CS_SRC})
 
 add_executable(cs2cs ${CS2CS_SRC} ${CS2CS_INCLUDE})
 target_link_libraries(cs2cs ${PROJ_LIBRARIES})
+target_compile_options(cs2cs PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS cs2cs
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/bin_geod.cmake
+++ b/src/bin_geod.cmake
@@ -8,9 +8,10 @@ set(GEOD_INCLUDE apps/geod_interface.h)
 
 source_group("Source Files\\Bin" FILES ${GEOD_SRC} ${GEOD_INCLUDE})
 
-#Executable
 add_executable(geod ${GEOD_SRC} ${GEOD_INCLUDE})
 target_link_libraries(geod ${PROJ_LIBRARIES})
+target_compile_options(geod PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS geod
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/bin_geodtest.cmake
+++ b/src/bin_geodtest.cmake
@@ -3,12 +3,11 @@ set(GEODTEST_INCLUDE)
 
 source_group("Source Files\\Bin" FILES ${GEODTEST_SRC} ${GEODTEST_INCLUDE})
 
-#Executable
 add_executable(geodtest ${GEODTEST_SRC} ${GEODTEST_INCLUDE})
 target_link_libraries(geodtest ${PROJ_LIBRARIES})
-# Do not install
+target_compile_options(geodtest PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
-# Instead run as a test
+# Do not install, instead run as a test
 add_test(NAME geodesic-test COMMAND geodtest)
 
 if(MSVC AND BUILD_LIBPROJ_SHARED)

--- a/src/bin_gie.cmake
+++ b/src/bin_gie.cmake
@@ -9,6 +9,8 @@ source_group("Source Files\\Bin" FILES ${GIE_SRC})
 
 add_executable(gie ${GIE_SRC} ${GIE_INCLUDE})
 target_link_libraries(gie ${PROJ_LIBRARIES})
+target_compile_options(gie PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS gie
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/bin_proj.cmake
+++ b/src/bin_proj.cmake
@@ -5,12 +5,13 @@ set(PROJ_SRC
 
 source_group("Source Files\\Bin" FILES ${PROJ_SRC})
 
-#Executable
 add_executable(binproj ${PROJ_SRC})
 set_target_properties(binproj
   PROPERTIES
   OUTPUT_NAME proj)
 target_link_libraries(binproj ${PROJ_LIBRARIES})
+target_compile_options(binproj PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS binproj
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/bin_projinfo.cmake
+++ b/src/bin_projinfo.cmake
@@ -2,12 +2,13 @@ set(PROJINFO_SRC apps/projinfo.cpp)
 
 source_group("Source Files\\Bin" FILES ${PROJINFO_SRC})
 
-#Executable
 add_executable(binprojinfo ${PROJINFO_SRC})
 set_target_properties(binprojinfo
   PROPERTIES
   OUTPUT_NAME projinfo)
 target_link_libraries(binprojinfo ${PROJ_LIBRARIES})
+target_compile_options(binprojinfo PRIVATE ${PROJ_CXX_WARN_FLAGS})
+
 install(TARGETS binprojinfo
   RUNTIME DESTINATION ${BINDIR})
 

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -42,15 +42,9 @@ if(ENABLE_LTO)
     set(CMAKE_REQUIRED_FLAGS "-Wl,-flto")
     check_cxx_source_compiles("int main(){ return 0; }"
       COMPILER_SUPPORTS_FLTO_FLAG)
-    if(COMPILER_SUPPORTS_FLTO_FLAG)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-    endif()
   else()
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag("-flto" COMPILER_SUPPORTS_FLTO_FLAG)
-    if(COMPILER_SUPPORTS_FLTO_FLAG)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-    endif()
   endif()
 endif()
 
@@ -351,6 +345,18 @@ add_library(
   ${ALL_LIBPROJ_HEADERS}
   ${PROJ_RESOURCES}
 )
+target_compile_options(${PROJ_CORE_TARGET}
+  PRIVATE $<$<COMPILE_LANGUAGE:C>:${PROJ_C_WARN_FLAGS}>
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${PROJ_CXX_WARN_FLAGS}>
+)
+
+if(COMPILER_SUPPORTS_FLTO_FLAG)
+  # See https://gitlab.kitware.com/cmake/cmake/issues/15245
+  # CMake v3.9:
+  # set_property(TARGET ${PROJ_CORE_TARGET}
+  #   PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  target_compile_options(${PROJ_CORE_TARGET} PRIVATE -flto)
+endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
   target_include_directories(${PROJ_CORE_TARGET} INTERFACE

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -11,12 +11,6 @@ else()
 
 message(STATUS "Using internal GTest")
 
-# FIXME: Deal with our old-school CMakeLists.txt behaving badly
-set(_save_c_flags "${CMAKE_C_FLAGS}")
-set(_save_cxx_flags "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "\\-W[a-z\\-]+" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
-string(REGEX REPLACE "\\-W[a-z\\-]+" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-
 #
 # Build Google Test
 #
@@ -48,12 +42,6 @@ add_subdirectory(
   ${CMAKE_BINARY_DIR}/googletest-build
   EXCLUDE_FROM_ALL)
 
-# FIXME: Deal with our old-school CMakeLists.txt behaving badly
-set(CMAKE_C_FLAGS "${_save_c_flags}")
-set(CMAKE_CXX_FLAGS "${_save_cxx_flags}")
-unset(_save_c_flags)
-unset(_save_cxx_flags)
-
 # Provide the same target name as find_package(GTest)
 add_library(GTest::gtest ALIAS gtest)
 
@@ -71,6 +59,9 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${SQLITE3_INCLUDE_DIR})
 # Add the directory containing proj_config.h
 include_directories(${CMAKE_BINARY_DIR}/src)
+
+# Apply to targets in the current directory and below
+add_compile_options(${PROJ_CXX_WARN_FLAGS})
 
 add_executable(proj_pj_transform_test
   main.cpp


### PR DESCRIPTION
This PR is to help modernize the CMake setup (#1263)

There a are likely several ways to accomplish this, but this is the cleanest way that I can see. Most of the custom flags added to date are warning flags. There are now cached into `PROJ_C_WARN_FLAGS`/`PROJ_CXX_WARN_FLAGS`, then applied to the relevant targets.

Currently, these target compile options `PRIVATE`, since warning flags should not change the behavior of the library/utilities. But perhaps these should be `INTERFACE`?

Also, `/D_CRT_SECURE_NO_WARNINGS` is not exactly a warning flag, so it's been bumped into a global `add_definitions`.

The only remaining `CMAKE_C_FLAGS` modification is related to an Intel flag, which I may address another day.