### PR TITLE
proj_create_crs_to_crs_from_pj(): make the PJ* arguments const PJ*

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -946,7 +946,7 @@ static PJ* add_coord_op_to_list(PJ* op,
 }
 
 /*****************************************************************************/
-static PJ* create_operation_to_base_geog_crs(PJ_CONTEXT* ctx, PJ* crs) {
+static PJ* create_operation_to_base_geog_crs(PJ_CONTEXT* ctx, const PJ* crs) {
 /*****************************************************************************/
     // Create a geographic 2D long-lat degrees CRS that is related to the
     // CRS
@@ -1052,7 +1052,7 @@ PJ  *proj_create_crs_to_crs (PJ_CONTEXT *ctx, const char *source_crs, const char
 }
 
 /*****************************************************************************/
-PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, PJ *source_crs, PJ *target_crs, PJ_AREA *area, const char* const *) {
+PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, const PJ *target_crs, PJ_AREA *area, const char* const *) {
 /******************************************************************************
     Create a transformation pipeline between two known coordinate reference
     systems.

--- a/src/proj.h
+++ b/src/proj.h
@@ -358,8 +358,8 @@ PJ PROJ_DLL *proj_create (PJ_CONTEXT *ctx, const char *definition);
 PJ PROJ_DLL *proj_create_argv (PJ_CONTEXT *ctx, int argc, char **argv);
 PJ PROJ_DLL *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area);
 PJ PROJ_DLL *proj_create_crs_to_crs_from_pj(PJ_CONTEXT *ctx,
-                                            PJ *source_crs,
-                                            PJ *target_crs,
+                                            const PJ *source_crs,
+                                            const PJ *target_crs,
                                             PJ_AREA *area,
                                             const char* const *options);
 PJ PROJ_DLL *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj);


### PR DESCRIPTION
This will make the life of C++ users using the C API slightly easier.
There's no ABI or API backward compatibility issue in doing that change as
constness of arguments is not retained in the C ABI, and any non-const
object passed as argument is implicitly converted as a const object if
that is what is mentionned in the argument list.