### PR TITLE
Create a '.deb' package builder with Docker

### DIFF
--- a/DEBIAN/control.template
+++ b/DEBIAN/control.template
@@ -1,0 +1,11 @@
+Package: proj
+Package-Type: deb
+Version: {PROJ_VERSION}
+Maintainer: Jean SIMARD <woshilapin@tuziwo.info>
+Description: Cartographic Projections and Coordinate Transformations Library
+Section: utils
+Priority: optional
+Installed-Size: {INSTALLED_SIZE}
+Architecture: amd64
+Bugs: https://github.com/OSGeo/PROJ/issues
+Homepage: https://proj.org

--- a/Dockerfile.deb-packager
+++ b/Dockerfile.deb-packager
@@ -1,0 +1,37 @@
+ARG DEBIAN_VERSION="stretch"
+FROM debian:${DEBIAN_VERSION}-slim
+ARG PROJ_VERSION="6.1.0"
+RUN apt update && apt install -y wget build-essential pkg-config sqlite3 libsqlite3-dev libssl-dev clang
+
+# Download and unzip PROJ
+WORKDIR /tmp
+RUN wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz
+RUN tar -xzvf proj-${PROJ_VERSION}.tar.gz
+
+# Compile PROJ and install in /usr
+WORKDIR proj-${PROJ_VERSION}
+RUN ./configure --prefix=/usr
+RUN make
+RUN touch /tmp/timestamp
+RUN make install
+
+# Prepare the folder for building the .deb package
+ENV DEB_NAME "proj_${PROJ_VERSION}_amd64"
+ENV DEB_PATH "/tmp/${DEB_NAME}"
+WORKDIR ${DEB_PATH}
+RUN find /usr ! -type d -cnewer /tmp/timestamp | while read FILE; \
+	do \
+		mkdir -p "${DEB_PATH}$( dirname "${FILE}" )"; \
+		cp "${FILE}" "${DEB_PATH}${FILE}" ; \
+	done
+RUN mkdir DEBIAN/
+RUN echo "2.0\n" > debian-binary
+COPY DEBIAN/control.template DEBIAN/control
+RUN sed --in-place "s/{PROJ_VERSION}/${PROJ_VERSION}/" DEBIAN/control
+RUN sed --in-place "s/{INSTALLED_SIZE}/$( du --summarize --bytes --exclude DEBIAN ${DEB_PATH} | cut --field=1 )/" DEBIAN/control
+RUN find . -type f ! -regex '.*?DEBIAN.*' -printf '%P ' | xargs md5sum > DEBIAN/md5sums
+
+# Build the .deb package
+WORKDIR /
+RUN mkdir /deb/
+RUN dpkg --build ${DEB_PATH} /deb/${DEB_NAME}.deb

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ If you are building from the git repository you have to first run
 
 which will generate a configure script that can be used as described above.
 
+### Build the '.deb' Debian package
+With `Dockerfile.deb-packager`, you can build a Debian package for PROJ. You can
+configure the version by changing the `PROJ_VERSION` argument (default is
+`6.1.0`). You can also change which version of Debian is used to build the
+package (default is `stretch`).
+```
+docker build \
+	--build-arg PROJ_VERSION="6.0.0" \
+	--build-arg DEBIAN_VERSION="buster" \
+	--tag proj:6.1.0 \
+	--file Dockerfile.deb-packager \
+	.
+```
+
+Once built, you can extract the package from the image by running the image and
+copy the file out. In one terminal, run the container with
+
+```
+docker run --name proj --interactive --tty proj:6.1.0
+```
+
+Then from another terminal, you can use the following command to extract the
+file in your current directory.
+```
+docker cp proj:/deb/proj_6.1.0_x86-64.deb ./
+```
+
 ### Distribution files and format
 
 Sources are distributed in one or more files.  The principle elements


### PR DESCRIPTION
I recently had to build a '.deb' package of PROJ. Debian provide old version of PROJ (version 4) and I needed a version 6 in order to use it in Rust (see crate [proj](https://crates.io/crates/proj)). I couldn't find anything in the project to do that.

I documented in the `README.md` how to use and get the '.deb' package.

I'm more than open to discuss and/or refactor totally this solution. I'm aware the solution is not ideal.