### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/strerrno.cpp
+++ b/src/strerrno.cpp
@@ -70,7 +70,7 @@ pj_err_list[] = {
     "argument not numerical or out of range",                          /* -58 */
     "inconsistent unit type between input and output",                 /* -59 */
     "arguments are mutually exclusive",                                /* -60 */
-    "generic error of unknow origin",                                  /* -61 */
+    "generic error of unknown origin",                                 /* -61 */
 
     /* When adding error messages, remember to update ID defines in
        projects.h, and transient_error array in pj_transform                  */


### PR DESCRIPTION
The lintian QA tool reported a spelling error for PROJ 6.1.0-rc1:

 * unknow -> unknown