### PR TITLE
proj_create(): add support for compoundCRS and concatenatedOperation named from their components

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -29,12 +29,17 @@ Synopsis
     |    {object_definition} | (-s {srs_def} -t {srs_def})
     |
 
-    where {object_definition} or {object_definition} is a PROJ string, a
-    WKT string, an object name, AUTHORITY:CODE
-    (where AUTHORITY is the name of a CRS authority and CODE the code of a CRS
-    found in the proj.db database) or a OGC URN (such as  "urn:ogc:def:crs:EPSG::4326",
-    "urn:ogc:def:coordinateOperation:EPSG::1671", "urn:ogc:def:ellipsoid:EPSG::7001"
-    or "urn:ogc:def:datum:EPSG::6326")
+    where {object_definition} or {srs_def} is
+
+    - a proj-string,
+    - a WKT string,
+    - an object code (like "EPSG:4326", "urn:ogc:def:crs:EPSG::4326",
+      "urn:ogc:def:coordinateOperation:EPSG::1671"),
+    - a OGC URN combining references for compound coordinate reference systems
+      (e.g "urn:ogc:def:crs,crs:EPSG::2393,crs:EPSG::5717" or custom abbreviated
+      syntax "EPSG:2393+5717"),
+    - a OGC URN combining references for concatenated operations
+      (e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618")
 
 Description
 ***********

--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -29,9 +29,17 @@ paragraph for more details.
 
 .. c:function:: PJ* proj_create(PJ_CONTEXT *ctx, const char *definition)
 
-    Create a transformation object, or a CRS object, from a proj-string,
-    a WKT string, or object code (like "EPSG:4326", "urn:ogc:def:crs:EPSG::4326",
-    "urn:ogc:def:coordinateOperation:EPSG::1671").
+    Create a transformation object, or a CRS object, from:
+
+    - a proj-string,
+    - a WKT string,
+    - an object code (like "EPSG:4326", "urn:ogc:def:crs:EPSG::4326",
+      "urn:ogc:def:coordinateOperation:EPSG::1671"),
+    - a OGC URN combining references for compound coordinate reference systems
+      (e.g "urn:ogc:def:crs,crs:EPSG::2393,crs:EPSG::5717" or custom abbreviated
+      syntax "EPSG:2393+5717"),
+    - a OGC URN combining references for concatenated operations
+      (e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618")
 
     Example call:
 
@@ -110,7 +118,8 @@ paragraph for more details.
 
         - the name of a CRS as found in the PROJ database, e.g "WGS84", "NAD27", etc.
 
-        - more generally any string accepted by :c:func:`proj_create`
+        - more generally any string accepted by :c:func:`proj_create` representing
+          a CRS
 
     An "area of use" can be specified in area. When it is supplied, the more
     accurate transformation between two given systems can be chosen.

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -993,15 +993,15 @@ class PROJ_GCC_DLL AuthorityFactory {
 
     PROJ_INTERNAL std::list<crs::CompoundCRSNNPtr>
     createCompoundCRSFromExisting(const crs::CompoundCRSNNPtr &crs) const;
+
+    PROJ_INTERNAL crs::CRSNNPtr
+    createCoordinateReferenceSystem(const std::string &code,
+                                    bool allowCompound) const;
     //! @endcond
 
   protected:
     PROJ_INTERNAL AuthorityFactory(const DatabaseContextNNPtr &context,
                                    const std::string &authorityName);
-
-    PROJ_INTERNAL crs::CRSNNPtr
-    createCoordinateReferenceSystem(const std::string &code,
-                                    bool allowCompound) const;
 
     PROJ_INTERNAL crs::GeodeticCRSNNPtr
     createGeodeticCRS(const std::string &code, bool geographicOnly) const;

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2484,6 +2484,8 @@ crs::CRSNNPtr AuthorityFactory::createCoordinateReferenceSystem(
     return createCoordinateReferenceSystem(code, true);
 }
 
+//! @cond Doxygen_Suppress
+
 crs::CRSNNPtr
 AuthorityFactory::createCoordinateReferenceSystem(const std::string &code,
                                                   bool allowCompound) const {
@@ -2513,6 +2515,9 @@ AuthorityFactory::createCoordinateReferenceSystem(const std::string &code,
     }
     throw FactoryException("unhandled CRS type: " + type);
 }
+
+//! @endcond
+
 // ---------------------------------------------------------------------------
 
 //! @cond Doxygen_Suppress


### PR DESCRIPTION
Support following syntaxes:
- OGC URN combining references for compoundCRS:
  e.g. "urn:ogc:def:crs,crs:EPSG::2393,crs:EPSG::5717"
- its GDAL shortcut: e.g. "EPSG:2393+5717"
- OGC URN combining references for concatenated operations:
  e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618"