### PR TITLE
identify(): take into account the authority passed in (fixes #1465)

### DIFF
--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -1650,6 +1650,38 @@ TEST_F(CApi, proj_identify) {
         ObjListKeeper keeper_res(res);
         EXPECT_EQ(res, nullptr);
     }
+    {
+        auto obj2 = proj_create(
+            m_ctxt, "+proj=longlat +datum=WGS84 +no_defs +type=crs");
+        ObjectKeeper keeper2(obj2);
+        ASSERT_NE(obj2, nullptr);
+        int *confidence = nullptr;
+        auto res = proj_identify(m_ctxt, obj2, nullptr, nullptr, &confidence);
+        ObjListKeeper keeper_res(res);
+        EXPECT_EQ(proj_list_get_count(res), 4);
+        proj_int_list_destroy(confidence);
+    }
+    {
+        auto obj2 = proj_create_from_database(m_ctxt, "IGNF", "ETRS89UTM28",
+                                              PJ_CATEGORY_CRS, false, nullptr);
+        ObjectKeeper keeper2(obj2);
+        ASSERT_NE(obj2, nullptr);
+        int *confidence = nullptr;
+        auto res = proj_identify(m_ctxt, obj2, "EPSG", nullptr, &confidence);
+        ObjListKeeper keeper_res(res);
+        EXPECT_EQ(proj_list_get_count(res), 1);
+        auto gotCRS = proj_list_get(m_ctxt, res, 0);
+        ASSERT_NE(gotCRS, nullptr);
+        ObjectKeeper keeper_gotCRS(gotCRS);
+        auto auth = proj_get_id_auth_name(gotCRS, 0);
+        ASSERT_TRUE(auth != nullptr);
+        EXPECT_EQ(auth, std::string("EPSG"));
+        auto code = proj_get_id_code(gotCRS, 0);
+        ASSERT_TRUE(code != nullptr);
+        EXPECT_EQ(code, std::string("25828"));
+        EXPECT_EQ(confidence[0], 70);
+        proj_int_list_destroy(confidence);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -1984,13 +1984,35 @@ TEST(crs, projectedCRS_identify_no_db) {
 TEST(crs, projectedCRS_identify_db) {
     auto dbContext = DatabaseContext::create();
     auto factoryEPSG = AuthorityFactory::create(dbContext, "EPSG");
+    auto factoryIGNF = AuthorityFactory::create(dbContext, "IGNF");
+    auto factoryAnonymous = AuthorityFactory::create(dbContext, std::string());
     {
         // Identify by existing code
-        auto res =
-            factoryEPSG->createProjectedCRS("2172")->identify(factoryEPSG);
-        ASSERT_EQ(res.size(), 1U);
-        EXPECT_EQ(res.front().first->getEPSGCode(), 2172);
-        EXPECT_EQ(res.front().second, 100);
+        auto crs = factoryEPSG->createProjectedCRS("2172");
+        {
+            auto res = crs->identify(factoryEPSG);
+            ASSERT_EQ(res.size(), 1U);
+            EXPECT_EQ(res.front().first->getEPSGCode(), 2172);
+            EXPECT_EQ(res.front().second, 100);
+        }
+        {
+            auto res = crs->identify(factoryAnonymous);
+            ASSERT_EQ(res.size(), 1U);
+        }
+        {
+            auto res = crs->identify(factoryIGNF);
+            ASSERT_EQ(res.size(), 0U);
+        }
+    }
+    {
+        // Identify by existing code
+        auto crs = factoryIGNF->createProjectedCRS("ETRS89UTM28");
+        {
+            auto res = crs->identify(factoryEPSG);
+            ASSERT_EQ(res.size(), 1U);
+            EXPECT_EQ(res.front().first->getEPSGCode(), 25828);
+            EXPECT_EQ(res.front().second, 70);
+        }
     }
     {
         // Non-existing code


### PR DESCRIPTION
When identifying an object that has already a code with authority A
but the authority of interest passed was B, then it was not checking
that A != B, and did not try to search in the objects of B.