### PR TITLE
proj_info().searchpath should not include PROJ_LIB path

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1403,16 +1403,17 @@ PJ_INFO proj_info (void) {
     info.release    = pj_get_release ();
 
     /* build search path string */
-    const char* envPROJ_LIB = getenv ("PROJ_LIB");
-    buf = path_append (buf, envPROJ_LIB, &buf_size);
-#ifdef PROJ_LIB
-    if( envPROJ_LIB == nullptr ) {
-        buf = path_append (buf, PROJ_LIB, &buf_size);
-    }
-#endif
     auto ctx = pj_get_default_ctx();
-    if( ctx ) {
-        for( const auto& path: ctx->search_paths ) {
+    if (!ctx || ctx->search_paths.empty()) {
+        const char *envPROJ_LIB = getenv("PROJ_LIB");
+        buf = path_append(buf, envPROJ_LIB, &buf_size);
+#ifdef PROJ_LIB
+        if (envPROJ_LIB == nullptr) {
+            buf = path_append(buf, PROJ_LIB, &buf_size);
+        }
+#endif
+    } else {
+        for (const auto &path : ctx->search_paths) {
             buf = path_append(buf, path.c_str(), &buf_size);
         }
     }


### PR DESCRIPTION
... if the context search_paths is not empty

The logic used when actually searching for files is that if
the context search_paths are set, these completely override
the PROJ_LIB variable. So we should make proj_info().searchpath
correctly reflect this, and not include the PROJ_LIB path
in searchpath if the context has search_paths manually set.

Refs https://github.com/qgis/QGIS/pull/30048/