### PR TITLE
Remove `PROJ_COMPILATION=1` definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.1)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
-add_definitions(-DPROJ_COMPILATION=1)
-
 # Set C++ version
 # Make CMAKE_CXX_STANDARD available as cache option overridable by user
 set(CMAKE_CXX_STANDARD 11

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ check_PROGRAMS = geodtest
 
 AM_CPPFLAGS =	-DPROJ_LIB=\"$(pkgdatadir)\" \
 		-DMUTEX_@MUTEX_SETTING@ @JNI_INCLUDE@ -I$(top_srcdir)/include @SQLITE3_CFLAGS@
-AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@ -DPROJ_COMPILATION
+AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@
 
 include_HEADERS = proj.h proj_experimental.h proj_constants.h proj_api.h geodesic.h \
 	org_proj4_PJ.h proj_symbol_rename.h


### PR DESCRIPTION
These do not appear to be used, and I can't see what they are for. They were added from the d928db15d53805d9b728b440079756081961c536 mega commit for the "GDAL SRS barn" work.

@rouault is it OK to remove these?