### PR TITLE
Update GitHub references: proj.4 -> PROJ

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,4 +39,4 @@ Contributors
 --------------------------------------------------------------------------------
 
 The full list of contributors can be found on GitHub
-https://github.com/OSGeo/proj.4/graphs/contributors
+https://github.com/OSGeo/PROJ/graphs/contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ the issue tracker.
 
 ## Adding bug reports
 
-Bug reports are handled in the [issue tracker](https://github.com/OSGeo/proj.4/issues)
+Bug reports are handled in the [issue tracker](https://github.com/OSGeo/PROJ/issues)
 on PROJ.4's home on GitHub. Writing a good bug report is not easy. But fixing a poorly
 documented bug is not easy either, so please put in the effort it takes to create a
 thorough bug report.
@@ -56,7 +56,7 @@ definitely a problem with PROJ.4.
 ## Feature requests
 
 Got an idea for a new feature in PROJ.4? Submit a thorough description of the new
-feature in the [issue tracker](https://github.com/OSGeo/proj.4/issues). Please
+feature in the [issue tracker](https://github.com/OSGeo/PROJ/issues). Please
 include any technical documents that can help the developer make the new feature a
 reality. An example of this could be a publicly available academic paper that
 describes a new projection. Also, including a numerical test case will make it
@@ -70,7 +70,7 @@ Note that not all feature requests are accepted.
 PROJ.4 is in dire need of better documentation. Any contributions of documentation
 are greatly appreciated. The PROJ.4 documentation is available on [proj.org](https://proj.org).
 The website is generated with [Sphinx](http://www.sphinx-doc.org/en/stable/). Contributions
-to the documentation should be made as [Pull Requests](https://github.com/OSGeo/proj.4/pulls)
+to the documentation should be made as [Pull Requests](https://github.com/OSGeo/PROJ/pulls)
 on GitHub.
 
 If you intend to document one of PROJ.4's supported projections please use the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##
-# osgeo/proj.4
+# OSGeo/PROJ
 
 FROM ubuntu:18.04 as builder
 
@@ -15,8 +15,8 @@ RUN apt-get update -y \
             git make cmake wget unzip libtool automake \
             zlib1g-dev libsqlite3-dev pkg-config sqlite3
 
-RUN git clone https://github.com/OSGeo/proj.4.git \
-    && cd proj.4 \
+RUN git clone https://github.com/OSGeo/PROJ.git \
+    && cd PROJ \
     && ./autogen.sh \
     && ./configure --prefix=/usr \
     && make \

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -198,7 +198,7 @@ git push --tags
 -------------------------------------------------------------------------------
 
 When the new tag is pushed upstream GitHub picks up that a new release has been
-issued. Update the new release on https://github.com/OSGeo/proj.4/releases with
+issued. Update the new release on https://github.com/OSGeo/PROJ/releases with
 the release notes from `NEWS` and add the prepared source distribution archives
 to the release (otherwise GitHub will just package the entire repository - we
 don't want that).

--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -31,7 +31,7 @@ check_function_exists(strerror HAVE_STRERROR)
 check_library_exists(m ceil "" HAVE_LIBM)
 
 set(PACKAGE "proj")
-set(PACKAGE_BUGREPORT "https://github.com/OSGeo/proj.4/issues")
+set(PACKAGE_BUGREPORT "https://github.com/OSGeo/PROJ/issues")
 set(PACKAGE_NAME "PROJ")
 set(PACKAGE_STRING "PROJ ${${PROJECT_INTERN_NAME}_VERSION}")
 set(PACKAGE_TARNAME "proj")

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
 AC_INIT([PROJ], [6.1.0],
-        [https://github.com/OSGeo/proj.4/issues], proj, [https://proj.org])
+        [https://github.com/OSGeo/PROJ/issues], proj, [https://proj.org])
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C)
 

--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -184,7 +184,7 @@ Hence, in honour of *cct* (the geodesist) this is :program:`cct` (the program).
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -229,7 +229,7 @@ outputs
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/apps/geod.rst
+++ b/docs/source/apps/geod.rst
@@ -205,7 +205,7 @@ Further reading
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/apps/gie.rst
+++ b/docs/source/apps/gie.rst
@@ -371,7 +371,7 @@ So in honour, and hopefully also in the spirit, of Gerald Ian Evenden
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/apps/proj.rst
+++ b/docs/source/apps/proj.rst
@@ -223,7 +223,7 @@ data will appear as three lines of::
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -326,7 +326,7 @@ Output:
     Bugs
     ****
 
-    A list of know bugs can be found at https://github.com/OSGeo/proj.4/issues
+    A list of know bugs can be found at https://github.com/OSGeo/PROJ/issues
     where new bug reports can be submitted to.
 
     Home page

--- a/docs/source/community/channels.rst
+++ b/docs/source/community/channels.rst
@@ -26,7 +26,7 @@ and feature requests. We are happy to take contributions in any form, either
 as code, bug reports, documentation or feature requests. See :ref:`contributing`
 for more info on how you can help improve PROJ.
 
-The PROJ GitHub page can be found at https://github.com/OSGeo/proj.4
+The PROJ GitHub page can be found at https://github.com/OSGeo/PROJ
 
 .. note::
 

--- a/docs/source/community/contributing.rst
+++ b/docs/source/community/contributing.rst
@@ -42,7 +42,7 @@ Adding bug reports
 ------------------
 
 Bug reports are handled in the `issue
-tracker <https://github.com/OSGeo/proj.4/issues>`__ on PROJ's home on
+tracker <https://github.com/OSGeo/PROJ/issues>`__ on PROJ's home on
 GitHub. Writing a good bug report is not easy. But fixing a poorly
 documented bug is not easy either, so please put in the effort it takes
 to create a thorough bug report.
@@ -74,7 +74,7 @@ Feature requests
 
 Got an idea for a new feature in PROJ? Submit a thorough description
 of the new feature in the `issue
-tracker <https://github.com/OSGeo/proj.4/issues>`__. Please include any
+tracker <https://github.com/OSGeo/PROJ/issues>`__. Please include any
 technical documents that can help the developer make the new feature a
 reality. An example of this could be a publicly available academic paper
 that describes a new projection. Also, including a numerical test case
@@ -91,7 +91,7 @@ documentation are greatly appreciated. The PROJ documentation is
 available on `proj.org <https://proj.org>`__. The website is generated
 with `Sphinx <http://www.sphinx-doc.org/en/stable/>`__. Contributions to
 the documentation should be made as `Pull
-Requests <https://github.com/OSGeo/proj.4/pulls>`__ on GitHub.
+Requests <https://github.com/OSGeo/PROJ/pulls>`__ on GitHub.
 
 If you intend to document one of PROJ's supported projections please
 use the :doc:`Mercator projection <../operations/projections/merc>`

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -90,7 +90,7 @@
   Author                   = {Gerald I. Evenden},
   Year                     = {2005},
 
-  Url                      = {https://github.com/OSGeo/proj.4/blob/master/docs/old/libproj.pdf}
+  Url                      = {https://github.com/OSGeo/PROJ/blob/master/docs/old/libproj.pdf}
 }
 
 @Manual{Evenden1995,

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -75,7 +75,7 @@ Below is a list of grids distributed under a free and open license.
 Switzerland
 ................................................................................
 
-Background in ticket `#145 <https://github.com/OSGeo/proj.4/issues/145>`__
+Background in ticket `#145 <https://github.com/OSGeo/PROJ/issues/145>`__
 
 We basically have two shift grids available. An official here:
 

--- a/travis/deploy_website.sh
+++ b/travis/deploy_website.sh
@@ -13,10 +13,10 @@ cp $builddir/latex/proj.pdf $destdir/projdocs
 cd $destdir/projdocs
 git init
 git checkout -b gh-pages
-git remote add origin git@github.com:OSGeo/proj.4.git
+git remote add origin git@github.com:OSGeo/PROJ.git
 
-git config user.email "proj4bot@proj4.bot"
-git config user.name "proj.4 deploybot"
+git config user.email "proj.bot@proj.bot"
+git config user.name "PROJ deploybot"
 
 # A few files we must manually create
 echo "_site" > .gitignore
@@ -24,6 +24,6 @@ touch .nojekyll
 echo "proj.org" > CNAME
 
 git add -A
-git commit -m "update with results of commit https://github.com/OSGeo/proj.4/commit/$TRAVIS_COMMIT"
+git commit -m "update with results of commit https://github.com/OSGeo/PROJ/commit/$TRAVIS_COMMIT"
 git push -f origin gh-pages
 


### PR DESCRIPTION
Most of these changes are to documentation and a few configuration files.

I've ignored several genres of files that should preserve history, including ChangeLog, NEWS, RFCs, and a few specific issues noted in source code. The GitHub redirects work fine for these links.