### PR TITLE
createOperations(): do not attempt using a unrelated datum intermediate when doing geog2D<-->geog3D conversions of same datum

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -154,6 +154,12 @@ class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
 
     PROJ_DLL CoordinateOperationNNPtr normalizeForVisualization() const;
 
+    PROJ_PRIVATE :
+        //! @cond Doxygen_Suppress
+        PROJ_FOR_TEST CoordinateOperationNNPtr
+        shallowClone() const;
+    //! @endcond
+
   protected:
     PROJ_INTERNAL CoordinateOperation();
     PROJ_INTERNAL CoordinateOperation(const CoordinateOperation &other);
@@ -178,6 +184,8 @@ class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
     PROJ_INTERNAL void
     setProperties(const util::PropertyMap
                       &properties); // throw(InvalidValueTypeException)
+
+    PROJ_INTERNAL virtual CoordinateOperationNNPtr _shallowClone() const = 0;
 
   private:
     PROJ_OPAQUE_PRIVATE_DATA
@@ -1328,6 +1336,8 @@ class PROJ_GCC_DLL Conversion : public SingleOperation {
     PROJ_FRIEND(crs::ProjectedCRS);
     PROJ_INTERNAL bool addWKTExtensionNode(io::WKTFormatter *formatter) const;
 
+    PROJ_INTERNAL CoordinateOperationNNPtr _shallowClone() const override;
+
   private:
     PROJ_OPAQUE_PRIVATE_DATA
     Conversion &operator=(const Conversion &other) = delete;
@@ -1543,6 +1553,8 @@ class PROJ_GCC_DLL Transformation : public SingleOperation {
 
     PROJ_INTERNAL TransformationNNPtr inverseAsTransformation() const;
 
+    PROJ_INTERNAL CoordinateOperationNNPtr _shallowClone() const override;
+
   private:
     PROJ_OPAQUE_PRIVATE_DATA
 };
@@ -1634,11 +1646,14 @@ class PROJ_GCC_DLL ConcatenatedOperation final : public CoordinateOperation {
     //! @endcond
 
   protected:
+    PROJ_INTERNAL ConcatenatedOperation(const ConcatenatedOperation &other);
     PROJ_INTERNAL explicit ConcatenatedOperation(
         const std::vector<CoordinateOperationNNPtr> &operationsIn);
 
     PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
         const override; // throw(FormattingException)
+
+    PROJ_INTERNAL CoordinateOperationNNPtr _shallowClone() const override;
 
     INLINED_MAKE_SHARED
 

--- a/include/proj/internal/coordinateoperation_internal.hpp
+++ b/include/proj/internal/coordinateoperation_internal.hpp
@@ -109,8 +109,9 @@ using InverseCoordinateOperationNNPtr = util::nn<InverseCoordinateOperationPtr>;
  */
 class InverseCoordinateOperation : virtual public CoordinateOperation {
   public:
-    InverseCoordinateOperation(const CoordinateOperationNNPtr &forwardOperation,
-                               bool wktSupportsInversion);
+    InverseCoordinateOperation(
+        const CoordinateOperationNNPtr &forwardOperationIn,
+        bool wktSupportsInversion);
 
     ~InverseCoordinateOperation() override;
 
@@ -123,6 +124,10 @@ class InverseCoordinateOperation : virtual public CoordinateOperation {
                         util::IComparable::Criterion::STRICT) const override;
 
     CoordinateOperationNNPtr inverse() const override;
+
+    const CoordinateOperationNNPtr &forwardOperation() const {
+        return forwardOperation_;
+    }
 
   protected:
     CoordinateOperationNNPtr forwardOperation_;
@@ -174,6 +179,8 @@ class InverseConversion : public Conversion, public InverseCoordinateOperation {
 #endif
 
     static CoordinateOperationNNPtr create(const ConversionNNPtr &forward);
+
+    CoordinateOperationNNPtr _shallowClone() const override;
 };
 
 // ---------------------------------------------------------------------------
@@ -204,6 +211,8 @@ class InverseTransformation : public Transformation,
         return InverseCoordinateOperation::inverse();
     }
 
+    TransformationNNPtr inverseAsTransformation() const;
+
 #ifdef _MSC_VER
     // To avoid a warning C4250:
     // 'osgeo::proj::operation::InverseTransformation': inherits
@@ -216,6 +225,8 @@ class InverseTransformation : public Transformation,
 #endif
 
     static TransformationNNPtr create(const TransformationNNPtr &forward);
+
+    CoordinateOperationNNPtr _shallowClone() const override;
 };
 
 // ---------------------------------------------------------------------------
@@ -253,10 +264,13 @@ class PROJBasedOperation : public SingleOperation {
     gridsNeeded(const io::DatabaseContextPtr &databaseContext) const override;
 
   protected:
+    PROJBasedOperation(const PROJBasedOperation &) = default;
     explicit PROJBasedOperation(const OperationMethodNNPtr &methodIn);
 
     void _exportToPROJString(io::PROJStringFormatter *formatter)
         const override; // throw(FormattingException)
+
+    CoordinateOperationNNPtr _shallowClone() const override;
 
     INLINED_MAKE_SHARED
 

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -1518,12 +1518,20 @@ class FactoryWithTmpDatabase : public ::testing::Test {
         const auto vals = std::vector<std::string>{"SOURCE", "TARGET", "PIVOT"};
         for (const auto &val : vals) {
 
+            ASSERT_TRUE(
+                execute("INSERT INTO geodetic_datum "
+                        "VALUES('FOO','" +
+                        val + "','" + val +
+                        "','',NULL,"
+                        "'EPSG','7030','EPSG','8901','EPSG','1262',0);"))
+                << last_error();
             ASSERT_TRUE(execute("INSERT INTO geodetic_crs "
                                 "VALUES('NS_" +
                                 val + "','" + val + "','" + val +
                                 "',NULL,NULL,'geographic 2D','EPSG','6422',"
-                                "'EPSG','6326',"
-                                "'EPSG','1262',NULL,0);"))
+                                "'FOO','" +
+                                val + "',"
+                                      "'EPSG','1262',NULL,0);"))
                 << last_error();
         }
     }


### PR DESCRIPTION
Seen when testing transformations between "CR 05" (EPSG:5365) and "CR-SIRGAS" (EPSG:8907)
which require going through their corresponding 3D GeogCRS to find a Helmert
transformation.