### PR TITLE
Fix tests still running despite being disabled in Release 5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,5 +164,6 @@ add_subdirectory(nad)
 add_subdirectory(src)
 add_subdirectory(man)
 add_subdirectory(cmake)
-add_subdirectory(test)
-
+if(PROJ_TESTS)
+  add_subdirectory(test)
+endif(PROJ_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
 
 # For historic reasons, the CMake PROJECT-NAME is PROJ4
-project(PROJ4 LANGUAGES C CXX)
+project(PROJ4 C CXX)
 set(PROJECT_INTERN_NAME PROJ)
 
 if (NOT CMAKE_VERSION VERSION_LESS 3.1)


### PR DESCRIPTION
This is currently in master / release 6.0, however in the lab I work at we are currently on Proj 5.2, so it would be great to backport this fix despite it being an older release. CMake 2.8.12.2 (testing on CentOS7) fails to download the GoogleTest files, and without this patch there is no way to disable testing.

I'm not sure what your policy is on backporting fixes to older versions / releasing them, but I figured it may help someone to have this here.