### PR TITLE
autoconf build: add a PROJ_DB_CACHE_DIR trick to speed-up builds

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -64,7 +64,13 @@ proj.db: $(DATAPATH)/sql/*.sql
 	 for x in $(SQL_ORDERED_LIST); do \
 		export SQL_EXPANDED_LIST="$${SQL_EXPANDED_LIST} $(DATAPATH)/$$x"; \
 	 done; \
-	 cat $${SQL_EXPANDED_LIST} | sqlite3 proj.db; \
+	 if test "x$(PROJ_DB_CACHE_DIR)" != "x" -a -f "$(PROJ_DB_CACHE_DIR)/proj.db" -a -f "$(PROJ_DB_CACHE_DIR)/proj.db.sql.md5" ; then \
+	    cat $${SQL_EXPANDED_LIST} | md5sum | diff - "$(PROJ_DB_CACHE_DIR)/proj.db.sql.md5" > /dev/null \
+	    && (echo "Reusing cached proj.db"; cp "$(PROJ_DB_CACHE_DIR)/proj.db" proj.db); \
+	 fi; \
+	 if test ! -f proj.db ; then \
+	   cat $${SQL_EXPANDED_LIST} | sqlite3 proj.db; \
+	 fi; \
 	 if [ $$? -ne 0 ] ; then \
 		echo "Build of proj.db failed"; \
 		$(RM) proj.db; \
@@ -77,6 +83,12 @@ proj.db: $(DATAPATH)/sql/*.sql
 		echo "Foreign key check failed"; \
 		$(RM) proj.db; \
 		exit 1; \
+	 else \
+	   if test "x$(PROJ_DB_CACHE_DIR)" != "x" ; then \
+		mkdir -p "$(PROJ_DB_CACHE_DIR)"; \
+		cat $${SQL_EXPANDED_LIST} | md5sum > "$(PROJ_DB_CACHE_DIR)/proj.db.sql.md5"; \
+		cp proj.db "$(PROJ_DB_CACHE_DIR)"; \
+	   fi \
 	 fi \
 	fi
 

--- a/travis/linux_clang/install.sh
+++ b/travis/linux_clang/install.sh
@@ -3,6 +3,7 @@
 set -e
 
 export CCACHE_CPP2=yes
+export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 # -fno-use-cxa-atexit is needed to build with -coverage
 CC="ccache clang" CXX="ccache clang++" CFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" CXXFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" LDFLAGS="-fsanitize=address" ./travis/install.sh

--- a/travis/linux_gcc/install.sh
+++ b/travis/linux_gcc/install.sh
@@ -3,5 +3,6 @@
 set -e
 
 export CCACHE_CPP2=yes
+export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 CC="ccache gcc" CXX="ccache g++" CFLAGS="-std=c89 -Werror" CXXFLAGS="-Werror" ./travis/install.sh

--- a/travis/linux_gcc7/install.sh
+++ b/travis/linux_gcc7/install.sh
@@ -3,5 +3,6 @@
 set -e
 
 export CCACHE_CPP2=yes
+export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 CC="ccache $CC" CXX="ccache $CXX" CFLAGS="-std=c89 -Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" ./travis/install.sh

--- a/travis/mingw32/install.sh
+++ b/travis/mingw32/install.sh
@@ -3,6 +3,7 @@
 set -e
 
 export CCACHE_CPP2=yes
+export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 # prepare wine environment
 wine64 cmd /c dir

--- a/travis/osx/install.sh
+++ b/travis/osx/install.sh
@@ -3,5 +3,6 @@
 set -e
 
 export CCACHE_CPP2=yes
+export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 CC="ccache clang" CXX="ccache clang++" CFLAGS="-Werror -O2" CXXFLAGS="-Werror -O2" ./travis/install.sh


### PR DESCRIPTION
If the PROJ_DB_CACHE_DIR environment variable is defined, then a
$(PROJ_DB_CACHED_DIR)/proj.db.sql.md5 file is used to determine if
the set of .sql files has changed since the last time. If not then
$(PROJ_DB_CACHED_DIR)/proj.db is directly used.
This can saved a few seconds when doing rebuilds.
This is a poor man equivalent of ccache for generating the database :-)