### PR TITLE
DOC: add sphinx links to reference in dev quickstart

### DIFF
--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -39,14 +39,14 @@ this in detail.
   :dedent: 4
 
 Next we create the :c:type:`PJ` transformation object ``P`` with the function
-:c:func:`proj_create`. ``proj_create`` takes the threading context ``C`` created above,
-and a proj-string that defines the desired transformation. Here we transform
-from geodetic coordinate to UTM zone 32N.
+:c:func:`proj_create`. :c:func:`proj_create` takes the threading context ``C``
+created above, and a proj-string that defines the desired transformation.
+Here we transform from geodetic coordinate to UTM zone 32N.
 It is recommended to create one threading-context per thread used by the program.
-This ensures that all ``PJ`` objects created in the same context will be sharing
-resources such as error-numbers and loaded grids.
-In case the creation of the ``PJ`` object fails an error message is displayed and
-the program returns. See :doc:`errorhandling` for further
+This ensures that all :c:type:`PJ` objects created in the same context will be
+sharing resources such as error-numbers and loaded grids.
+In case the creation of the :c:type:`PJ` object fails an error message is
+displayed and the program returns. See :doc:`errorhandling` for further
 details.
 
 .. literalinclude:: ../../../examples/pj_obs_api_mini_demo.c
@@ -55,9 +55,9 @@ details.
   :dedent: 4
 
 PROJ uses it's own data structures for handling coordinates. Here we use a
-:c:type:`PJ_COORD` which is easily assigned with the function :c:func:`proj_coord`. Note
-that the input values are converted to radians with :c:func:`proj_torad`. This is
-necessary since PROJ is using radians internally. See :doc:`transformations`
+:c:type:`PJ_COORD` which is easily assigned with the function :c:func:`proj_coord`.
+Note that the input values are converted to radians with :c:func:`proj_torad`.
+This is necessary since PROJ is using radians internally. See :doc:`transformations`
 for further details.
 
 .. literalinclude:: ../../../examples/pj_obs_api_mini_demo.c
@@ -66,9 +66,9 @@ for further details.
   :dedent: 4
 
 The coordinate defined above is transformed with :c:func:`proj_trans`. For this
-a ``PJ`` object, a transformation direction (either forward or inverse) and the
-coordinate is needed. The transformed coordinate is returned in ``b``.
-Here the forward (``PJ_FWD``) transformation from geodetic to UTM is made.
+a :c:type:`PJ` object, a transformation direction (either forward or inverse)
+and the coordinate is needed. The transformed coordinate is returned in ``b``.
+Here the forward (:c:type:`PJ_FWD`) transformation from geodetic to UTM is made.
 
 .. literalinclude:: ../../../examples/pj_obs_api_mini_demo.c
   :language: c
@@ -76,7 +76,7 @@ Here the forward (``PJ_FWD``) transformation from geodetic to UTM is made.
   :dedent: 4
 
 The inverse transformation (UTM to geodetic) is done similar to above,
-this time using ``PJ_INV`` as the direction.
+this time using :c:type:`PJ_INV` as the direction.
 
 .. literalinclude:: ../../../examples/pj_obs_api_mini_demo.c
   :language: c

--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -28,7 +28,7 @@ See the :doc:`reference for more info on data types <reference/datatypes>`.
   :lines: 43-45
   :dedent: 4
 
-For use in multi-threaded programs the ``PJ_CONTEXT`` threading-context is used.
+For use in multi-threaded programs the :c:type:`PJ_CONTEXT` threading-context is used.
 In this particular example it is not needed, but for the sake of completeness
 it created here. The section on :doc:`threads <threads>` discusses
 this in detail.
@@ -38,8 +38,8 @@ this in detail.
   :lines: 49
   :dedent: 4
 
-Next we create the ``PJ`` transformation object ``P`` with the function
-``proj_create``. ``proj_create`` takes the threading context ``C`` created above,
+Next we create the :c:type:`PJ` transformation object ``P`` with the function
+:c:func:`proj_create`. ``proj_create`` takes the threading context ``C`` created above,
 and a proj-string that defines the desired transformation. Here we transform
 from geodetic coordinate to UTM zone 32N.
 It is recommended to create one threading-context per thread used by the program.
@@ -55,8 +55,8 @@ details.
   :dedent: 4
 
 PROJ uses it's own data structures for handling coordinates. Here we use a
-``PJ_COORD`` which is easily assigned with the function ``proj_coord``. Note
-that the input values are converted to radians with ``proj_torad``. This is
+:c:type:`PJ_COORD` which is easily assigned with the function :c:func:`proj_coord`. Note
+that the input values are converted to radians with :c:func:`proj_torad`. This is
 necessary since PROJ is using radians internally. See :doc:`transformations`
 for further details.
 
@@ -65,7 +65,7 @@ for further details.
   :lines: 57
   :dedent: 4
 
-The coordinate defined above is transformed with ``proj_trans``. For this
+The coordinate defined above is transformed with :c:func:`proj_trans`. For this
 a ``PJ`` object, a transformation direction (either forward or inverse) and the
 coordinate is needed. The transformed coordinate is returned in ``b``.
 Here the forward (``PJ_FWD``) transformation from geodetic to UTM is made.


### PR DESCRIPTION
Question before merging this: I now only made the first occurrence of a type of function into a sphinx link, and left the subsequent as normal sphinx code format to check this is working. But you might prefer to convert all occurrences of linkable objects? (I do I think)