### PR TITLE
Fix doc build on Travis OSX

### DIFF
--- a/travis/osx/before_install.sh
+++ b/travis/osx/before_install.sh
@@ -10,6 +10,7 @@ brew install sqlite3
 brew install doxygen
 
 export PATH=$HOME/Library/Python/2.7/bin:$PATH
-pip install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
+# breathe=4.12.0 is the last version to work for us with sphinx 1.8.5 / Python 2
+pip install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe==4.12.0
 which sphinx-build
 (cd docs; make html)


### PR DESCRIPTION
Latest breathe 4.13.0 no longer work with sphinx 1.8.5 / Pyhon 2,
so force use 4.12.0 for now.

See
https://travis-ci.com/OSGeo/proj.4/jobs/194629602
https://github.com/michaeljones/breathe/issues/431