### PR TITLE
gs50 and other mod_ster projections: avoid divison by zero

### DIFF
--- a/src/projections/mod_ster.cpp
+++ b/src/projections/mod_ster.cpp
@@ -35,7 +35,12 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
         pow((1. - esphi) / (1. + esphi), P->e * .5)) - M_HALFPI;
     schi = sin(chi);
     cchi = cos(chi);
-    s = 2. / (1. + Q->schio * schi + Q->cchio * cchi * coslon);
+    const double denom = 1. + Q->schio * schi + Q->cchio * cchi * coslon;
+    if( denom == 0 ) {
+        proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
+        return xy;
+    }
+    s = 2. / denom;
     p.r = s * cchi * sinlon;
     p.i = s * (Q->cchio * schi - Q->schio * cchi * coslon);
     p = pj_zpoly1(p, Q->zcoeff, Q->n);

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -1853,6 +1853,10 @@ expect  4030931.833981509 1323687.864777399
 accept  -80.000000000 36.000000000
 expect  3450764.261536101 -175619.041820732
 
+# For some reason, does not fail on MacOSX
+#accept  60 -45
+#expect  failure errno tolerance_condition
+
 direction inverse
 accept  -1800000.000000000 2600000.000000000
 expect  -157.989285000 64.851559610


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14421
Credit to OSS Fuzz