### PR TITLE
CMake: better support for Intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,23 +68,19 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     /wd4996  # Suppress warning about sprintf, etc., being unsafe
   )
   set(PROJ_CXX_WARN_FLAGS /EHsc ${PROJ_C_WARN_FLAGS})
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+  if(MSVC)
+    set(PROJ_C_WARN_FLAGS /Wall)
+    set(PROJ_CXX_WARN_FLAGS /Wall)
+  else()
+    set(PROJ_C_WARN_FLAGS -Wall)
+    set(PROJ_CXX_WARN_FLAGS -Wall)
+  endif()
 endif()
 set(PROJ_C_WARN_FLAGS "${PROJ_C_WARN_FLAGS}"
   CACHE STRING "C flags used to compile PROJ targets")
 set(PROJ_CXX_WARN_FLAGS "${PROJ_CXX_WARN_FLAGS}"
   CACHE STRING "C++ flags used to compile PROJ targets")
-
-# Tell Intel compiler to do arithmetic accurately.  This is needed to
-# stop the compiler from ignoring parentheses in expressions like
-# (a + b) + c and from simplifying 0.0 + x to x (which is wrong if
-# x = -0.0).
-if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
-  if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:precise")
-  else()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fp-model precise")
-  endif()
-endif()
 
 ################################################################################
 # PROJ CMake modules

--- a/cmake/ProjSystemInfo.cmake
+++ b/cmake/ProjSystemInfo.cmake
@@ -62,6 +62,10 @@ if(WIN32)
     set(PROJ_COMPILER_NAME "mingw-${GCC_VERSION}")
   endif()
 
+  if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+    set(PROJ_COMPILER_NAME "intel-win")
+  endif()
+
   if(CMAKE_GENERATOR MATCHES "Win64")
     set(PROJ_PLATFORM_NAME "x64")
   else()
@@ -70,7 +74,12 @@ if(WIN32)
 endif()  # WIN32
 
 if(UNIX)
-  set(PROJ_COMPILER_NAME "gcc-${GCC_VERSION}")
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    set(PROJ_COMPILER_NAME "gcc-${GCC_VERSION}")
+  elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+    set(PROJ_COMPILER_NAME "intel-linux")
+  endif()
+
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
     set(PROJ_PLATFORM_NAME "x64")
   else()

--- a/include/proj/internal/internal.hpp
+++ b/include/proj/internal/internal.hpp
@@ -53,7 +53,7 @@
 #if ((defined(__clang__) &&                                                    \
       (__clang_major__ > 3 ||                                                  \
        (__clang_major__ == 3 && __clang_minor__ >= 7))) ||                     \
-     __GNUC__ >= 7)
+     (__GNUC__ >= 7 && !__INTEL_COMPILER))
 /** Macro for fallthrough in a switch case construct */
 #define PROJ_FALLTHROUGH [[clang::fallthrough]];
 #else


### PR DESCRIPTION
- Move precise floating precision model flag to `src/lib_proj.cmake`, and limit scope this option to just `geodesic.c` for now (there is one test that fails without the option, but all tests pass with)
- Add common warning flags, but not `-Wremarks` which generates too many remarks. So far, there is only one warning:
```[ 98%] Building CXX object test/unit/CMakeFiles/proj_test_cpp_api.dir/test_factory.cpp.o
/tmp/proj.4/test/unit/test_factory.cpp(1653): warning #177: function "<unnamed>::FactoryWithTmpDatabase::get_table" was declared but never referenced
      bool get_table(const char *sql, sqlite3 *db = nullptr) {
           ^
```
- Resolve #1269 that showed a warning related to `PROJ_FALLTHROUGH`, as the Intel compiler has `__GNUC__ >= 7`
- Before CMake v3.9, only Intel compilers supported the `INTERPROCEDURAL_OPTIMIZATION` target property; add a TODO note to use `CheckIPOSupported` macro from CMake v3.9 to check/set this flag for all compilers.
- Limit `PROJ_COMPILER_NAME` based on `CMAKE_C_COMPILER_ID` (i.e., don't assume it's `gcc-${GCC_VERSION}`). Add `intel-win` and `intel-linux`, which appear to be valid Boost toolset identifiers.