### PR TITLE
Inverse cart: better deal with x,y,z equal of very close to zero

### DIFF
--- a/src/conversions/cart.cpp
+++ b/src/conversions/cart.cpp
@@ -162,6 +162,12 @@ static PJ_LPZ geodetic (PJ_XYZ cart,  PJ *P) {
     c  =  cos(theta);
     s  =  sin(theta);
     lpz.phi  =  atan2 (cart.z + P->e2s*P->b*s*s*s,  p - P->es*P->a*c*c*c);
+    if( fabs(lpz.phi) > M_HALFPI ) {
+        // this happen on non-sphere ellipsoid when x,y,z is very close to 0
+        // there is no single solution to the cart->geodetic conversion in
+        // that case, so arbitrarily pickup phi = 0.
+        lpz.phi = 0;
+    }
     lpz.lam  =  atan2 (cart.y, cart.x);
     N        =  normal_radius_of_curvature (P->a, P->es, lpz.phi);
 

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -794,5 +794,64 @@ expect  25  25  25  25
 operation +proj=aeqd +R=1 +lat_0=91
 expect  failure errno lat_larger_than_90
 
+-------------------------------------------------------------------------------
+# cart
+-------------------------------------------------------------------------------
+
+operation   +proj=cart +ellps=GRS80
+tolerance 0.001mm
+
+accept      0 0 0
+expect      6378137 0 0
+
+accept      0 90 0
+expect      0 0 6356752.314140347
+
+accept      0 -90 0
+expect      0 0 -6356752.314140347
+
+accept      90 0 0
+expect      0 6378137 0
+
+accept      -90 0 0
+expect      0 -6378137 0
+
+accept      180 0 0
+expect      -6378137 0 0
+
+accept      -180 0 0
+expect      -6378137 0 0
+
+# Center of Earth !
+accept      0 0 -6378137
+expect      0 0 0
+
+accept      0 90 -6356752.314140347
+expect      0 0 0
+
+direction inverse
+
+accept      6378137 0 0
+expect      0 0 0
+
+accept      0 0 6356752.314140347
+expect      0 90 0
+
+accept      0 0 -6356752.314140347
+expect      0 -90 0
+
+accept      0 6378137 0
+expect      90 0 0
+
+accept      0 -6378137 0
+expect      -90 0 0
+
+accept      -6378137 0 0
+expect      180 0 0
+
+# Center of Earth !
+accept      0 0 0
+expect      0 0 -6378137
+
 
 </gie>


### PR DESCRIPTION
In that case, for a non-spherical ellipsoid, a phi = 180deg was returned,
which caused a division by zero in the foward path of moll.cpp
Fixup the latitude to be 0 when that happens.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14348
Credit to OSS Fuzz