### PR TITLE
Prefix inverse and forward functions by their projection names

### DIFF
--- a/src/projections/aea.cpp
+++ b/src/projections/aea.cpp
@@ -99,7 +99,7 @@ static PJ *destructor (PJ *P, int errlev) {                        /* Destructor
 
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {   /* Ellipsoid/spheroid, forward */
+static PJ_XY aea_e_forward (PJ_LP lp, PJ *P) {   /* Ellipsoid/spheroid, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     Q->rho = Q->c - (Q->ellips ? Q->n * pj_qsfn(sin(lp.phi), P->e, P->one_es) : Q->n2 * sin(lp.phi));;
@@ -114,7 +114,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {   /* Ellipsoid/spheroid, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {   /* Ellipsoid/spheroid, inverse */
+static PJ_LP aea_e_inverse (PJ_XY xy, PJ *P) {   /* Ellipsoid/spheroid, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     if( (Q->rho = hypot(xy.x, xy.y = Q->rho0 - xy.y)) != 0.0 ) {
@@ -152,8 +152,8 @@ static PJ *setup(PJ *P) {
     int secant;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = aea_e_inverse;
+    P->fwd = aea_e_forward;
 
     if (fabs(Q->phi1) > M_HALFPI || fabs(Q->phi2) > M_HALFPI)
         return destructor(P, PJD_ERR_LAT_LARGER_THAN_90);

--- a/src/projections/aeqd.cpp
+++ b/src/projections/aeqd.cpp
@@ -91,7 +91,7 @@ static PJ_XY e_guam_fwd(PJ_LP lp, PJ *P) {        /* Guam elliptical */
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY aeqd_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi, rho;
@@ -130,7 +130,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY aeqd_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi;
@@ -195,7 +195,7 @@ static PJ_LP e_guam_inv(PJ_XY xy, PJ *P) { /* Guam elliptical */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP aeqd_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double c;
@@ -227,7 +227,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP aeqd_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cosc, c_rh, sinc;
@@ -291,8 +291,8 @@ PJ *PROJECTION(aeqd) {
         Q->cosph0 = cos(P->phi0);
     }
     if (P->es == 0.0) {
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = aeqd_s_inverse;
+        P->fwd = aeqd_s_forward;
     } else {
         if (!(Q->en = pj_enfn(P->es)))
             return pj_default_destructor (P, 0);
@@ -315,8 +315,8 @@ PJ *PROJECTION(aeqd) {
                 Q->He *= Q->cosph0;
                 break;
             }
-            P->inv = e_inverse;
-            P->fwd = e_forward;
+            P->inv = aeqd_e_inverse;
+            P->fwd = aeqd_e_forward;
         }
     }
 

--- a/src/projections/airy.cpp
+++ b/src/projections/airy.cpp
@@ -58,7 +58,7 @@ struct pj_opaque {
 # define EPS 1.e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY airy_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  sinlam, coslam, cosphi, sinphi, t, s, Krho, cosz;
@@ -151,7 +151,7 @@ PJ *PROJECTION(airy) {
             Q->cosph0 = cos(P->phi0);
         }
     }
-    P->fwd = s_forward;
+    P->fwd = airy_s_forward;
     P->es = 0.;
     return P;
 }

--- a/src/projections/aitoff.cpp
+++ b/src/projections/aitoff.cpp
@@ -58,11 +58,11 @@ PROJ_HEAD(wintri, "Winkel Tripel") "\n\tMisc Sph\n\tlat_1";
 
 
 #if 0
-FORWARD(s_forward); /* spheroid */
+FORWARD(aitoff_s_forward); /* spheroid */
 #endif
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY aitoff_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double c, d;
@@ -100,7 +100,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 *
 ************************************************************************************/
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP aitoff_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int iter, MAXITER = 10, round = 0, MAXROUND = 20;
@@ -171,8 +171,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 
 static PJ *setup(PJ *P) {
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = aitoff_s_inverse;
+    P->fwd = aitoff_s_forward;
     P->es = 0.;
     return P;
 }

--- a/src/projections/august.cpp
+++ b/src/projections/august.cpp
@@ -9,7 +9,7 @@ PROJ_HEAD(august, "August Epicycloidal") "\n\tMisc Sph, no inv";
 #define M 1.333333333333333
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY august_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	double t, c1, c, x1, x12, y1, y12;
 	(void) P;
@@ -29,7 +29,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(august) {
     P->inv = nullptr;
-    P->fwd = s_forward;
+    P->fwd = august_s_forward;
     P->es = 0.;
     return P;
 }

--- a/src/projections/bacon.cpp
+++ b/src/projections/bacon.cpp
@@ -20,7 +20,7 @@ PROJ_HEAD(ortel, "Ortelius Oval") "\n\tMisc Sph, no inv";
 PROJ_HEAD(bacon, "Bacon Globular") "\n\tMisc Sph, no inv";
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY bacon_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 	double ax, f;
@@ -50,7 +50,7 @@ PJ *PROJECTION(bacon) {
 	Q->bacn = 1;
 	Q->ortl = 0;
 	P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = bacon_s_forward;
     return P;
 }
 
@@ -63,7 +63,7 @@ PJ *PROJECTION(apian) {
 
 	Q->bacn = Q->ortl = 0;
 	P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = bacon_s_forward;
     return P;
 }
 
@@ -77,6 +77,6 @@ PJ *PROJECTION(ortel) {
 	Q->bacn = 0;
 	Q->ortl = 1;
 	P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = bacon_s_forward;
     return P;
 }

--- a/src/projections/bertin1953.cpp
+++ b/src/projections/bertin1953.cpp
@@ -27,7 +27,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {
+static PJ_XY bertin1953_s_forward (PJ_LP lp, PJ *P) {
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -89,7 +89,7 @@ PJ *PROJECTION(bertin1953) {
     Q->sin_delta_gamma = 0.;
 
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = bertin1953_s_forward;
 
     return P;
 }

--- a/src/projections/bipc.cpp
+++ b/src/projections/bipc.cpp
@@ -36,7 +36,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY bipc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cphi, sphi, tphi, t, al, Az, z, Av, cdlam, sdlam, r;
@@ -113,7 +113,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP bipc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t, r, rp, rl, al, z = 0.0, fAz, Az, s, c, Av;
@@ -169,8 +169,8 @@ PJ *PROJECTION(bipc) {
     P->opaque = Q;
 
     Q->noskew = pj_param(P->ctx, P->params, "bns").i;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = bipc_s_inverse;
+    P->fwd = bipc_s_forward;
     P->es = 0.;
     return P;
 }

--- a/src/projections/boggs.cpp
+++ b/src/projections/boggs.cpp
@@ -12,7 +12,7 @@ PROJ_HEAD(boggs, "Boggs Eumorphic") "\n\tPCyl, no inv, Sph";
 # define FYC	0.49931
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY boggs_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	double theta, th1, c;
 	int i;
@@ -39,6 +39,6 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(boggs) {
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = boggs_s_forward;
     return P;
 }

--- a/src/projections/bonne.cpp
+++ b/src/projections/bonne.cpp
@@ -20,7 +20,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY bonne_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rh, E, c;
@@ -38,7 +38,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY bonne_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double E, rh;
@@ -53,7 +53,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP bonne_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rh;
@@ -72,7 +72,7 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP bonne_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double s, rh;
@@ -125,15 +125,15 @@ PJ *PROJECTION(bonne) {
         Q->m1 = pj_mlfn(Q->phi1, Q->am1 = sin(Q->phi1),
             c = cos(Q->phi1), Q->en);
         Q->am1 = c / (sqrt(1. - P->es * Q->am1 * Q->am1) * Q->am1);
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = bonne_e_inverse;
+        P->fwd = bonne_e_forward;
     } else {
         if (fabs(Q->phi1) + EPS10 >= M_HALFPI)
             Q->cphi1 = 0.;
         else
             Q->cphi1 = 1. / tan(Q->phi1);
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = bonne_s_inverse;
+        P->fwd = bonne_s_forward;
     }
     return P;
 }

--- a/src/projections/calcofi.cpp
+++ b/src/projections/calcofi.cpp
@@ -35,7 +35,7 @@ whatever ellipsoid is provided. */
 #define ROTATION_ANGLE 0.52359877559829882 /*CalCOFI angle of 30 deg in rad */
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY calcofi_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     double oy; /* pt O y value in Mercator */
     double l1; /* l1 and l2 are distances calculated using trig that sum
@@ -67,7 +67,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY calcofi_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double oy;
     double l1;
@@ -93,7 +93,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP calcofi_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double ry;     /* y value of point r */
     double oymctr; /* Mercator-transformed y value of point O */
@@ -116,7 +116,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP calcofi_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double ry;
     double oymctr;
@@ -153,11 +153,11 @@ PJ *PROJECTION(calcofi) {
     P->over = 1;
 
     if (P->es != 0.0) { /* ellipsoid */
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = calcofi_e_inverse;
+        P->fwd = calcofi_e_forward;
     } else { /* sphere */
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = calcofi_s_inverse;
+        P->fwd = calcofi_s_forward;
     }
     return P;
 }

--- a/src/projections/cass.cpp
+++ b/src/projections/cass.cpp
@@ -25,7 +25,7 @@ struct pj_opaque {
 
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY cass_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     double n, t, a1, c, a2, tn;
     PJ_XY xy = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
@@ -47,7 +47,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY cass_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     xy.x  =  asin (cos (lp.phi) * sin (lp.lam));
     xy.y  =  atan2 (tan (lp.phi), cos (lp.lam)) - P->phi0;
@@ -55,7 +55,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP cass_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     double n, t, r, dd, d2, tn, ph1;
     PJ_LP lp = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
@@ -76,7 +76,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP cass_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double dd;
     lp.phi = asin(sin(dd = xy.y + P->phi0) * cos(xy.x));
@@ -101,8 +101,8 @@ PJ *PROJECTION(cass) {
 
     /* Spheroidal? */
     if (0==P->es) {
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = cass_s_inverse;
+        P->fwd = cass_s_forward;
         return P;
     }
 
@@ -117,8 +117,8 @@ PJ *PROJECTION(cass) {
         return pj_default_destructor (P, ENOMEM);
 
     static_cast<struct pj_opaque*>(P->opaque)->m0 = pj_mlfn (P->phi0,  sin (P->phi0),  cos (P->phi0),  static_cast<struct pj_opaque*>(P->opaque)->en);
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = cass_e_inverse;
+    P->fwd = cass_e_forward;
 
     return P;
 }

--- a/src/projections/cc.cpp
+++ b/src/projections/cc.cpp
@@ -9,7 +9,7 @@ PROJ_HEAD(cc, "Central Cylindrical") "\n\tCyl, Sph";
 #define EPS10 1.e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY cc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     if (fabs (fabs(lp.phi) - M_HALFPI) <= EPS10) {
         proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
@@ -21,7 +21,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP cc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
     lp.phi = atan(xy.y);
@@ -34,8 +34,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(cc) {
     P->es = 0.;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = cc_s_inverse;
+    P->fwd = cc_s_forward;
 
     return P;
 }

--- a/src/projections/ccon.cpp
+++ b/src/projections/ccon.cpp
@@ -43,7 +43,7 @@ PROJ_HEAD(ccon, "Central Conic")
 
 
 
-static PJ_XY forward (PJ_LP lp, PJ *P) {
+static PJ_XY ccon_forward (PJ_LP lp, PJ *P) {
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double r;
@@ -56,7 +56,7 @@ static PJ_XY forward (PJ_LP lp, PJ *P) {
 }
 
 
-static PJ_LP inverse (PJ_XY xy, PJ *P) {
+static PJ_LP ccon_inverse (PJ_XY xy, PJ *P) {
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -100,8 +100,8 @@ PJ *PROJECTION(ccon) {
     Q->ctgphi1 = Q->cosphi1/Q->sinphi1;
 
 
-    P->inv = inverse;
-    P->fwd = forward;
+    P->inv = ccon_inverse;
+    P->fwd = ccon_forward;
 
     return P;
 }

--- a/src/projections/cea.cpp
+++ b/src/projections/cea.cpp
@@ -17,7 +17,7 @@ PROJ_HEAD(cea, "Equal Area Cylindrical") "\n\tCyl, Sph&Ell\n\tlat_ts=";
 # define EPS    1e-10
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY cea_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     xy.x = P->k0 * lp.lam;
     xy.y = 0.5 * pj_qsfn (sin (lp.phi), P->e, P->one_es) / P->k0;
@@ -25,7 +25,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY cea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     xy.x = P->k0 * lp.lam;
     xy.y = sin(lp.phi) / P->k0;
@@ -33,7 +33,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP cea_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     lp.phi = pj_authlat(asin( 2. * xy.y * P->k0 / static_cast<struct pj_opaque*>(P->opaque)->qp), static_cast<struct pj_opaque*>(P->opaque)->apa);
     lp.lam = xy.x / P->k0;
@@ -41,7 +41,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP cea_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double t;
 
@@ -92,11 +92,11 @@ PJ *PROJECTION(cea) {
             return pj_default_destructor(P, ENOMEM);
 
         Q->qp = pj_qsfn(1., P->e, P->one_es);
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = cea_e_inverse;
+        P->fwd = cea_e_forward;
     } else {
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = cea_s_inverse;
+        P->fwd = cea_s_forward;
     }
 
     return P;

--- a/src/projections/chamb.cpp
+++ b/src/projections/chamb.cpp
@@ -54,7 +54,7 @@ static double lc(projCtx ctx, double b,double c,double a) {
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY chamb_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double sinphi, cosphi, a;
@@ -135,7 +135,7 @@ PJ *PROJECTION(chamb) {
     Q->p.x = Q->c[2].p.x = Q->c[0].p.x + Q->c[2].v.r * cos(Q->beta_0);
 
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = chamb_s_forward;
 
     return P;
 }

--- a/src/projections/collg.cpp
+++ b/src/projections/collg.cpp
@@ -11,7 +11,7 @@ PROJ_HEAD(collg, "Collignon") "\n\tPCyl, Sph";
 #define ONEEPS  1.0000001
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY collg_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
     if ((xy.y = 1. - sin(lp.phi)) <= 0.)
@@ -24,7 +24,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP collg_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     lp.phi = xy.y / FYC - 1.;
     if (fabs(lp.phi = 1. - lp.phi * lp.phi) < 1.)
@@ -46,8 +46,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(collg) {
     P->es = 0.0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = collg_s_inverse;
+    P->fwd = collg_s_forward;
 
     return P;
 }

--- a/src/projections/comill.cpp
+++ b/src/projections/comill.cpp
@@ -26,7 +26,7 @@ PROJ_HEAD(comill, "Compact Miller") "\n\tCyl, Sph";
 /* Not sure at all of the appropriate number for MAX_ITER... */
 #define MAX_ITER 100
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY comill_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double lat_sq;
 
@@ -39,7 +39,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP comill_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double yc, tol, y2, f, fder;
     int i;
@@ -78,8 +78,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(comill) {
     P->es = 0;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = comill_s_inverse;
+    P->fwd = comill_s_forward;
 
     return P;
 }

--- a/src/projections/crast.cpp
+++ b/src/projections/crast.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(crast, "Craster Parabolic (Putnins P4)") "\n\tPCyl, Sph";
 #define THIRD   0.333333333333333333
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY crast_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
     lp.phi *= THIRD;
@@ -23,7 +23,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP crast_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
     lp.phi = 3. * asin(xy.y * RYM);
@@ -34,8 +34,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(crast) {
     P->es = 0.0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = crast_s_inverse;
+    P->fwd = crast_s_forward;
 
     return P;
 }

--- a/src/projections/denoy.cpp
+++ b/src/projections/denoy.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(denoy, "Denoyer Semi-Elliptical") "\n\tPCyl, no inv, Sph";
 #define D5  0.03
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {            /* Spheroidal, forward */
+static PJ_XY denoy_s_forward (PJ_LP lp, PJ *P) {            /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     (void) P;
     xy.y = lp.phi;
@@ -27,7 +27,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {            /* Spheroidal, forward */
 
 PJ *PROJECTION(denoy) {
     P->es = 0.0;
-    P->fwd = s_forward;
+    P->fwd = denoy_s_forward;
 
     return P;
 }

--- a/src/projections/eck1.cpp
+++ b/src/projections/eck1.cpp
@@ -9,7 +9,7 @@ PROJ_HEAD(eck1, "Eckert I") "\n\tPCyl, Sph";
 #define RP  0.31830988618379067154
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eck1_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -20,7 +20,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eck1_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
 
@@ -34,8 +34,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(eck1) {
     P->es = 0.0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eck1_s_inverse;
+    P->fwd = eck1_s_forward;
 
     return P
 ;

--- a/src/projections/eck2.cpp
+++ b/src/projections/eck2.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(eck2, "Eckert II") "\n\tPCyl, Sph";
 #define ONEEPS  1.0000001
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eck2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -25,7 +25,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eck2_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
 
@@ -49,8 +49,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(eck2) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eck2_s_inverse;
+    P->fwd = eck2_s_forward;
 
     return P;
 }

--- a/src/projections/eck3.cpp
+++ b/src/projections/eck3.cpp
@@ -18,7 +18,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eck3_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -28,7 +28,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eck3_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double denominator;
@@ -45,8 +45,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 static PJ *setup(PJ *P) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eck3_s_inverse;
+    P->fwd = eck3_s_forward;
     return P;
 }
 

--- a/src/projections/eck4.cpp
+++ b/src/projections/eck4.cpp
@@ -16,7 +16,7 @@ PROJ_HEAD(eck4, "Eckert IV") "\n\tPCyl, Sph";
 #define NITER   6
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eck4_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double p, V, s, c;
     int i;
@@ -44,7 +44,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eck4_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double c;
 
@@ -57,8 +57,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(eck4) {
     P->es = 0.0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eck4_s_inverse;
+    P->fwd = eck4_s_forward;
 
     return P;
 }

--- a/src/projections/eck5.cpp
+++ b/src/projections/eck5.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(eck5, "Eckert V") "\n\tPCyl, Sph";
 #define RYF 1.13375401361911319568
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eck5_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
     xy.x = XF * (1. + cos(lp.phi)) * lp.lam;
@@ -23,7 +23,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eck5_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
     lp.lam = RXF * xy.x / (1. + cos( lp.phi = RYF * xy.y));
@@ -34,8 +34,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(eck5) {
     P->es = 0.0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eck5_s_inverse;
+    P->fwd = eck5_s_forward;
 
     return P;
 }

--- a/src/projections/eqc.cpp
+++ b/src/projections/eqc.cpp
@@ -16,7 +16,7 @@ PROJ_HEAD(eqc, "Equidistant Cylindrical (Plate Carree)")
     "\n\tCyl, Sph\n\tlat_ts=[, lat_0=0]";
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY eqc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -27,7 +27,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP eqc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -46,8 +46,8 @@ PJ *PROJECTION(eqc) {
 
     if ((Q->rc = cos(pj_param(P->ctx, P->params, "rlat_ts").f)) <= 0.)
         return pj_default_destructor (P, PJD_ERR_LAT_TS_LARGER_THAN_90);
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = eqc_s_inverse;
+    P->fwd = eqc_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/eqdc.cpp
+++ b/src/projections/eqdc.cpp
@@ -25,7 +25,7 @@ PROJ_HEAD(eqdc, "Equidistant Conic")
 # define EPS10  1.e-10
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY eqdc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -38,7 +38,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP eqdc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -121,8 +121,8 @@ PJ *PROJECTION(eqdc) {
         Q->rho0 = Q->c - P->phi0;
     }
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = eqdc_e_inverse;
+    P->fwd = eqdc_e_forward;
 
     return P;
 }

--- a/src/projections/eqearth.cpp
+++ b/src/projections/eqearth.cpp
@@ -40,7 +40,7 @@ struct pj_opaque {
 };
 } // anonymous namespace
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {           /* Ellipsoidal/spheroidal, forward */
+static PJ_XY eqearth_e_forward (PJ_LP lp, PJ *P) {           /* Ellipsoidal/spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double sbeta;
@@ -74,7 +74,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {           /* Ellipsoidal/spheroidal, 
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {           /* Ellipsoidal/spheroidal, inverse */
+static PJ_LP eqearth_e_inverse (PJ_XY xy, PJ *P) {           /* Ellipsoidal/spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double yc, y2, y6;
@@ -148,8 +148,8 @@ PJ *PROJECTION(eqearth) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = Q;
     P->destructor = destructor;
-    P->fwd = e_forward;
-    P->inv = e_inverse;
+    P->fwd = eqearth_e_forward;
+    P->inv = eqearth_e_inverse;
     Q->rqda = 1.0;
 
     /* Ellipsoidal case */

--- a/src/projections/fahey.cpp
+++ b/src/projections/fahey.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(fahey, "Fahey") "\n\tPcyl, Sph";
 #define TOL 1e-6
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY fahey_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -21,7 +21,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP fahey_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
 
@@ -35,8 +35,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(fahey) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = fahey_s_inverse;
+    P->fwd = fahey_s_forward;
 
     return P;
 }

--- a/src/projections/fouc_s.cpp
+++ b/src/projections/fouc_s.cpp
@@ -18,7 +18,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY fouc_s_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t;
@@ -30,7 +30,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP fouc_s_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double V;
@@ -66,7 +66,7 @@ PJ *PROJECTION(fouc_s) {
 
     Q->n1 = 1. - Q->n;
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = fouc_s_s_inverse;
+    P->fwd = fouc_s_s_forward;
     return P;
 }

--- a/src/projections/gall.cpp
+++ b/src/projections/gall.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(gall, "Gall (Gall Stereographic)") "\n\tCyl, Sph";
 #define RXF 1.41421356237309504880
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY gall_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -24,7 +24,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP gall_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
 
@@ -38,8 +38,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(gall) {
     P->es = 0.0;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = gall_s_inverse;
+    P->fwd = gall_s_forward;
 
     return P;
 }

--- a/src/projections/geos.cpp
+++ b/src/projections/geos.cpp
@@ -52,7 +52,7 @@ struct pj_opaque {
 PROJ_HEAD(geos, "Geostationary Satellite View") "\n\tAzi, Sph&Ell\n\th=";
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY geos_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double Vx, Vy, Vz, tmp;
@@ -82,7 +82,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY geos_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double r, Vx, Vy, Vz, tmp;
@@ -118,7 +118,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP geos_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double Vx, Vy, Vz, a, b, det, k;
@@ -155,7 +155,7 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP geos_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double Vx, Vy, Vz, a, b, det, k;
@@ -226,12 +226,12 @@ PJ *PROJECTION(geos) {
         Q->radius_p      = sqrt (P->one_es);
         Q->radius_p2     = P->one_es;
         Q->radius_p_inv2 = P->rone_es;
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = geos_e_inverse;
+        P->fwd = geos_e_forward;
     } else {
         Q->radius_p = Q->radius_p2 = Q->radius_p_inv2 = 1.0;
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = geos_s_inverse;
+        P->fwd = geos_s_forward;
     }
 
     return P;

--- a/src/projections/gins8.cpp
+++ b/src/projections/gins8.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(gins8, "Ginsburg VIII (TsNIIGAiK)") "\n\tPCyl, Sph, no inv";
 #define C12 0.08333333333333333
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY gins8_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double t = lp.phi * lp.phi;
     (void) P;
@@ -27,7 +27,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 PJ *PROJECTION(gins8) {
     P->es = 0.0;
     P->inv = nullptr;
-    P->fwd = s_forward;
+    P->fwd = gins8_s_forward;
 
     return P;
 }

--- a/src/projections/gn_sinu.cpp
+++ b/src/projections/gn_sinu.cpp
@@ -23,7 +23,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY gn_sinu_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     double s, c;
 
@@ -33,7 +33,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP gn_sinu_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double s;
 
@@ -50,7 +50,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY gn_sinu_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -80,7 +80,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP gn_sinu_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -109,8 +109,8 @@ static PJ *destructor (PJ *P, int errlev) {                        /* Destructor
 static void setup(PJ *P) {
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = gn_sinu_s_inverse;
+    P->fwd = gn_sinu_s_forward;
 
     Q->C_x = (Q->C_y = sqrt((Q->m + 1.) / Q->n))/(Q->m + 1.);
 }
@@ -127,8 +127,8 @@ PJ *PROJECTION(sinu) {
         return pj_default_destructor (P, ENOMEM);
 
     if (P->es != 0.0) {
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = gn_sinu_e_inverse;
+        P->fwd = gn_sinu_e_forward;
     } else {
         Q->n = 1.;
         Q->m = 0.;

--- a/src/projections/gnom.cpp
+++ b/src/projections/gnom.cpp
@@ -29,7 +29,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY gnom_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi;
@@ -77,7 +77,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP gnom_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  rh, cosz, sinz;
@@ -139,8 +139,8 @@ PJ *PROJECTION(gnom) {
         Q->cosph0 = cos(P->phi0);
     }
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = gnom_s_inverse;
+    P->fwd = gnom_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/goode.cpp
+++ b/src/projections/goode.cpp
@@ -21,7 +21,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY goode_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -35,7 +35,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP goode_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -77,8 +77,8 @@ PJ *PROJECTION(goode) {
     if (!(Q->sinu = pj_sinu(Q->sinu)) || !(Q->moll = pj_moll(Q->moll)))
         return destructor (P, ENOMEM);
 
-    P->fwd = s_forward;
-    P->inv = s_inverse;
+    P->fwd = goode_s_forward;
+    P->inv = goode_s_inverse;
 
     return P;
 }

--- a/src/projections/gstmerc.cpp
+++ b/src/projections/gstmerc.cpp
@@ -22,7 +22,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY gstmerc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double L, Ls, sinLs1, Ls1;
@@ -38,7 +38,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP gstmerc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double L, LC, sinC;
@@ -68,8 +68,8 @@ PJ *PROJECTION(gstmerc) {
     Q->XS = 0;
     Q->YS = -1.0 * Q->n2 * Q->phic;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = gstmerc_s_inverse;
+    P->fwd = gstmerc_s_forward;
 
     return P;
 }

--- a/src/projections/hammer.cpp
+++ b/src/projections/hammer.cpp
@@ -19,7 +19,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY hammer_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cosphi, d;
@@ -38,7 +38,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP hammer_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double z;
@@ -77,8 +77,8 @@ PJ *PROJECTION(hammer) {
     Q->m /= Q->w;
 
     P->es = 0.;
-    P->fwd = s_forward;
-    P->inv = s_inverse;
+    P->fwd = hammer_s_forward;
+    P->inv = hammer_s_inverse;
 
     return P;
 }

--- a/src/projections/hatano.cpp
+++ b/src/projections/hatano.cpp
@@ -22,7 +22,7 @@ PROJ_HEAD(hatano, "Hatano Asymmetrical Equal Area") "\n\tPCyl, Sph";
 #define RXC 1.17647058823529411764
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY hatano_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double th1, c;
     int i;
@@ -40,7 +40,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP hatano_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double th;
 
@@ -76,8 +76,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(hatano) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = hatano_s_inverse;
+    P->fwd = hatano_s_forward;
 
     return P;
 }

--- a/src/projections/healpix.cpp
+++ b/src/projections/healpix.cpp
@@ -281,7 +281,7 @@ static PJ_XY healpix_sphere(PJ_LP lp) {
 /**
  * Return the inverse of healpix_sphere().
 **/
-static PJ_LP healpix_sphere_inverse(PJ_XY xy) {
+static PJ_LP healpix_spherhealpix_e_inverse(PJ_XY xy) {
     PJ_LP lp;
     double x = xy.x;
     double y = xy.y;
@@ -532,7 +532,7 @@ static PJ_LP s_healpix_inverse(PJ_XY xy, PJ *P) { /* sphere */
         pj_ctx_set_errno(P->ctx, PJD_ERR_INVALID_X_OR_Y);
         return lp;
     }
-    return healpix_sphere_inverse(xy);
+    return healpix_spherhealpix_e_inverse(xy);
 }
 
 
@@ -546,7 +546,7 @@ static PJ_LP e_healpix_inverse(PJ_XY xy, PJ *P) { /* ellipsoid */
         pj_ctx_set_errno(P->ctx, PJD_ERR_INVALID_X_OR_Y);
         return lp;
     }
-    lp = healpix_sphere_inverse(xy);
+    lp = healpix_spherhealpix_e_inverse(xy);
     lp.phi = auth_lat(P, lp.phi, 1);
     return lp;
 }
@@ -581,7 +581,7 @@ static PJ_LP s_rhealpix_inverse(PJ_XY xy, PJ *P) { /* sphere */
         return lp;
     }
     xy = combine_caps(xy.x, xy.y, Q->north_square, Q->south_square, 1);
-    return healpix_sphere_inverse(xy);
+    return healpix_spherhealpix_e_inverse(xy);
 }
 
 
@@ -597,7 +597,7 @@ static PJ_LP e_rhealpix_inverse(PJ_XY xy, PJ *P) { /* ellipsoid */
         return lp;
     }
     xy = combine_caps(xy.x, xy.y, Q->north_square, Q->south_square, 1);
-    lp = healpix_sphere_inverse(xy);
+    lp = healpix_spherhealpix_e_inverse(xy);
     lp.phi = auth_lat(P, lp.phi, 1);
     return lp;
 }

--- a/src/projections/igh.cpp
+++ b/src/projections/igh.cpp
@@ -41,7 +41,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY igh_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int z;
@@ -74,7 +74,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP igh_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     const double y90 = Q->dy0 + sqrt(2.0); /* lt=90 corresponds to y=y0+sqrt(2) */
@@ -219,8 +219,8 @@ PJ *PROJECTION(igh) {
     SETUP(11, moll,   d20, -Q->dy0,   d20);
     SETUP(12, moll,  d140, -Q->dy0,  d140);
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = igh_s_inverse;
+    P->fwd = igh_s_forward;
     P->destructor = destructor;
     P->es = 0.;
 

--- a/src/projections/imw_p.cpp
+++ b/src/projections/imw_p.cpp
@@ -97,14 +97,14 @@ static PJ_XY loc_for(PJ_LP lp, PJ *P, double *yc) {
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY imw_p_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     double yc;
     PJ_XY xy = loc_for(lp, P, &yc);
     return (xy);
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP imw_p_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     PJ_XY t;
@@ -219,8 +219,8 @@ PJ *PROJECTION(imw_p) {
     Q->Pp = (m2 * x1 - m1 * x2) * t;
     Q->Qp = (x2 - x1) * t;
 
-    P->fwd = e_forward;
-    P->inv = e_inverse;
+    P->fwd = imw_p_e_forward;
+    P->inv = imw_p_e_inverse;
     P->destructor = destructor;
 
     return P;

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -1014,7 +1014,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY isea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     struct isea_pt out;
@@ -1045,7 +1045,7 @@ PJ *PROJECTION(isea) {
     P->opaque = Q;
 
 
-    P->fwd = s_forward;
+    P->fwd = isea_s_forward;
     isea_grid_init(&Q->dgg);
 
     Q->dgg.output = ISEA_PLANE;

--- a/src/projections/krovak.cpp
+++ b/src/projections/krovak.cpp
@@ -103,7 +103,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {                /* Ellipsoidal, forward */
+static PJ_XY krovak_e_forward (PJ_LP lp, PJ *P) {                /* Ellipsoidal, forward */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     PJ_XY xy = {0.0,0.0};
 
@@ -137,7 +137,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {                /* Ellipsoidal, forwar
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {                /* Ellipsoidal, inverse */
+static PJ_LP krovak_e_inverse (PJ_XY xy, PJ *P) {                /* Ellipsoidal, inverse */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     PJ_LP lp = {0.0,0.0};
 
@@ -232,8 +232,8 @@ PJ *PROJECTION(krovak) {
     Q->rho0 = P->k0 * n0 / tan(S0);
     Q->ad = M_PI_2 - UQ;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = krovak_e_inverse;
+    P->fwd = krovak_e_forward;
 
     return P;
 }

--- a/src/projections/labrd.cpp
+++ b/src/projections/labrd.cpp
@@ -16,7 +16,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY labrd_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double V1, V2, ps, sinps, cosps, sinps2, cosps2;
@@ -49,7 +49,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP labrd_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     /* t = 0.0 optimization is to avoid a false positive cppcheck warning */
@@ -130,8 +130,8 @@ PJ *PROJECTION(labrd) {
     Q->Cc = 3. * (Q->Ca * Q->Ca - Q->Cb * Q->Cb);
     Q->Cd = 6. * Q->Ca * Q->Cb;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = labrd_e_inverse;
+    P->fwd = labrd_e_forward;
 
     return P;
 }

--- a/src/projections/laea.cpp
+++ b/src/projections/laea.cpp
@@ -32,7 +32,7 @@ struct pj_opaque {
 
 #define EPS10   1.e-10
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY laea_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double coslam, sinlam, sinphi, q, sinb=0.0, cosb=0.0, b=0.0;
@@ -94,7 +94,7 @@ eqcon:
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY laea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi;
@@ -136,7 +136,7 @@ oblcon:
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP laea_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cCe, sCe, q, rho, ab=0.0;
@@ -185,7 +185,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP laea_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  cosz=0.0, rh, sinz=0.0;
@@ -287,15 +287,15 @@ PJ *PROJECTION(laea) {
             Q->xmf *= Q->dd;
             break;
         }
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = laea_e_inverse;
+        P->fwd = laea_e_forward;
     } else {
         if (Q->mode == OBLIQ) {
             Q->sinb1 = sin(P->phi0);
             Q->cosb1 = cos(P->phi0);
         }
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = laea_s_inverse;
+        P->fwd = laea_s_forward;
     }
 
     return P;

--- a/src/projections/lagrng.cpp
+++ b/src/projections/lagrng.cpp
@@ -21,7 +21,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY lagrng_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double v, c;
@@ -45,7 +45,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP lagrng_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double c, x2, y2p, y2m;
@@ -93,8 +93,8 @@ PJ *PROJECTION(lagrng) {
     Q->a2 = Q->a1 * Q->a1;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = lagrng_s_inverse;
+    P->fwd = lagrng_s_forward;
 
     return P;
 }

--- a/src/projections/larr.cpp
+++ b/src/projections/larr.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(larr, "Larrivee") "\n\tMisc Sph, no inv";
 #define SIXTH .16666666666666666
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY larr_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -23,7 +23,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 PJ *PROJECTION(larr) {
 
     P->es = 0;
-    P->fwd = s_forward;
+    P->fwd = larr_s_forward;
 
     return P;
 }

--- a/src/projections/lask.cpp
+++ b/src/projections/lask.cpp
@@ -17,7 +17,7 @@ PROJ_HEAD(lask, "Laskowski") "\n\tMisc Sph, no inv";
 #define b05 -0.0491032
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY lask_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double l2, p2;
     (void) P;
@@ -33,7 +33,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(lask) {
 
-    P->fwd = s_forward;
+    P->fwd = lask_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/lcc.cpp
+++ b/src/projections/lcc.cpp
@@ -20,7 +20,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY lcc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0., 0.};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rho;
@@ -43,7 +43,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP lcc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0., 0.};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rho;
@@ -144,8 +144,8 @@ PJ *PROJECTION(lcc) {
             Q->c * pow(tan(M_FORTPI + .5 * P->phi0), -Q->n);
     }
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = lcc_e_inverse;
+    P->fwd = lcc_e_forward;
 
     return P;
 }

--- a/src/projections/lcca.cpp
+++ b/src/projections/lcca.cpp
@@ -80,7 +80,7 @@ static double fSp(double S, double C) {       /* deriv of fs */
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY lcca_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double S, r, dr;
@@ -94,7 +94,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP lcca_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double theta, dr, S, dif;
@@ -156,8 +156,8 @@ PJ *PROJECTION(lcca) {
     Q->r0 = N0 / tan0;
     Q->C = 1. / (6. * R0 * N0);
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = lcca_e_inverse;
+    P->fwd = lcca_e_forward;
     P->destructor = destructor;
 
     return P;

--- a/src/projections/loxim.cpp
+++ b/src/projections/loxim.cpp
@@ -19,7 +19,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY loxim_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -37,7 +37,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP loxim_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -69,8 +69,8 @@ PJ *PROJECTION(loxim) {
 
     Q->tanphi1 = tan(M_FORTPI + 0.5 * Q->phi1);
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = loxim_s_inverse;
+    P->fwd = loxim_s_forward;
     P->es = 0.;
 
    return P;

--- a/src/projections/lsat.cpp
+++ b/src/projections/lsat.cpp
@@ -44,7 +44,7 @@ static void seraz0(double lam, double mult, PJ *P) {
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY lsat_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int l, nn;
@@ -107,7 +107,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP lsat_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int nn;
@@ -208,8 +208,8 @@ PJ *PROJECTION(lsat) {
     Q->c1 /= 15.;
     Q->c3 /= 45.;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = lsat_e_inverse;
+    P->fwd = lsat_e_forward;
 
     return P;
 }

--- a/src/projections/mbt_fps.cpp
+++ b/src/projections/mbt_fps.cpp
@@ -16,7 +16,7 @@ PROJ_HEAD(mbt_fps, "McBryde-Thomas Flat-Pole Sine (No. 2)") "\n\tCyl, Sph";
 #define C_y 1.44492
 #define C1_2 0.33333333333333333333333333
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY mbt_fps_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double k, V, t;
     int i;
@@ -37,7 +37,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP mbt_fps_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double t;
 
@@ -51,8 +51,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(mbt_fps) {
 
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = mbt_fps_s_inverse;
+    P->fwd = mbt_fps_s_forward;
 
     return P;
 }

--- a/src/projections/mbtfpp.cpp
+++ b/src/projections/mbtfpp.cpp
@@ -15,7 +15,7 @@ PROJ_HEAD(mbtfpp, "McBride-Thomas Flat-Polar Parabolic") "\n\tCyl, Sph";
 #define ONEEPS  1.0000001
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY mbtfpp_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -26,7 +26,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP mbtfpp_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 
     lp.phi = xy.y / FYC;
@@ -58,8 +58,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(mbtfpp) {
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = mbtfpp_s_inverse;
+    P->fwd = mbtfpp_s_forward;
 
     return P;
 }

--- a/src/projections/mbtfpq.cpp
+++ b/src/projections/mbtfpq.cpp
@@ -18,7 +18,7 @@ PROJ_HEAD(mbtfpq, "McBryde-Thomas Flat-Polar Quartic") "\n\tCyl, Sph";
 #define RXC 3.20041258076506210122
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY mbtfpq_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double th1, c;
     int i;
@@ -36,7 +36,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP mbtfpq_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double t;
 
@@ -67,8 +67,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(mbtfpq) {
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = mbtfpq_s_inverse;
+    P->fwd = mbtfpq_s_forward;
 
     return P;
 }

--- a/src/projections/merc.cpp
+++ b/src/projections/merc.cpp
@@ -19,7 +19,7 @@ static double logtanpfpim1(double x) {       /* log(tan(x/2 + M_FORTPI)) */
     return log(tan(M_FORTPI + .5 * x));
 }
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY merc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) {
         proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
@@ -31,7 +31,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY merc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     if (fabs(fabs(lp.phi) - M_HALFPI) <= EPS10) {
         proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
@@ -43,7 +43,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP merc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     if ((lp.phi = pj_phi2(P->ctx, exp(- xy.y / P->k0), P->e)) == HUGE_VAL) {
         proj_errno_set(P, PJD_ERR_TOLERANCE_CONDITION);
@@ -54,7 +54,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP merc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     lp.phi = atan(sinh(xy.y / P->k0));
     lp.lam = xy.x / P->k0;
@@ -75,15 +75,15 @@ PJ *PROJECTION(merc) {
     if (P->es != 0.0) { /* ellipsoid */
         if (is_phits)
             P->k0 = pj_msfn(sin(phits), cos(phits), P->es);
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = merc_e_inverse;
+        P->fwd = merc_e_forward;
     }
 
     else { /* sphere */
         if (is_phits)
             P->k0 = cos(phits);
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = merc_s_inverse;
+        P->fwd = merc_s_forward;
     }
 
     return P;
@@ -94,7 +94,7 @@ PJ *PROJECTION(webmerc) {
     /* Overriding k_0 with fixed parameter */
     P->k0 = 1.0;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = merc_s_inverse;
+    P->fwd = merc_s_forward;
     return P;
 }

--- a/src/projections/mill.cpp
+++ b/src/projections/mill.cpp
@@ -7,7 +7,7 @@
 
 PROJ_HEAD(mill, "Miller Cylindrical") "\n\tCyl, Sph";
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY mill_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -18,7 +18,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP mill_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     (void) P;
 
@@ -31,8 +31,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(mill) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = mill_s_inverse;
+    P->fwd = mill_s_forward;
 
     return P;
 }

--- a/src/projections/misrsom.cpp
+++ b/src/projections/misrsom.cpp
@@ -62,7 +62,7 @@ static void seraz0(double lam, double mult, PJ *P) {
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY misrsom_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int l, nn;
@@ -123,7 +123,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP misrsom_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int nn;
@@ -216,8 +216,8 @@ PJ *PROJECTION(misrsom) {
     Q->c1 /= 15.;
     Q->c3 /= 45.;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = misrsom_e_inverse;
+    P->fwd = misrsom_e_forward;
 
    return P;
 }

--- a/src/projections/mod_ster.cpp
+++ b/src/projections/mod_ster.cpp
@@ -22,7 +22,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY mod_ster_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double sinlon, coslon, esphi, chi, schi, cchi, s;
@@ -51,7 +51,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP mod_ster_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     int nn;
@@ -119,8 +119,8 @@ static PJ *setup(PJ *P) { /* general initialization */
         chio = P->phi0;
     Q->schio = sin(chio);
     Q->cchio = cos(chio);
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = mod_ster_e_inverse;
+    P->fwd = mod_ster_e_forward;
 
     return P;
 }

--- a/src/projections/moll.cpp
+++ b/src/projections/moll.cpp
@@ -20,7 +20,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY moll_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double k, V;
@@ -43,7 +43,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP moll_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     lp.phi = aasin(P->ctx, xy.y / Q->C_y);
@@ -70,8 +70,8 @@ static PJ * setup(PJ *P, double p) {
     Q->C_y = r / sp;
     Q->C_p = p2 + sin(p2);
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = moll_s_inverse;
+    P->fwd = moll_s_forward;
     return P;
 }
 
@@ -106,8 +106,8 @@ PJ *PROJECTION(wag5) {
     Q->C_y = 1.65014;
     Q->C_p = 3.00896;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = moll_s_inverse;
+    P->fwd = moll_s_forward;
 
     return P;
 }

--- a/src/projections/natearth.cpp
+++ b/src/projections/natearth.cpp
@@ -42,7 +42,7 @@ PROJ_HEAD(natearth, "Natural Earth") "\n\tPCyl, Sph";
 #define MAX_ITER 100
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY natearth_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double phi2, phi4;
     (void) P;
@@ -55,7 +55,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP natearth_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double yc, tol, y2, y4, f, fder;
     int i;
@@ -94,8 +94,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(natearth) {
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = natearth_s_inverse;
+    P->fwd = natearth_s_forward;
 
     return P;
 }

--- a/src/projections/natearth2.cpp
+++ b/src/projections/natearth2.cpp
@@ -34,7 +34,7 @@ PROJ_HEAD(natearth2, "Natural Earth 2") "\n\tPCyl, Sph";
 #define MAX_ITER 100
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY natearth2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double phi2, phi4, phi6;
     (void) P;
@@ -49,7 +49,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP natearth2_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double yc, tol, y2, y4, y6, f, fder;
     int i;
@@ -91,8 +91,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(natearth2) {
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = natearth2_s_inverse;
+    P->fwd = natearth2_s_forward;
 
     return P;
 }

--- a/src/projections/nell.cpp
+++ b/src/projections/nell.cpp
@@ -11,7 +11,7 @@ PROJ_HEAD(nell, "Nell") "\n\tPCyl, Sph";
 #define LOOP_TOL 1e-7
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY nell_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double k, V;
     int i;
@@ -33,7 +33,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP nell_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     lp.lam = 2. * xy.x / (1. + cos(xy.y));
     lp.phi = aasin(P->ctx,0.5 * (xy.y + sin(xy.y)));
@@ -45,8 +45,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(nell) {
 
     P->es = 0;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = nell_s_inverse;
+    P->fwd = nell_s_forward;
 
     return P;
 }

--- a/src/projections/nell_h.cpp
+++ b/src/projections/nell_h.cpp
@@ -11,7 +11,7 @@ PROJ_HEAD(nell_h, "Nell-Hammer") "\n\tPCyl, Sph";
 #define EPS 1e-7
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY nell_h_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -22,7 +22,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP nell_h_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double V, c, p;
     int i;
@@ -47,8 +47,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(nell_h) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = nell_h_s_inverse;
+    P->fwd = nell_h_s_forward;
 
     return P;
 }

--- a/src/projections/nicol.cpp
+++ b/src/projections/nicol.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(nicol, "Nicolosi Globular") "\n\tMisc Sph, no inv";
 #define EPS 1e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY nicol_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     (void) P;
 
@@ -49,7 +49,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(nicol) {
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = nicol_s_forward;
 
     return P;
 }

--- a/src/projections/nsper.cpp
+++ b/src/projections/nsper.cpp
@@ -38,7 +38,7 @@ PROJ_HEAD(tpers, "Tilted perspective") "\n\tAzi, Sph\n\ttilt= azi= h=";
 # define EPS10 1.e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY nsper_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi;
@@ -93,7 +93,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP nsper_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  rh;
@@ -165,8 +165,8 @@ static PJ *setup(PJ *P) {
     Q->rp = 1. / Q->p;
     Q->h = 1. / Q->pn1;
     Q->pfact = (Q->p + 1.) * Q->h;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = nsper_s_inverse;
+    P->fwd = nsper_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/nzmg.cpp
+++ b/src/projections/nzmg.cpp
@@ -58,7 +58,7 @@ static const double tpsi[] = { .6399175073, -.1358797613, .063294409, -.02526853
 #define Ntphi 8
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY nzmg_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     COMPLEX p;
     const double *C;
@@ -77,7 +77,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP nzmg_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     int nn, i;
     COMPLEX p, f, fp, dp;
@@ -116,8 +116,8 @@ PJ *PROJECTION(nzmg) {
     P->x0 = 2510000.;
     P->y0 = 6023150.;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = nzmg_e_inverse;
+    P->fwd = nzmg_e_forward;
 
 
     return P;

--- a/src/projections/ocea.cpp
+++ b/src/projections/ocea.cpp
@@ -19,7 +19,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY ocea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t;
@@ -34,7 +34,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP ocea_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t, s;
@@ -106,8 +106,8 @@ PJ *PROJECTION(ocea) {
     P->lam0 = lam_p + M_HALFPI;
     Q->cosphi = cos(phi_p);
     Q->sinphi = sin(phi_p);
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = ocea_s_inverse;
+    P->fwd = ocea_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/oea.cpp
+++ b/src/projections/oea.cpp
@@ -16,7 +16,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY oea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double Az, M, N, cp, sp, cl, shz;
@@ -35,7 +35,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP oea_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double N, M, xp, yp, z, Az, cz, sz, cAz;
@@ -77,8 +77,8 @@ PJ *PROJECTION(oea) {
         Q->two_r_m = 2. * Q->rm;
         Q->hm = 0.5 * Q->m;
         Q->hn = 0.5 * Q->n;
-        P->fwd = s_forward;
-        P->inv = s_inverse;
+        P->fwd = oea_s_forward;
+        P->inv = oea_s_inverse;
         P->es = 0.;
     }
 

--- a/src/projections/omerc.cpp
+++ b/src/projections/omerc.cpp
@@ -45,7 +45,7 @@ struct pj_opaque {
 #define EPS 1.e-10
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY omerc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double S, T, U, V, W, temp, u, v;
@@ -84,7 +84,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP omerc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  u, v, Qp, Sp, Tp, Vp, Up;
@@ -238,8 +238,8 @@ PJ *PROJECTION(omerc) {
     F = 0.5 * gamma0;
     Q->v_pole_n = Q->ArB * log(tan(M_FORTPI - F));
     Q->v_pole_s = Q->ArB * log(tan(M_FORTPI + F));
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = omerc_e_inverse;
+    P->fwd = omerc_e_forward;
 
     return P;
 }

--- a/src/projections/ortho.cpp
+++ b/src/projections/ortho.cpp
@@ -32,7 +32,7 @@ static PJ_XY forward_error(PJ *P, PJ_LP lp, PJ_XY xy) {
     return xy;
 }
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY ortho_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  coslam, cosphi, sinphi;
@@ -66,7 +66,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP ortho_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  rh, cosc, sinc;
@@ -133,8 +133,8 @@ PJ *PROJECTION(ortho) {
         Q->cosph0 = cos(P->phi0);
     } else
         Q->mode = EQUIT;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = ortho_s_inverse;
+    P->fwd = ortho_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/patterson.cpp
+++ b/src/projections/patterson.cpp
@@ -61,7 +61,7 @@ PROJ_HEAD(patterson, "Patterson Cylindrical") "\n\tCyl";
 #define MAX_ITER 100
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY patterson_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double phi2;
     (void) P;
@@ -74,7 +74,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP patterson_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double yc, tol, y2, f, fder;
     int i;
@@ -111,8 +111,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(patterson) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = patterson_s_inverse;
+    P->fwd = patterson_s_forward;
 
     return P;
 }

--- a/src/projections/poly.cpp
+++ b/src/projections/poly.cpp
@@ -23,7 +23,7 @@ struct pj_opaque {
 #define ITOL 1.e-12
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY poly_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  ms, sp, cp;
@@ -42,7 +42,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY poly_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  cot, E;
@@ -60,7 +60,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP poly_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -104,7 +104,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP poly_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double B, dphi, tp;
     int i;
@@ -159,12 +159,12 @@ PJ *PROJECTION(poly) {
         if (!(Q->en = pj_enfn(P->es)))
             return pj_default_destructor (P, ENOMEM);
         Q->ml0 = pj_mlfn(P->phi0, sin(P->phi0), cos(P->phi0), Q->en);
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = poly_e_inverse;
+        P->fwd = poly_e_forward;
     } else {
         Q->ml0 = -P->phi0;
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = poly_s_inverse;
+        P->fwd = poly_s_forward;
     }
 
     return P;

--- a/src/projections/putp2.cpp
+++ b/src/projections/putp2.cpp
@@ -15,7 +15,7 @@ PROJ_HEAD(putp2, "Putnins P2") "\n\tPCyl, Sph";
 #define PI_DIV_3	1.0471975511965977
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY putp2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	double p, c, s, V;
 	int i;
@@ -41,7 +41,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP putp2_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 	double c;
 
@@ -55,8 +55,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(putp2) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp2_s_inverse;
+    P->fwd = putp2_s_forward;
 
     return P;
 }

--- a/src/projections/putp3.cpp
+++ b/src/projections/putp3.cpp
@@ -17,7 +17,7 @@ PROJ_HEAD(putp3p, "Putnins P3'") "\n\tPCyl, Sph";
 #define RPISQ   0.1013211836
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY putp3_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 
     xy.x = C * lp.lam * (1. - static_cast<struct pj_opaque*>(P->opaque)->A * lp.phi * lp.phi);
@@ -27,7 +27,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP putp3_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 
     lp.phi = xy.y / C;
@@ -46,8 +46,8 @@ PJ *PROJECTION(putp3) {
     Q->A = 4. * RPISQ;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp3_s_inverse;
+    P->fwd = putp3_s_forward;
 
     return P;
 }
@@ -61,8 +61,8 @@ PJ *PROJECTION(putp3p) {
     Q->A = 2. * RPISQ;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp3_s_inverse;
+    P->fwd = putp3_s_forward;
 
     return P;
 }

--- a/src/projections/putp4p.cpp
+++ b/src/projections/putp4p.cpp
@@ -16,7 +16,7 @@ PROJ_HEAD(putp4p, "Putnins P4'") "\n\tPCyl, Sph";
 PROJ_HEAD(weren, "Werenskiold I") "\n\tPCyl, Sph";
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY putp4p_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -29,7 +29,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP putp4p_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -53,8 +53,8 @@ PJ *PROJECTION(putp4p) {
     Q->C_y = 3.883251825;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp4p_s_inverse;
+    P->fwd = putp4p_s_forward;
 
     return P;
 }
@@ -70,8 +70,8 @@ PJ *PROJECTION(weren) {
     Q->C_y = 4.442882938;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp4p_s_inverse;
+    P->fwd = putp4p_s_forward;
 
     return P;
 }

--- a/src/projections/putp5.cpp
+++ b/src/projections/putp5.cpp
@@ -19,7 +19,7 @@ PROJ_HEAD(putp5p, "Putnins P5'") "\n\tPCyl, Sph";
 #define D 1.2158542
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY putp5_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -30,7 +30,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP putp5_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
@@ -52,8 +52,8 @@ PJ *PROJECTION(putp5) {
     Q->B = 1.;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp5_s_inverse;
+    P->fwd = putp5_s_forward;
 
     return P;
 }
@@ -69,8 +69,8 @@ PJ *PROJECTION(putp5p) {
     Q->B = 0.5;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp5_s_inverse;
+    P->fwd = putp5_s_forward;
 
     return P;
 }

--- a/src/projections/putp6.cpp
+++ b/src/projections/putp6.cpp
@@ -20,7 +20,7 @@ PROJ_HEAD(putp6p, "Putnins P6'") "\n\tPCyl, Sph";
 #define CON_POLE 1.732050807568877
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY putp6_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double p, r, V;
@@ -44,7 +44,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP putp6_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double r;
@@ -71,8 +71,8 @@ PJ *PROJECTION(putp6) {
     Q->D   = 2.;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp6_s_inverse;
+    P->fwd = putp6_s_forward;
 
     return P;
 }
@@ -91,8 +91,8 @@ PJ *PROJECTION(putp6p) {
     Q->D   = 3.;
 
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = putp6_s_inverse;
+    P->fwd = putp6_s_forward;
 
     return P;
 }

--- a/src/projections/qsc.cpp
+++ b/src/projections/qsc.cpp
@@ -119,7 +119,7 @@ static double qsc_shift_lon_origin(double lon, double offset) {
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY qsc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double lat, lon;
@@ -235,7 +235,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP qsc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double mu, nu, cosmu, tannu;
@@ -382,8 +382,8 @@ PJ *PROJECTION(qsc) {
         return pj_default_destructor (P, ENOMEM);
     P->opaque = Q;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = qsc_e_inverse;
+    P->fwd = qsc_e_forward;
     /* Determine the cube face from the center of projection. */
     if (P->phi0 >= M_HALFPI - M_FORTPI / 2.0) {
         Q->face = FACE_TOP;

--- a/src/projections/robin.cpp
+++ b/src/projections/robin.cpp
@@ -77,7 +77,7 @@ static const struct COEFS Y[] = {
 /* Not sure at all of the appropriate number for MAX_ITER... */
 #define MAX_ITER 100
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY robin_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     long i;
     double dphi;
@@ -99,7 +99,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP robin_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     long i;
     double t, t1;
@@ -149,8 +149,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(robin) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = robin_s_inverse;
+    P->fwd = robin_s_forward;
 
     return P;
 }

--- a/src/projections/rouss.cpp
+++ b/src/projections/rouss.cpp
@@ -44,7 +44,7 @@ struct pj_opaque {
 PROJ_HEAD(rouss, "Roussilhe Stereographic") "\n\tAzi, Ell";
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY rouss_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double s, al, cp, sp, al2, s2;
@@ -65,7 +65,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP rouss_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double s, al, x = xy.x / P->k0, y = xy.y / P->k0, x2, y2;;
@@ -150,8 +150,8 @@ PJ *PROJECTION(rouss) {
     Q->D10 = R_R0_4 * t * (29. + t2 * (86. + t2 * 48.))/(96. * N0);
     Q->D11 = R_R0_4 * t * (37. + t2 * 44.)/(96. * N0);
 
-    P->fwd = e_forward;
-    P->inv = e_inverse;
+    P->fwd = rouss_e_forward;
+    P->inv = rouss_e_inverse;
     P->destructor = destructor;
 
     return P;

--- a/src/projections/rpoly.cpp
+++ b/src/projections/rpoly.cpp
@@ -20,7 +20,7 @@ PROJ_HEAD(rpoly, "Rectangular Polyconic")
 
 #define EPS 1e-9
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY rpoly_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double fa;
@@ -53,7 +53,7 @@ PJ *PROJECTION(rpoly) {
         Q->fxa = 0.5 / Q->fxb;
     }
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = rpoly_s_forward;
 
     return P;
 }

--- a/src/projections/sch.cpp
+++ b/src/projections/sch.cpp
@@ -55,7 +55,7 @@ struct pj_opaque {
 
 PROJ_HEAD(sch, "Spherical Cross-track Height") "\n\tMisc\n\tplat_0= plon_0= phdg_0= [h_0=]";
 
-static PJ_LPZ inverse3d(PJ_XYZ xyz, PJ *P) {
+static PJ_LPZ sch_inverse3d(PJ_XYZ xyz, PJ *P) {
     PJ_LPZ lpz = {0.0, 0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double temp[3];
@@ -93,7 +93,7 @@ static PJ_LPZ inverse3d(PJ_XYZ xyz, PJ *P) {
     return lpz;
 }
 
-static PJ_XYZ forward3d(PJ_LPZ lpz, PJ *P) {
+static PJ_XYZ sch_forward3d(PJ_LPZ lpz, PJ *P) {
     PJ_XYZ xyz = {0.0, 0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double temp[3];
@@ -187,8 +187,8 @@ static PJ *setup(PJ *P) { /* general initialization */
     Q->xyzoff[1] = pxyz[1] - (Q->rcurv) * clt * slo;
     Q->xyzoff[2] = pxyz[2] - (Q->rcurv) * slt;
 
-    P->fwd3d = forward3d;
-    P->inv3d = inverse3d;
+    P->fwd3d = sch_forward3d;
+    P->inv3d = sch_inverse3d;
     return P;
 }
 

--- a/src/projections/sconics.cpp
+++ b/src/projections/sconics.cpp
@@ -62,7 +62,7 @@ static int phi12(PJ *P, double *del) {
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY sconics_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rho;
@@ -85,7 +85,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {  /* Spheroidal, (and ellipsoidal?) inverse */
+static PJ_LP sconics_s_inverse (PJ_XY xy, PJ *P) {  /* Spheroidal, (and ellipsoidal?) inverse */
     PJ_LP lp = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rho;
@@ -177,8 +177,8 @@ static PJ *setup(PJ *P, enum Type type) {
         break;
     }
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = sconics_s_inverse;
+    P->fwd = sconics_s_forward;
     P->es = 0;
     return (P);
 }

--- a/src/projections/somerc.cpp
+++ b/src/projections/somerc.cpp
@@ -18,7 +18,7 @@ struct pj_opaque {
 #define NITER 6
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY somerc_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0, 0.0};
     double phip, lamp, phipp, lampp, sp, cp;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
@@ -37,7 +37,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP somerc_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double phip, lamp, phipp, lampp, cp, esp, con, delp;
@@ -88,7 +88,7 @@ PJ *PROJECTION(somerc) {
         log (tan (M_FORTPI + 0.5 * P->phi0)) - Q->hlf_e *
         log ((1. + sp) / (1. - sp)));
     Q->kR = P->k0 * sqrt(P->one_es) / (1. - sp * sp);
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = somerc_e_inverse;
+    P->fwd = somerc_e_forward;
     return P;
 }

--- a/src/projections/stere.cpp
+++ b/src/projections/stere.cpp
@@ -41,7 +41,7 @@ static double ssfn_ (double phit, double sinphi, double eccen) {
 }
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY stere_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double coslam, sinlam, sinX = 0.0, cosX = 0.0, X, A = 0.0, sinphi;
@@ -95,7 +95,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY stere_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  sinphi, cosphi, coslam, sinlam;
@@ -137,7 +137,7 @@ oblcon:
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP stere_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cosphi, sinphi, tp=0.0, phi_l=0.0, rho, halfe=0.0, halfpi=0.0;
@@ -188,7 +188,7 @@ static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP stere_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double  c, rh, sinc, cosc;
@@ -265,8 +265,8 @@ static PJ *setup(PJ *P) {                   /* general initialization */
             Q->cosX1 = cos (X);
             break;
         }
-        P->inv = e_inverse;
-        P->fwd = e_forward;
+        P->inv = stere_e_inverse;
+        P->fwd = stere_e_forward;
     } else {
         switch (Q->mode) {
         case OBLIQ:
@@ -284,8 +284,8 @@ static PJ *setup(PJ *P) {                   /* general initialization */
             break;
         }
 
-        P->inv = s_inverse;
-        P->fwd = s_forward;
+        P->inv = stere_s_inverse;
+        P->fwd = stere_s_forward;
     }
     return P;
 }

--- a/src/projections/sterea.cpp
+++ b/src/projections/sterea.cpp
@@ -44,7 +44,7 @@ PROJ_HEAD(sterea, "Oblique Stereographic Alternative") "\n\tAzimuthal, Sph&Ell";
 
 
 
-static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
+static PJ_XY sterea_e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cosc, sinc, cosl, k;
@@ -65,7 +65,7 @@ static PJ_XY e_forward (PJ_LP lp, PJ *P) {          /* Ellipsoidal, forward */
 }
 
 
-static PJ_LP e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
+static PJ_LP sterea_e_inverse (PJ_XY xy, PJ *P) {          /* Ellipsoidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double rho, c, sinc, cosc;
@@ -114,8 +114,8 @@ PJ *PROJECTION(sterea) {
     Q->cosc0 = cos (Q->phic0);
     Q->R2 = 2. * R;
 
-    P->inv = e_inverse;
-    P->fwd = e_forward;
+    P->inv = sterea_e_inverse;
+    P->fwd = sterea_e_forward;
     P->destructor = destructor;
 
     return P;

--- a/src/projections/sts.cpp
+++ b/src/projections/sts.cpp
@@ -20,7 +20,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY sts_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 	double c;
@@ -40,7 +40,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP sts_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 	double c;
@@ -59,8 +59,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 static PJ *setup(PJ *P, double p, double q, int mode) {
 	P->es  = 0.;
-	P->inv = s_inverse;
-	P->fwd = s_forward;
+	P->inv = sts_s_inverse;
+	P->fwd = sts_s_forward;
 	static_cast<struct pj_opaque*>(P->opaque)->C_x = q / p;
 	static_cast<struct pj_opaque*>(P->opaque)->C_y = p;
 	static_cast<struct pj_opaque*>(P->opaque)->C_p = 1/ q;

--- a/src/projections/tcc.cpp
+++ b/src/projections/tcc.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(tcc, "Transverse Central Cylindrical") "\n\tCyl, Sph, no inv";
 #define EPS10 1.e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY tcc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     double b, bt;
 
@@ -27,7 +27,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(tcc) {
     P->es  = 0.;
-    P->fwd = s_forward;
+    P->fwd = tcc_s_forward;
     P->inv = nullptr;
 
     return P;

--- a/src/projections/tcea.cpp
+++ b/src/projections/tcea.cpp
@@ -8,7 +8,7 @@
 PROJ_HEAD(tcea, "Transverse Cylindrical Equal Area") "\n\tCyl, Sph";
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY tcea_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     xy.x = cos (lp.phi) * sin (lp.lam) / P->k0;
     xy.y = P->k0 * (atan2 (tan (lp.phi), cos (lp.lam)) - P->phi0);
@@ -16,7 +16,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP tcea_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0, 0.0};
     double t;
 
@@ -30,8 +30,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 
 PJ *PROJECTION(tcea) {
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = tcea_s_inverse;
+    P->fwd = tcea_s_forward;
     P->es = 0.;
     return P;
 }

--- a/src/projections/times.cpp
+++ b/src/projections/times.cpp
@@ -38,7 +38,7 @@
 
 PROJ_HEAD(times, "Times") "\n\tCyl, Sph";
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY times_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     double T, S, S2;
     PJ_XY xy = {0.0,0.0};
     (void) P;
@@ -54,7 +54,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP times_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     double T, S, S2;
     PJ_LP lp = {0.0,0.0};
     (void) P;
@@ -73,8 +73,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 PJ *PROJECTION(times) {
     P->es = 0.0;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = times_s_inverse;
+    P->fwd = times_s_forward;
 
     return P;
 }

--- a/src/projections/tobmerc.cpp
+++ b/src/projections/tobmerc.cpp
@@ -18,7 +18,7 @@ static double logtanpfpim1(double x) {       /* log(tan(x/2 + M_FORTPI)) */
     return log(tan(M_FORTPI + .5 * x));
 }
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY tobmerc_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     double cosphi;
 
@@ -33,7 +33,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     return xy;
 }
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP tobmerc_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0, 0.0};
     double cosphi;
 
@@ -44,7 +44,7 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 }
 
 PJ *PROJECTION(tobmerc) {
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = tobmerc_s_inverse;
+    P->fwd = tobmerc_s_forward;
     return P;
 }

--- a/src/projections/tpeqd.cpp
+++ b/src/projections/tpeqd.cpp
@@ -16,7 +16,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY tpeqd_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t, z1, z2, dl1, dl2, sp, cp;
@@ -37,7 +37,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP tpeqd_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double cz1, cz2, s, d, cp, sp;
@@ -104,8 +104,8 @@ PJ *PROJECTION(tpeqd) {
     Q->r2z0 = 0.5 / Q->z02;
     Q->z02 *= Q->z02;
 
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = tpeqd_s_inverse;
+    P->fwd = tpeqd_s_forward;
     P->es = 0.;
 
     return P;

--- a/src/projections/urm5.cpp
+++ b/src/projections/urm5.cpp
@@ -15,7 +15,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY urm5_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double t;
@@ -54,7 +54,7 @@ PJ *PROJECTION(urm5) {
 
     P->es = 0.;
     P->inv = nullptr;
-    P->fwd = s_forward;
+    P->fwd = urm5_s_forward;
 
     return P;
 }

--- a/src/projections/urmfps.cpp
+++ b/src/projections/urmfps.cpp
@@ -19,7 +19,7 @@ struct pj_opaque {
 #define Cy 1.139753528477
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY urmfps_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     lp.phi = aasin (P->ctx,static_cast<struct pj_opaque*>(P->opaque)->n * sin (lp.phi));
     xy.x = C_x * lp.lam * cos (lp.phi);
@@ -28,7 +28,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP urmfps_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0, 0.0};
     xy.y /= static_cast<struct pj_opaque*>(P->opaque)->C_y;
     lp.phi = aasin(P->ctx, sin (xy.y) / static_cast<struct pj_opaque*>(P->opaque)->n);
@@ -40,8 +40,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 static PJ *setup(PJ *P) {
     static_cast<struct pj_opaque*>(P->opaque)->C_y = Cy / static_cast<struct pj_opaque*>(P->opaque)->n;
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = urmfps_s_inverse;
+    P->fwd = urmfps_s_forward;
     return P;
 }
 

--- a/src/projections/vandg.cpp
+++ b/src/projections/vandg.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(vandg, "van der Grinten (I)") "\n\tMisc Sph";
 # define HPISQ      4.93480220054467930934
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY vandg_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double  al, al2, g, g2, p2;
 
@@ -58,7 +58,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP vandg_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
     double t, c0, c1, c2, c3, al, r2, r, m, d, ay, x2, y2;
 
@@ -105,8 +105,8 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(vandg) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = vandg_s_inverse;
+    P->fwd = vandg_s_forward;
 
     return P;
 }

--- a/src/projections/vandg2.cpp
+++ b/src/projections/vandg2.cpp
@@ -18,7 +18,7 @@ PROJ_HEAD(vandg3, "van der Grinten III") "\n\tMisc Sph, no inv";
 #define TOL    1e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY vandg2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     double x1, at, bt, ct;
@@ -58,7 +58,7 @@ PJ *PROJECTION(vandg2) {
     P->opaque = Q;
 
     Q->vdg3 = 0;
-    P->fwd = s_forward;
+    P->fwd = vandg2_s_forward;
 
     return P;
 }
@@ -71,7 +71,7 @@ PJ *PROJECTION(vandg3) {
 
     Q->vdg3 = 1;
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = vandg2_s_forward;
 
     return P;
 }

--- a/src/projections/vandg4.cpp
+++ b/src/projections/vandg4.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(vandg4, "van der Grinten IV") "\n\tMisc Sph, no inv";
 #define TOL 1e-10
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY vandg4_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
     double x1, t, bt, ct, ft, bt2, ct2, dt, dt2;
     (void) P;
@@ -50,7 +50,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 PJ *PROJECTION(vandg4) {
     P->es = 0.;
-    P->fwd = s_forward;
+    P->fwd = vandg4_s_forward;
 
     return P;
 }

--- a/src/projections/wag2.cpp
+++ b/src/projections/wag2.cpp
@@ -13,7 +13,7 @@ PROJ_HEAD(wag2, "Wagner II") "\n\tPCyl, Sph";
 #define C_p2 0.88550
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY wag2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	lp.phi = aasin (P->ctx,C_p1 * sin (C_p2 * lp.phi));
 	xy.x = C_x * lp.lam * cos (lp.phi);
@@ -22,7 +22,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP wag2_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 	lp.phi = xy.y / C_y;
 	lp.lam = xy.x / (C_x * cos(lp.phi));
@@ -33,7 +33,7 @@ static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
 
 PJ *PROJECTION(wag2) {
     P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = wag2_s_inverse;
+    P->fwd = wag2_s_forward;
     return P;
 }

--- a/src/projections/wag3.cpp
+++ b/src/projections/wag3.cpp
@@ -17,7 +17,7 @@ struct pj_opaque {
 } // anonymous namespace
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY wag3_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	xy.x = static_cast<struct pj_opaque*>(P->opaque)->C_x * lp.lam * cos(TWOTHIRD * lp.phi);
 	xy.y = lp.phi;
@@ -25,7 +25,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP wag3_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 	lp.phi = xy.y;
 	lp.lam = xy.x / (static_cast<struct pj_opaque*>(P->opaque)->C_x * cos(TWOTHIRD * lp.phi));
@@ -44,8 +44,8 @@ PJ *PROJECTION(wag3) {
 	ts = pj_param (P->ctx, P->params, "rlat_ts").f;
 	static_cast<struct pj_opaque*>(P->opaque)->C_x = cos (ts) / cos (2.*ts/3.);
 	P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = wag3_s_inverse;
+    P->fwd = wag3_s_forward;
 
     return P;
 }

--- a/src/projections/wag7.cpp
+++ b/src/projections/wag7.cpp
@@ -9,7 +9,7 @@ PROJ_HEAD(wag7, "Wagner VII") "\n\tMisc Sph, no inv";
 
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY wag7_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
 	double theta, ct, D;
 
@@ -24,7 +24,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 
 
 PJ *PROJECTION(wag7) {
-    P->fwd = s_forward;
+    P->fwd = wag7_s_forward;
     P->inv = nullptr;
     P->es = 0.;
     return P;

--- a/src/projections/wink1.cpp
+++ b/src/projections/wink1.cpp
@@ -16,7 +16,7 @@ struct pj_opaque {
 
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY wink1_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0,0.0};
 	xy.x = .5 * lp.lam * (static_cast<struct pj_opaque*>(P->opaque)->cosphi1 + cos(lp.phi));
 	xy.y = lp.phi;
@@ -24,7 +24,7 @@ static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
 }
 
 
-static PJ_LP s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
+static PJ_LP wink1_s_inverse (PJ_XY xy, PJ *P) {           /* Spheroidal, inverse */
     PJ_LP lp = {0.0,0.0};
 	lp.phi = xy.y;
 	lp.lam = 2. * xy.x / (static_cast<struct pj_opaque*>(P->opaque)->cosphi1 + cos(lp.phi));
@@ -40,8 +40,8 @@ PJ *PROJECTION(wink1) {
 
 	static_cast<struct pj_opaque*>(P->opaque)->cosphi1 = cos (pj_param(P->ctx, P->params, "rlat_ts").f);
 	P->es = 0.;
-    P->inv = s_inverse;
-    P->fwd = s_forward;
+    P->inv = wink1_s_inverse;
+    P->fwd = wink1_s_forward;
 
     return P;
 }

--- a/src/projections/wink2.cpp
+++ b/src/projections/wink2.cpp
@@ -18,7 +18,7 @@ struct pj_opaque {
 #define LOOP_TOL    1e-7
 
 
-static PJ_XY s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
+static PJ_XY wink2_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
 	double k, V;
 	int i;
@@ -51,7 +51,7 @@ PJ *PROJECTION(wink2) {
 	static_cast<struct pj_opaque*>(P->opaque)->cosphi1 = cos(pj_param(P->ctx, P->params, "rlat_1").f);
 	P->es  = 0.;
     P->inv = nullptr;
-    P->fwd = s_forward;
+    P->fwd = wink2_s_forward;
 
     return P;
 }


### PR DESCRIPTION
This is mostly to have better OSSFuzz report. Currently a lot
of bug summaries are like
`proj4/standard_fuzzer: Divide-by-zero in s_inverse`

By prefixing the projection name, we will get better reports, like
`Divide-by-zero in airy_s_inverse`

This also makes it slightly easier to set a breakpoint by
function name.