### PR TITLE
vgridshift: handle longitude wrap-around for grids with 360deg longitude extent

### DIFF
--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -253,6 +253,24 @@ ignore    pjd_err_failed_to_load_grid
 accept    12.5 55.5   0                  0
 expect    12.5 55.5 -36.021305084228516  0
 
+accept    -180.1 0 0
+expect    -180.1 0 -21.2423
+
+accept    179.9 0 0
+expect    179.9 0 -21.2423
+
+accept    180 0 0
+expect    180 0 -21.1533 
+
+accept    540 0 0
+expect    540 0 -21.1533 
+
+accept    -180 0 0
+expect    -180 0 -21.1533 
+
+accept    -540 0 0
+expect    -540 0 -21.1533 
+
 roundtrip 100 1 nm
 -------------------------------------------------------------------------------
 Fail on purpose: +grids parameter is mandatory


### PR DESCRIPTION
Like egm96_15.gtx
Fixes #1415

Technically, a similar fix could be done for horizontal grids, but world
extent is less common for them.