### PR TITLE
Bump CMake minimum version from 3.5 to 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 ################################################################################
 # General settings
 ################################################################################
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 
 # For historic reasons, the CMake PROJECT-NAME is PROJ4
 project(PROJ4 LANGUAGES C CXX)


### PR DESCRIPTION
With reference to #1540, the Visual Studio 15 2017 generator [was added with CMake 3.7](https://cmake.org/cmake/help/latest/release/3.7.html), released in [November 11, 2016](https://blog.kitware.com/cmake-3-7-0-available-for-download/).

Any objections bumping the CMake minimum version from 3.5 to 3.7?

Note that Ubuntu Xenial LTS has [3.5](https://packages.ubuntu.com/xenial/cmake), so these users would need to seek an an alternative version.