### PR TITLE
WKT1 importer: do case insensitive comparison for axis direction

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -2311,7 +2311,7 @@ WKTParser::Private::buildAxis(const WKTNodeNNPtr &node,
         direction = &AxisDirection::GEOCENTRIC_Z;
     } else if (dirString == AxisDirectionWKT1::OTHER.toString()) {
         direction = &AxisDirection::UNSPECIFIED;
-    } else if (!direction && AxisDirectionWKT1::valueOf(dirString) != nullptr) {
+    } else if (!direction && AxisDirectionWKT1::valueOf(toupper(dirString)) != nullptr) {
         direction = AxisDirection::valueOf(tolower(dirString));
     }
 

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -1018,7 +1018,7 @@ TEST(wkt_parse, wkt1_projected) {
                "    PARAMETER[\"false_northing\",0],\n"
                "    UNIT[\"metre\",1,\n"
                "        AUTHORITY[\"EPSG\",\"9001\"]],\n"
-               "    AXIS[\"(E)\",EAST],\n"
+               "    AXIS[\"(E)\",East],\n" // should normally be uppercase
                "    AXIS[\"(N)\",NORTH],\n"
                "    AUTHORITY[\"EPSG\",\"32631\"]]";
     auto obj = WKTParser()


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/1623

http://portal.opengeospatial.org/files/?artifact_id=999 is not explicit if
string comparisons should be case sensitive or not, but WKT2 allows for case
differences in keyword and enumerated value, so follow this relaxed interpretation
for WKT1 as well.