### PR TITLE
Add proj_create_crs_to_crs_from_pj()

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -153,6 +153,18 @@ paragraph for more details.
     :type `area`: PJ_AREA
     :returns: :c:type:`PJ*`
 
+.. c:function:: PJ* proj_create_crs_to_crs_from_pj(PJ_CONTEXT *ctx, PJ *source_crs, PJ *target_crs, PJ_AREA *area, const char* const *options)
+
+    .. versionadded:: 6.2.0
+
+    Create a transformation object that is a pipeline between two known
+    coordinate reference systems.
+
+    This is the same as :c:func:`proj_create_crs_to_crs` except that the source and
+    target CRS are passed as PJ* objects which must of the CRS variety.
+
+    :param `options`: should be set to NULL currently.
+
 .. c:function:: PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj)
 
     .. versionadded:: 6.1.0

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -874,6 +874,7 @@ proj_create_conversion_wagner_v
 proj_create_conversion_wagner_vi
 proj_create_conversion_wagner_vii
 proj_create_crs_to_crs
+proj_create_crs_to_crs_from_pj
 proj_create_cs
 proj_create_ellipsoidal_2D_cs
 proj_create_engineering_crs

--- a/src/proj.h
+++ b/src/proj.h
@@ -357,6 +357,11 @@ int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_leg
 PJ PROJ_DLL *proj_create (PJ_CONTEXT *ctx, const char *definition);
 PJ PROJ_DLL *proj_create_argv (PJ_CONTEXT *ctx, int argc, char **argv);
 PJ PROJ_DLL *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area);
+PJ PROJ_DLL *proj_create_crs_to_crs_from_pj(PJ_CONTEXT *ctx,
+                                            PJ *source_crs,
+                                            PJ *target_crs,
+                                            PJ_AREA *area,
+                                            const char* const *options);
 PJ PROJ_DLL *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj);
 PJ PROJ_DLL *proj_destroy (PJ *P);
 

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -3711,4 +3711,30 @@ TEST_F(Fixture_proj_context_set_autoclose_database,
        proj_context_set_autoclose_database_false) {
     test(false);
 }
+
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_create_crs_to_crs_from_pj) {
+
+    auto src = proj_create(m_ctxt, "EPSG:4326");
+    ObjectKeeper keeper_src(src);
+    ASSERT_NE(src, nullptr);
+
+    auto dst = proj_create(m_ctxt, "EPSG:32631");
+    ObjectKeeper keeper_dst(dst);
+    ASSERT_NE(dst, nullptr);
+
+    auto P = proj_create_crs_to_crs_from_pj(m_ctxt, src, dst, nullptr, nullptr);
+    ObjectKeeper keeper_P(P);
+    ASSERT_NE(P, nullptr);
+    auto Pnormalized = proj_normalize_for_visualization(m_ctxt, P);
+    ObjectKeeper keeper_Pnormalized(Pnormalized);
+    ASSERT_NE(Pnormalized, nullptr);
+    auto projstr = proj_as_proj_string(m_ctxt, Pnormalized, PJ_PROJ_5, nullptr);
+    ASSERT_NE(projstr, nullptr);
+    EXPECT_EQ(std::string(projstr),
+              "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
+              "+step +proj=utm +zone=31 +ellps=WGS84");
+}
+
 } // namespace


### PR DESCRIPTION
I've been frustrated a number of times with proj_create_crs_to_crs()
not accepting a PJ* object for the source and target CRS.
And thus constraining to go back to WKT2 in a artificial way.