### PR TITLE
Doc: add link to final WKT2:2019 document

### DIFF
--- a/src/general_doc.dox
+++ b/src/general_doc.dox
@@ -102,11 +102,10 @@ definitions, and coordinate operations. This is an implementation of
 
 PROJ implements the two following revisions of the standard:
 
-\subsubsection WKT2_2018 WKT2:2018
+\subsubsection WKT2_2018 WKT2:2018 / WKT2:2019
 
-[OGC 18-010r1, 2018-06-08, WKT2-2018]
-(https://portal.opengeospatial.org/files/?artifact_id=79826)
-(not yet adopted, at time of writing)
+[OGC 18-010r7, 2019-06-24, WKT2-2019]
+(http://docs.opengeospatial.org/is/18-010r7/18-010r7.html)
 
 \subsubsection WKT2_2015 WKT2:2015
 


### PR DESCRIPTION
This PR is boring by itself, but didn't want to commit that in master as we're in RC mode and wasn't sure what our policy is.

Another more important question (but boring itself) is that due to the lennnnnngthy pubication process what I thought was going to be WKT2:2018 ended up being WKT2:2019 / ISO-19162:2019. All references in PROJ documentation, code... and API are about WKT2:2018. Should we do something about that ? Like switching to 2019, and having alias enumeration values for 2018 to go on 2019 ?