### PR TITLE
Fix incorrect delimator ";" used to separate proj_info().searchpath entries

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1367,9 +1367,9 @@ static char *path_append (char *buf, const char *app, size_t *buf_size) {
     }
     assert(buf);
 
-    /* Only append a semicolon if something's already there */
+    /* Only append a delimiter if something's already there */
     if (0 != buflen)
-        strcat (buf, ";");
+        strcat (buf, delim);
     strcat (buf, app);
     return buf;
 }

--- a/src/proj.h
+++ b/src/proj.h
@@ -277,7 +277,8 @@ struct PJ_INFO {
     const char  *version;           /* Full version number                  */
     const char  *searchpath;        /* Paths where init and grid files are  */
                                     /* looked for. Paths are separated by   */
-                                    /* semi-colons.                         */
+                                    /* semi-colons on Windows, and colons   */
+                                    /* on non-Windows platforms.            */
     const char * const *paths;
     size_t path_count;
 };


### PR DESCRIPTION
... on non-windows platforms, should be ":", not ";"