### PR TITLE
AppVeyor: disable VS 2015 builds, currently broken, due to issue with  vcpkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ environment:
   matrix:
 
 # VS 2015
-  - VS_VERSION: Visual Studio 14
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#  - VS_VERSION: Visual Studio 14
+#    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 # VS 2017
   - VS_VERSION: Visual Studio 15


### PR DESCRIPTION
VS 2015 builds fail with
https://ci.appveyor.com/project/OSGeo/proj/builds/26511038/job/73p3d8qphw2b2y9u
```
Warning: Different source is available for vcpkg (2018.11.23 -> 2019.7.18). Use .\bootstrap-vcpkg.bat to update.
Your feedback is important to improve Vcpkg! Please take 3 minutes to complete our survey by running: vcpkg contact --survey
Warning: an error occurred while parsing 'abseil'
[...]
```

The suggested trick of running .\bootstrap-vcpkg.bat does not work, as
vcpkg build from source fails on AppVeyor with VS2015, although upstream vcpkg
claims to support VS2015

The same issue affected GDAL per https://github.com/OSGeo/gdal/issues/1747
and I also had to disable VS2015 builds