### PR TITLE
HOWTO-RELEASE: add instructions to avoid website to be erased by an older version

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -235,3 +235,11 @@ version numbers in the files.
 
 *Commit changes. Either to master or maintenance branch depending on the nature
 of the release.*
+
+3.2 Disable website deployment when releasing a new non-bugfix version
+-------------------------------------------------------------------------------
+
+If the previous active version was, let's say, 6.1 and the new version is, let's say, 6.2,
+then checkout 6.1 branch, and in travis/after_success.sh, remove the code
+that causes commits to 6.1 to cause a website refresh, that is remove the
+code under `if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "6.1"; then`.


### PR DESCRIPTION
@kbevers This should avoid the website to be corrupted like the recent commit in the 5.2 branch did (addressed by b285484ea3b6fb62f0ead9876458f894d6ba3194 and 0d878429db637da5f29c1dfdb428390229b08e8c)