### PR TITLE
Adjust test outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # This is the config file for building proj.4 and running its test suite
 # with Travis-ci.org
+language: cpp
 
 branches:
   except:
@@ -16,7 +17,6 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
-      language: cpp
       sudo: required
       services:
         - docker
@@ -26,6 +26,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      compiler: gcc
       sudo: required
       services:
         - docker
@@ -44,7 +45,6 @@ matrix:
     - os: linux
       dist: trusty
       compiler: clang
-      language: cpp
       sudo: required
       services:
         - docker
@@ -53,7 +53,6 @@ matrix:
         - DETAILS="linux, clang"
 
     - os: osx
-      language: cpp
       env:
         - BUILD_NAME=osx
         - DETAILS="osx"
@@ -61,7 +60,6 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
-      language: cpp
       sudo: required
       env:
         - BUILD_NAME=mingw32
@@ -69,7 +67,6 @@ matrix:
 
     - os: linux
       compiler: gcc
-      language: cpp
       dist: trusty
       sudo: required
       env:

--- a/test/cli/test27
+++ b/test/cli/test27
@@ -836,7 +836,7 @@ EOF
 #
 # do 'diff' with distribution results
 echo "diff ${OUT} with pj_out27.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/pj_out27.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/pj_out27.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/test83
+++ b/test/cli/test83
@@ -717,7 +717,7 @@ EOF
 #
 # do 'diff' with distribution results
 echo "diff ${OUT} with pj_out83.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/pj_out83.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/pj_out83.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/testIGNF
+++ b/test/cli/testIGNF
@@ -158,7 +158,7 @@ EOF
 #
 # do 'diff' with distribution results
 echo "diff ${OUT} with ${OUT}.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
 if [ $? -ne 0 ] ; then
 echo  ""
 echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/testdatumfile
+++ b/test/cli/testdatumfile
@@ -113,7 +113,7 @@ rm -rf "dir with \" space"
 # Done!     
 # do 'diff' with distribution results
 echo "diff ${OUT} with ${OUT}.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/testflaky
+++ b/test/cli/testflaky
@@ -58,7 +58,7 @@ EOF
 # Done!
 # do 'diff' with distribution results
 echo "diff ${OUT} with ${OUT}.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/testntv2
+++ b/test/cli/testntv2
@@ -57,7 +57,7 @@ EOF
 # Done! 
 # do 'diff' with distribution results
 echo "diff ${OUT} with ${OUT}.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -969,7 +969,7 @@ EOF
 # Done!
 # do 'diff' with distribution results
 echo "diff ${OUT} with ${OUT}.dist"
-diff -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
+diff -u -b ${OUT} ${TEST_CLI_DIR}/${OUT}.dist
 if [ $? -ne 0 ] ; then
 	echo  ""
 	echo "PROBLEMS HAVE OCCURRED"

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -2,3 +2,7 @@
 
 # All platform-specific before_install scripts starts by running this
 # "global" before_install script.
+
+# Configure Python pip
+pip install --user --upgrade pip
+pip config --user set global.progress_bar off

--- a/travis/csa/install.sh
+++ b/travis/csa/install.sh
@@ -6,6 +6,6 @@ set -e
 ./autogen.sh
 
 CXXFLAGS="-std=c++11" ./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build -o scanbuildoutput -plist -v ./configure
-./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build -o scanbuildoutput -plist -v make -j3
+./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build -o scanbuildoutput -plist -v make -j2
 
 if grep -r "\.c" scanbuildoutput | grep "<string>" | grep -v -e "<key>" -e _generated_parser; then echo "error" && /bin/false; else echo "ok"; fi 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -27,7 +27,7 @@ if [ -f /usr/lib/jvm/java-7-openjdk-amd64/include/jni.h ]; then
 else
     ../configure --prefix=/tmp/proj_autoconf_install_from_dist_all
 fi
-make -j3
+make -j2
 make check
 make install
 find /tmp/proj_autoconf_install_from_dist_all
@@ -37,7 +37,7 @@ cd ..
 mkdir build_cmake
 cd build_cmake
 cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj_cmake_install
-make -j3
+VERBOSE=1 make -j2
 make install
 # The cmake build is not able to generate the null file, so copy it at hand
 cp /tmp/proj_autoconf_install_from_dist_all/share/proj/null /tmp/proj_cmake_install/share/proj
@@ -55,7 +55,7 @@ cd ../..
 mkdir build_autoconf_grids
 cd build_autoconf_grids
 ../configure --prefix=/tmp/proj_autoconf_install_grids
-make -j3
+make -j2
 make check
 (cd src && make multistresstest && make test228)
 PROJ_LIB=../data src/multistresstest
@@ -74,7 +74,7 @@ if [ "$BUILD_NAME" != "linux_clang" ]; then
 else
     ./configure
 fi
-make -j3
+make -j2
 make check
 
 # Rerun tests without grids not included in proj-datumgrid

--- a/travis/mingw32/install.sh
+++ b/travis/mingw32/install.sh
@@ -13,7 +13,7 @@ ln -s /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll  $HOME/.wine/drive_c/windo
 # build sqlite3
 wget https://sqlite.org/2018/sqlite-autoconf-3250100.tar.gz
 tar xzf sqlite-autoconf-3250100.tar.gz
-(cd sqlite-autoconf-3250100 &&  CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 && make -j3 && sudo make install)
+(cd sqlite-autoconf-3250100 &&  CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 && make -j2 && sudo make install)
 ln -s /usr/x86_64-w64-mingw32/bin/libsqlite3-0.dll  $HOME/.wine/drive_c/windows
 
 # prepare build files
@@ -22,11 +22,11 @@ ln -s /usr/x86_64-w64-mingw32/bin/libsqlite3-0.dll  $HOME/.wine/drive_c/windows
 mkdir build_autoconf
 cd build_autoconf
 CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install
-make -j3
+make -j2
 make install
 make dist-all
 find /tmp/proj_autoconf_install
-(cd test; make -j3)
+(cd test; make -j2)
 test/unit/test_cpp_api.exe
 cd ..
 # Now with grids
@@ -38,7 +38,7 @@ cd ..
 mkdir build_autoconf_grids
 cd build_autoconf_grids
 CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install_nad
-make -j3
+make -j2
 make install
 find /tmp/proj_autoconf_install_nad
 #make check


### PR DESCRIPTION
 - Travis CI only has two cores, so `-j2` is sufficent
 - Tests should use unified diff with expected results
 - Show CMake build compile commands (`VERBOSE=1`)