### PR TITLE
Use in API and utilities WKT2_2019 instead of WKT2_2018 (fixes #1578)

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -71,9 +71,11 @@ The following control parameters can appear in any order:
 .. option:: -o formats
 
     formats is a comma separated combination of:
-    ``all``, ``default``, ``PROJ``, ``WKT_ALL``, ``WKT2_2015``, ``WKT2_2018``, ``WKT1_GDAL``, ``WKT1_ESRI``, ``PROJJSON``.
+    ``all``, ``default``, ``PROJ``, ``WKT_ALL``, ``WKT2:2015``, ``WKT2:2019``, ``WKT1:GDAL``, ``WKT1:ESRI``, ``PROJJSON``.
 
     Except ``all`` and ``default``, other formats can be preceded by ``-`` to disable them.
+
+    .. note:: WKT2_2019 was previously called WKT2_2018.
 
 .. option:: -k crs|operation|ellipsoid
 
@@ -244,7 +246,7 @@ Output:
     PROJ.4 string:
     +proj=longlat +datum=WGS84 +no_defs +type=crs
 
-    WKT2_2018 string:
+    WKT2:2019 string:
     GEOGCRS["WGS 84",
         DATUM["World Geodetic System 1984",
             ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -283,7 +285,7 @@ Output:
     +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=conus \
     +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-    WKT2_2018 string:
+    WKT2:2019 string:
     COORDINATEOPERATION["NAD27 to NAD83 (1)",
         SOURCECRS[
             GEOGCRS["NAD27",

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -137,7 +137,7 @@ of the Well-Known Text output:
     PROJ.4 string:
     +proj=longlat +datum=WGS84 +no_defs +type=crs
 
-    WKT2_2018 string:
+    WKT2:2019 string:
     GEOGCRS["WGS 84",
         DATUM["World Geodetic System 1984",
             ELLIPSOID["WGS 84",6378137,298.257223563,

--- a/include/proj/coordinatesystem.hpp
+++ b/include/proj/coordinatesystem.hpp
@@ -623,7 +623,7 @@ class PROJ_GCC_DLL TemporalCS : public CoordinateSystem {
     INLINED_MAKE_SHARED
 
     PROJ_INTERNAL std::string
-    getWKT2Type(bool use2018Keywords) const override = 0;
+    getWKT2Type(bool use2019Keywords) const override = 0;
 
   private:
     TemporalCS(const TemporalCS &other) = delete;
@@ -661,7 +661,7 @@ class PROJ_GCC_DLL DateTimeTemporalCS final : public TemporalCS {
         const CoordinateSystemAxisNNPtr &axis);
     INLINED_MAKE_SHARED
 
-    PROJ_INTERNAL std::string getWKT2Type(bool use2018Keywords) const override;
+    PROJ_INTERNAL std::string getWKT2Type(bool use2019Keywords) const override;
 
   private:
     DateTimeTemporalCS(const DateTimeTemporalCS &other) = delete;
@@ -697,7 +697,7 @@ class PROJ_GCC_DLL TemporalCountCS final : public TemporalCS {
         const CoordinateSystemAxisNNPtr &axis);
     INLINED_MAKE_SHARED
 
-    PROJ_INTERNAL std::string getWKT2Type(bool use2018Keywords) const override;
+    PROJ_INTERNAL std::string getWKT2Type(bool use2019Keywords) const override;
 
   private:
     TemporalCountCS(const TemporalCountCS &other) = delete;
@@ -733,7 +733,7 @@ class PROJ_GCC_DLL TemporalMeasureCS final : public TemporalCS {
         const CoordinateSystemAxisNNPtr &axis);
     INLINED_MAKE_SHARED
 
-    PROJ_INTERNAL std::string getWKT2Type(bool use2018Keywords) const override;
+    PROJ_INTERNAL std::string getWKT2Type(bool use2019Keywords) const override;
 
   private:
     TemporalMeasureCS(const TemporalMeasureCS &other) = delete;

--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1352,7 +1352,7 @@ struct PROJ_GCC_DLL DerivedEngineeringCRSTraits {
     inline static const std::string &CRSName();
     inline static const std::string &WKTKeyword();
     inline static const std::string &WKTBaseKeyword();
-    static const bool wkt2_2018_only = true;
+    static const bool wkt2_2019_only = true;
 };
 //! @endcond
 
@@ -1390,7 +1390,7 @@ struct PROJ_GCC_DLL DerivedParametricCRSTraits {
     inline static const std::string &CRSName();
     inline static const std::string &WKTKeyword();
     inline static const std::string &WKTBaseKeyword();
-    static const bool wkt2_2018_only = false;
+    static const bool wkt2_2019_only = false;
 };
 //! @endcond
 
@@ -1427,7 +1427,7 @@ struct PROJ_GCC_DLL DerivedTemporalCRSTraits {
     inline static const std::string &CRSName();
     inline static const std::string &WKTKeyword();
     inline static const std::string &WKTBaseKeyword();
-    static const bool wkt2_2018_only = false;
+    static const bool wkt2_2019_only = false;
 };
 //! @endcond
 

--- a/include/proj/internal/io_internal.hpp
+++ b/include/proj/internal/io_internal.hpp
@@ -87,8 +87,8 @@ class WKTConstants {
     static const std::string CONVERSION;
     static const std::string METHOD;
     static const std::string REMARK;
-    static const std::string GEOGCRS;     // WKT2-2018
-    static const std::string BASEGEOGCRS; // WKT2-2018
+    static const std::string GEOGCRS;     // WKT2-2019
+    static const std::string BASEGEOGCRS; // WKT2-2019
     static const std::string SCOPE;
     static const std::string AREA;
     static const std::string BBOX;
@@ -103,27 +103,27 @@ class WKTConstants {
     static const std::string TARGETCRS;
     static const std::string INTERPOLATIONCRS;
     static const std::string OPERATIONACCURACY;
-    static const std::string CONCATENATEDOPERATION; // WKT2-2018
-    static const std::string STEP;                  // WKT2-2018
+    static const std::string CONCATENATEDOPERATION; // WKT2-2019
+    static const std::string STEP;                  // WKT2-2019
     static const std::string BOUNDCRS;
     static const std::string ABRIDGEDTRANSFORMATION;
     static const std::string DERIVINGCONVERSION;
     static const std::string TDATUM;
-    static const std::string CALENDAR; // WKT2-2018
+    static const std::string CALENDAR; // WKT2-2019
     static const std::string TIMEORIGIN;
     static const std::string TIMECRS;
     static const std::string VERTICALEXTENT;
     static const std::string TIMEEXTENT;
-    static const std::string USAGE;            // WKT2-2018
-    static const std::string DYNAMIC;          // WKT2-2018
-    static const std::string FRAMEEPOCH;       // WKT2-2018
-    static const std::string MODEL;            // WKT2-2018
-    static const std::string VELOCITYGRID;     // WKT2-2018
-    static const std::string ENSEMBLE;         // WKT2-2018
-    static const std::string MEMBER;           // WKT2-2018
-    static const std::string ENSEMBLEACCURACY; // WKT2-2018
-    static const std::string DERIVEDPROJCRS;   // WKT2-2018
-    static const std::string BASEPROJCRS;      // WKT2-2018
+    static const std::string USAGE;            // WKT2-2019
+    static const std::string DYNAMIC;          // WKT2-2019
+    static const std::string FRAMEEPOCH;       // WKT2-2019
+    static const std::string MODEL;            // WKT2-2019
+    static const std::string VELOCITYGRID;     // WKT2-2019
+    static const std::string ENSEMBLE;         // WKT2-2019
+    static const std::string MEMBER;           // WKT2-2019
+    static const std::string ENSEMBLEACCURACY; // WKT2-2019
+    static const std::string DERIVEDPROJCRS;   // WKT2-2019
+    static const std::string BASEPROJCRS;      // WKT2-2019
     static const std::string EDATUM;
     static const std::string ENGCRS;
     static const std::string PDATUM;
@@ -140,11 +140,11 @@ class WKTConstants {
     static const std::string GEODETICDATUM;
     static const std::string PROJECTEDCRS;
     static const std::string PRIMEMERIDIAN;
-    static const std::string GEOGRAPHICCRS; // WKT2-2018
-    static const std::string TRF;           // WKT2-2018
+    static const std::string GEOGRAPHICCRS; // WKT2-2019
+    static const std::string TRF;           // WKT2-2019
     static const std::string VERTICALCRS;
     static const std::string VERTICALDATUM;
-    static const std::string VRF; // WKT2-2018
+    static const std::string VRF; // WKT2-2019
     static const std::string TIMEDATUM;
     static const std::string TEMPORALQUANTITY;
     static const std::string ENGINEERINGDATUM;

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -182,18 +182,24 @@ class PROJ_GCC_DLL WKTFormatter {
         WKT2_SIMPLIFIED,
         WKT2_2015_SIMPLIFIED = WKT2_SIMPLIFIED,
 
-        /** Full WKT2 string, conforming to ISO 19162:2018 / OGC 18-010, with
-         * (\ref WKT2_2018) all possible nodes and new keyword names.
+        /** Full WKT2 string, conforming to ISO 19162:2019 / OGC 18-010, with
+         * (\ref WKT2_2019) all possible nodes and new keyword names.
          * Non-normative list of differences:
          * <ul>
-         *      <li>WKT2_2018 uses GEOGCRS / BASEGEOGCRS keywords for
+         *      <li>WKT2_2019 uses GEOGCRS / BASEGEOGCRS keywords for
          * GeographicCRS.</li>
          * </ul>
          */
-        WKT2_2018,
+        WKT2_2019,
 
-        /** WKT2_2018 with the simplification rule of WKT2_SIMPLIFIED */
-        WKT2_2018_SIMPLIFIED,
+        /** Deprecated alias for WKT2_2019 */
+        WKT2_2018 = WKT2_2019,
+
+        /** WKT2_2019 with the simplification rule of WKT2_SIMPLIFIED */
+        WKT2_2019_SIMPLIFIED,
+
+        /** Deprecated alias for WKT2_2019_SIMPLIFIED */
+        WKT2_2018_SIMPLIFIED = WKT2_2019_SIMPLIFIED,
 
         /** WKT1 as traditionally output by GDAL, deriving from OGC 01-009.
             A notable departure from WKT1_GDAL with respect to OGC 01-009 is
@@ -322,7 +328,7 @@ class PROJ_GCC_DLL WKTFormatter {
     };
 
     PROJ_INTERNAL Version version() const;
-    PROJ_INTERNAL bool use2018Keywords() const;
+    PROJ_INTERNAL bool use2019Keywords() const;
     PROJ_INTERNAL bool useESRIDialect() const;
 
     PROJ_INTERNAL const DatabaseContextPtr &databaseContext() const;
@@ -736,8 +742,10 @@ class PROJ_GCC_DLL WKTParser {
 
     /** Guessed WKT "dialect" */
     enum class PROJ_MSVC_DLL WKTGuessedDialect {
-        /** \ref WKT2_2018 */
-        WKT2_2018,
+        /** \ref WKT2_2019 */
+        WKT2_2019,
+        /** Deprecated alias for WKT2_2019 */
+        WKT2_2018 = WKT2_2019,
         /** \ref WKT2_2015 */
         WKT2_2015,
         /** \ref WKT1 */

--- a/scripts/doxygen.sh
+++ b/scripts/doxygen.sh
@@ -53,7 +53,7 @@ for i in ${TOPDIR}/docs/build/xml/*; do
 done
 
 # There is a confusion for Breathe between PROJStringFormatter::Convention and WKTFormatter:Convention
-sed "s/Convention/Convention_/g" < ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml | sed "s/WKT2_2018/_WKT2_2018/g" | sed "s/WKT2_2015/_WKT2_2015/g" | sed "s/WKT1_GDAL/_WKT1_GDAL/g" | sed "s/WKT1_ESRI/_WKT1_ESRI/g" > ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml.tmp
+sed "s/Convention/Convention_/g" < ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml | sed "s/WKT2_2018/_WKT2_2018/g" | sed "s/WKT2_2019/_WKT2_2019/g" | sed "s/WKT2_2015/_WKT2_2015/g" | sed "s/WKT1_GDAL/_WKT1_GDAL/g" | sed "s/WKT1_ESRI/_WKT1_ESRI/g" > ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml.tmp
 mv ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml.tmp  ${TOPDIR}/docs/build/xml/classosgeo_1_1proj_1_1io_1_1WKTFormatter.xml
 
 popd > /dev/null || exit

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -61,8 +61,8 @@ namespace { // anonymous namespace
 struct OutputOptions {
     bool quiet = false;
     bool PROJ5 = false;
-    bool WKT2_2018 = false;
-    bool WKT2_2018_SIMPLIFIED = false;
+    bool WKT2_2019 = false;
+    bool WKT2_2019_SIMPLIFIED = false;
     bool WKT2_2015 = false;
     bool WKT2_2015_SIMPLIFIED = false;
     bool WKT1_GDAL = false;
@@ -101,8 +101,8 @@ static void usage() {
         << std::endl;
     std::cerr << std::endl;
     std::cerr << "-o: formats is a comma separated combination of: "
-                 "all,default,PROJ,WKT_ALL,WKT2_2015,WKT2_2018,WKT1_GDAL,"
-                 "WKT1_ESRI,PROJJSON"
+                 "all,default,PROJ,WKT_ALL,WKT2:2015,WKT2:2019,WKT1:GDAL,"
+                 "WKT1:ESRI,PROJJSON"
               << std::endl;
     std::cerr << "    Except 'all' and 'default', other format can be preceded "
                  "by '-' to disable them"
@@ -309,7 +309,7 @@ static void outputObject(
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT2_2015 string:" << std::endl;
+                    std::cout << "WKT2:2015 string:" << std::endl;
                 }
                 auto formatter =
                     WKTFormatter::create(WKTFormatter::Convention::WKT2_2015);
@@ -323,7 +323,7 @@ static void outputObject(
                 }
                 std::cout << wkt << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT2_2015: " << e.what()
+                std::cerr << "Error when exporting to WKT2:2015: " << e.what()
                           << std::endl;
             }
             alreadyOutputed = true;
@@ -335,7 +335,7 @@ static void outputObject(
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT2_2015_SIMPLIFIED string:" << std::endl;
+                    std::cout << "WKT2:2015_SIMPLIFIED string:" << std::endl;
                 }
                 auto formatter = WKTFormatter::create(
                     WKTFormatter::Convention::WKT2_2015_SIMPLIFIED);
@@ -349,22 +349,22 @@ static void outputObject(
                 }
                 std::cout << wkt << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT2_2015_SIMPLIFIED: "
+                std::cerr << "Error when exporting to WKT2:2015_SIMPLIFIED: "
                           << e.what() << std::endl;
             }
             alreadyOutputed = true;
         }
 
-        if (outputOpt.WKT2_2018) {
+        if (outputOpt.WKT2_2019) {
             try {
                 if (alreadyOutputed) {
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT2_2018 string:" << std::endl;
+                    std::cout << "WKT2:2019 string:" << std::endl;
                 }
                 auto formatter =
-                    WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+                    WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
                 if (outputOpt.singleLine) {
                     formatter->setMultiLine(false);
                 }
@@ -375,22 +375,22 @@ static void outputObject(
                 }
                 std::cout << wkt << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT2_2018: " << e.what()
+                std::cerr << "Error when exporting to WKT2:2019: " << e.what()
                           << std::endl;
             }
             alreadyOutputed = true;
         }
 
-        if (outputOpt.WKT2_2018_SIMPLIFIED) {
+        if (outputOpt.WKT2_2019_SIMPLIFIED) {
             try {
                 if (alreadyOutputed) {
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT2_2018_SIMPLIFIED string:" << std::endl;
+                    std::cout << "WKT2:2019_SIMPLIFIED string:" << std::endl;
                 }
                 auto formatter = WKTFormatter::create(
-                    WKTFormatter::Convention::WKT2_2018_SIMPLIFIED);
+                    WKTFormatter::Convention::WKT2_2019_SIMPLIFIED);
                 if (outputOpt.singleLine) {
                     formatter->setMultiLine(false);
                 }
@@ -401,7 +401,7 @@ static void outputObject(
                 }
                 std::cout << wkt << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT2_2018_SIMPLIFIED: "
+                std::cerr << "Error when exporting to WKT2:2019_SIMPLIFIED: "
                           << e.what() << std::endl;
             }
             alreadyOutputed = true;
@@ -413,7 +413,7 @@ static void outputObject(
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT1_GDAL:" << std::endl;
+                    std::cout << "WKT1:GDAL string:" << std::endl;
                 }
 
                 auto crs = nn_dynamic_pointer_cast<CRS>(obj);
@@ -440,7 +440,7 @@ static void outputObject(
                 std::cout << wkt << std::endl;
                 std::cout << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT1_GDAL: " << e.what()
+                std::cerr << "Error when exporting to WKT1:GDAL: " << e.what()
                           << std::endl;
             }
             alreadyOutputed = true;
@@ -452,7 +452,7 @@ static void outputObject(
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "WKT1_ESRI:" << std::endl;
+                    std::cout << "WKT1:ESRI string:" << std::endl;
                 }
 
                 auto formatter = WKTFormatter::create(
@@ -465,7 +465,7 @@ static void outputObject(
                 std::cout << wkt << std::endl;
                 std::cout << std::endl;
             } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to WKT1_ESRI: " << e.what()
+                std::cerr << "Error when exporting to WKT1:ESRI: " << e.what()
                           << std::endl;
             }
             alreadyOutputed = true;
@@ -745,14 +745,14 @@ int main(int argc, char **argv) {
             for (auto format : formats) {
                 if (ci_equal(format, "all")) {
                     outputOpt.PROJ5 = true;
-                    outputOpt.WKT2_2018 = true;
+                    outputOpt.WKT2_2019 = true;
                     outputOpt.WKT2_2015 = true;
                     outputOpt.WKT1_GDAL = true;
                     outputOpt.WKT1_ESRI = true;
                     outputOpt.PROJJSON = true;
                 } else if (ci_equal(format, "default")) {
                     outputOpt.PROJ5 = true;
-                    outputOpt.WKT2_2018 = true;
+                    outputOpt.WKT2_2019 = true;
                     outputOpt.WKT2_2015 = false;
                     outputOpt.WKT1_GDAL = false;
                 } else if (ci_equal(format, "PROJ")) {
@@ -761,26 +761,38 @@ int main(int argc, char **argv) {
                     outputOpt.PROJ5 = false;
                 } else if (ci_equal(format, "WKT_ALL") ||
                            ci_equal(format, "WKT-ALL")) {
-                    outputOpt.WKT2_2018 = true;
+                    outputOpt.WKT2_2019 = true;
                     outputOpt.WKT2_2015 = true;
                     outputOpt.WKT1_GDAL = true;
                 } else if (ci_equal(format, "-WKT_ALL") ||
                            ci_equal(format, "-WKT-ALL")) {
-                    outputOpt.WKT2_2018 = false;
+                    outputOpt.WKT2_2019 = false;
                     outputOpt.WKT2_2015 = false;
                     outputOpt.WKT1_GDAL = false;
-                } else if (ci_equal(format, "WKT2_2018") ||
+                } else if (ci_equal(format, "WKT2_2019") ||
+                           ci_equal(format, "WKT2-2019") ||
+                           ci_equal(format, "WKT2:2019") ||
+                           /* legacy: undocumented */
+                           ci_equal(format, "WKT2_2018") ||
                            ci_equal(format, "WKT2-2018") ||
                            ci_equal(format, "WKT2:2018")) {
-                    outputOpt.WKT2_2018 = true;
-                } else if (ci_equal(format, "WKT2_2018_SIMPLIFIED") ||
+                    outputOpt.WKT2_2019 = true;
+                } else if (ci_equal(format, "WKT2_2019_SIMPLIFIED") ||
+                           ci_equal(format, "WKT2-2019_SIMPLIFIED") ||
+                           ci_equal(format, "WKT2:2019_SIMPLIFIED") ||
+                           /* legacy: undocumented */
+                           ci_equal(format, "WKT2_2018_SIMPLIFIED") ||
                            ci_equal(format, "WKT2-2018_SIMPLIFIED") ||
                            ci_equal(format, "WKT2:2018_SIMPLIFIED")) {
-                    outputOpt.WKT2_2018_SIMPLIFIED = true;
-                } else if (ci_equal(format, "-WKT2_2018") ||
+                    outputOpt.WKT2_2019_SIMPLIFIED = true;
+                } else if (ci_equal(format, "-WKT2_2019") ||
+                           ci_equal(format, "-WKT2-2019") ||
+                           ci_equal(format, "-WKT2:2019") ||
+                           /* legacy: undocumented */
+                           ci_equal(format, "-WKT2_2018") ||
                            ci_equal(format, "-WKT2-2018") ||
                            ci_equal(format, "-WKT2:2018")) {
-                    outputOpt.WKT2_2018 = false;
+                    outputOpt.WKT2_2019 = false;
                 } else if (ci_equal(format, "WKT2_2015") ||
                            ci_equal(format, "WKT2-2015") ||
                            ci_equal(format, "WKT2:2015")) {
@@ -1027,11 +1039,11 @@ int main(int argc, char **argv) {
 
     if (!outputSwithSpecified) {
         outputOpt.PROJ5 = true;
-        outputOpt.WKT2_2018 = true;
+        outputOpt.WKT2_2019 = true;
     }
 
     if (outputOpt.quiet &&
-        (outputOpt.PROJ5 + outputOpt.WKT2_2018 + outputOpt.WKT2_2015 +
+        (outputOpt.PROJ5 + outputOpt.WKT2_2019 + outputOpt.WKT2_2015 +
          outputOpt.WKT1_GDAL + outputOpt.PROJJSON) != 1) {
         std::cerr << "-q can only be used with a single output format"
                   << std::endl;
@@ -1046,8 +1058,8 @@ int main(int argc, char **argv) {
             if (guessDialect) {
                 auto dialect = WKTParser().guessDialect(user_string);
                 std::cout << "Guessed WKT dialect: ";
-                if (dialect == WKTParser::WKTGuessedDialect::WKT2_2018) {
-                    std::cout << "WKT2_2018";
+                if (dialect == WKTParser::WKTGuessedDialect::WKT2_2019) {
+                    std::cout << "WKT2_2019";
                 } else if (dialect == WKTParser::WKTGuessedDialect::WKT2_2015) {
                     std::cout << "WKT2_2015";
                 } else if (dialect == WKTParser::WKTGuessedDialect::WKT1_GDAL) {

--- a/src/general_doc.dox
+++ b/src/general_doc.dox
@@ -102,7 +102,7 @@ definitions, and coordinate operations. This is an implementation of
 
 PROJ implements the two following revisions of the standard:
 
-\subsubsection WKT2_2018 WKT2:2018 / WKT2:2019
+\subsubsection WKT2_2019 WKT2:2019
 
 [OGC 18-010r7, 2019-06-24, WKT2-2019]
 (http://docs.opengeospatial.org/is/18-010r7/18-010r7.html)

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -360,8 +360,8 @@ PJ_GUESSED_WKT_DIALECT proj_context_guess_wkt_dialect(PJ_CONTEXT *ctx,
     (void)ctx;
     assert(wkt);
     switch (WKTParser().guessDialect(wkt)) {
-    case WKTParser::WKTGuessedDialect::WKT2_2018:
-        return PJ_GUESSED_WKT2_2018;
+    case WKTParser::WKTGuessedDialect::WKT2_2019:
+        return PJ_GUESSED_WKT2_2019;
     case WKTParser::WKTGuessedDialect::WKT2_2015:
         return PJ_GUESSED_WKT2_2015;
     case WKTParser::WKTGuessedDialect::WKT1_GDAL:
@@ -1308,10 +1308,10 @@ const char *proj_as_wkt(PJ_CONTEXT *ctx, const PJ *obj, PJ_WKT_TYPE type,
             return WKTFormatter::Convention::WKT2_2015;
         case PJ_WKT2_2015_SIMPLIFIED:
             return WKTFormatter::Convention::WKT2_2015_SIMPLIFIED;
-        case PJ_WKT2_2018:
-            return WKTFormatter::Convention::WKT2_2018;
-        case PJ_WKT2_2018_SIMPLIFIED:
-            return WKTFormatter::Convention::WKT2_2018_SIMPLIFIED;
+        case PJ_WKT2_2019:
+            return WKTFormatter::Convention::WKT2_2019;
+        case PJ_WKT2_2019_SIMPLIFIED:
+            return WKTFormatter::Convention::WKT2_2019_SIMPLIFIED;
         case PJ_WKT1_GDAL:
             return WKTFormatter::Convention::WKT1_GDAL;
         case PJ_WKT1_ESRI:

--- a/src/iso19111/common.cpp
+++ b/src/iso19111/common.cpp
@@ -989,7 +989,7 @@ void ObjectDomain::_exportToWKT(WKTFormatter *formatter) const {
         formatter->startNode(WKTConstants::SCOPE, false);
         formatter->addQuotedString(*(d->scope_));
         formatter->endNode();
-    } else if (formatter->use2018Keywords()) {
+    } else if (formatter->use2019Keywords()) {
         formatter->startNode(WKTConstants::SCOPE, false);
         formatter->addQuotedString("unknown");
         formatter->endNode();
@@ -1192,7 +1192,7 @@ void ObjectUsage::baseExportToWKT(WKTFormatter *formatter) const {
     if (isWKT2 && formatter->outputUsage()) {
         auto l_domains = domains();
         if (!l_domains.empty()) {
-            if (formatter->use2018Keywords()) {
+            if (formatter->use2019Keywords()) {
                 for (const auto &domain : l_domains) {
                     formatter->startNode(WKTConstants::USAGE, false);
                     domain->_exportToWKT(formatter);

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -7943,7 +7943,7 @@ static void exportSourceCRSAndTargetCRSToWKT(const CoordinateOperation *co,
     assert(l_targetCRS);
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
     const bool canExportCRSId =
-        (isWKT2 && formatter->use2018Keywords() &&
+        (isWKT2 && formatter->use2019Keywords() &&
          !(formatter->idOnTopLevelOnly() && formatter->topLevelHasId()));
 
     const bool hasDomains = !co->domains().empty();
@@ -8000,7 +8000,7 @@ void SingleOperation::exportTransformationToWKT(
 
     formatter->addQuotedString(nameStr());
 
-    if (formatter->use2018Keywords()) {
+    if (formatter->use2019Keywords()) {
         const auto &version = operationVersion();
         if (version.has_value()) {
             formatter->startNode(io::WKTConstants::VERSION, false);
@@ -9405,13 +9405,13 @@ ConcatenatedOperationNNPtr ConcatenatedOperation::create(
 #ifdef DEBUG_CONCATENATED_OPERATION
                 {
                     auto f(io::WKTFormatter::create(
-                        io::WKTFormatter::Convention::WKT2_2018));
+                        io::WKTFormatter::Convention::WKT2_2019));
                     std::cerr << "Source CRS of step " << i << ":" << std::endl;
                     std::cerr << l_sourceCRS->exportToWKT(f.get()) << std::endl;
                 }
                 {
                     auto f(io::WKTFormatter::create(
-                        io::WKTFormatter::Convention::WKT2_2018));
+                        io::WKTFormatter::Convention::WKT2_2019));
                     std::cerr << "Target CRS of step " << i - 1 << ":"
                               << std::endl;
                     std::cerr << lastTargetCRS->exportToWKT(f.get())
@@ -9434,7 +9434,7 @@ ConcatenatedOperationNNPtr ConcatenatedOperation::create(
 #ifdef DEBUG_CONCATENATED_OPERATION
     {
         auto f(
-            io::WKTFormatter::create(io::WKTFormatter::Convention::WKT2_2018));
+            io::WKTFormatter::create(io::WKTFormatter::Convention::WKT2_2019));
         std::cerr << "ConcatenatedOperation::create()" << std::endl;
         std::cerr << op->exportToWKT(f.get()) << std::endl;
     }
@@ -9697,16 +9697,16 @@ CoordinateOperationNNPtr ConcatenatedOperation::inverse() const {
 //! @cond Doxygen_Suppress
 void ConcatenatedOperation::_exportToWKT(io::WKTFormatter *formatter) const {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (!isWKT2 || !formatter->use2018Keywords()) {
+    if (!isWKT2 || !formatter->use2019Keywords()) {
         throw io::FormattingException(
-            "Transformation can only be exported to WKT2:2018");
+            "Transformation can only be exported to WKT2:2019");
     }
 
     formatter->startNode(io::WKTConstants::CONCATENATEDOPERATION,
                          !identifiers().empty());
     formatter->addQuotedString(nameStr());
 
-    if (isWKT2 && formatter->use2018Keywords()) {
+    if (isWKT2 && formatter->use2019Keywords()) {
         const auto &version = operationVersion();
         if (version.has_value()) {
             formatter->startNode(io::WKTConstants::VERSION, false);

--- a/src/iso19111/coordinatesystem.cpp
+++ b/src/iso19111/coordinatesystem.cpp
@@ -519,7 +519,7 @@ void CoordinateSystem::_exportToWKT(
     const auto &l_axisList = axisList();
     if (isWKT2) {
         formatter->startNode(io::WKTConstants::CS_, !identifiers().empty());
-        formatter->add(getWKT2Type(formatter->use2018Keywords()));
+        formatter->add(getWKT2Type(formatter->use2019Keywords()));
         formatter->add(static_cast<int>(l_axisList.size()));
         formatter->endNode();
         formatter->startNode(std::string(),
@@ -1268,8 +1268,8 @@ DateTimeTemporalCS::create(const util::PropertyMap &properties,
 
 // ---------------------------------------------------------------------------
 
-std::string DateTimeTemporalCS::getWKT2Type(bool use2018Keywords) const {
-    return use2018Keywords ? "TemporalDateTime" : "temporal";
+std::string DateTimeTemporalCS::getWKT2Type(bool use2019Keywords) const {
+    return use2019Keywords ? "TemporalDateTime" : "temporal";
 }
 
 // ---------------------------------------------------------------------------
@@ -1301,8 +1301,8 @@ TemporalCountCS::create(const util::PropertyMap &properties,
 
 // ---------------------------------------------------------------------------
 
-std::string TemporalCountCS::getWKT2Type(bool use2018Keywords) const {
-    return use2018Keywords ? "TemporalCount" : "temporal";
+std::string TemporalCountCS::getWKT2Type(bool use2019Keywords) const {
+    return use2019Keywords ? "TemporalCount" : "temporal";
 }
 
 // ---------------------------------------------------------------------------
@@ -1334,8 +1334,8 @@ TemporalMeasureCS::create(const util::PropertyMap &properties,
 
 // ---------------------------------------------------------------------------
 
-std::string TemporalMeasureCS::getWKT2Type(bool use2018Keywords) const {
-    return use2018Keywords ? "TemporalMeasure" : "temporal";
+std::string TemporalMeasureCS::getWKT2Type(bool use2019Keywords) const {
+    return use2019Keywords ? "TemporalMeasure" : "temporal";
 }
 
 } // namespace cs

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1148,7 +1148,7 @@ void GeodeticCRS::_exportToWKT(io::WKTFormatter *formatter) const {
     const bool isGeographic =
         dynamic_cast<const GeographicCRS *>(this) != nullptr;
     formatter->startNode(isWKT2
-                             ? ((formatter->use2018Keywords() && isGeographic)
+                             ? ((formatter->use2019Keywords() && isGeographic)
                                     ? io::WKTConstants::GEOGCRS
                                     : io::WKTConstants::GEODCRS)
                              : isGeocentric() ? io::WKTConstants::GEOCCS
@@ -2698,11 +2698,11 @@ void DerivedCRS::baseExportToWKT(io::WKTFormatter *formatter,
     formatter->addQuotedString(nameStr());
 
     const auto &l_baseCRS = d->baseCRS_;
-    formatter->startNode(baseKeyword, formatter->use2018Keywords() &&
+    formatter->startNode(baseKeyword, formatter->use2019Keywords() &&
                                           !l_baseCRS->identifiers().empty());
     formatter->addQuotedString(l_baseCRS->nameStr());
     l_baseCRS->exportDatumOrDatumEnsembleToWkt(formatter);
-    if (formatter->use2018Keywords() &&
+    if (formatter->use2019Keywords() &&
         !(formatter->idOnTopLevelOnly() && formatter->topLevelHasId())) {
         l_baseCRS->formatID(formatter);
     }
@@ -2883,9 +2883,9 @@ void ProjectedCRS::_exportToWKT(io::WKTFormatter *formatter) const {
 
     const auto &l_coordinateSystem = d->coordinateSystem();
     const auto &axisList = l_coordinateSystem->axisList();
-    if (axisList.size() == 3 && !(isWKT2 && formatter->use2018Keywords())) {
+    if (axisList.size() == 3 && !(isWKT2 && formatter->use2019Keywords())) {
         io::FormattingException::Throw(
-            "Projected 3D CRS can only be exported since WKT2:2018");
+            "Projected 3D CRS can only be exported since WKT2:2019");
     }
 
     const auto exportAxis = [&l_coordinateSystem, &axisList, &formatter]() {
@@ -2962,11 +2962,11 @@ void ProjectedCRS::_exportToWKT(io::WKTFormatter *formatter) const {
 
     if (isWKT2) {
         formatter->startNode(
-            (formatter->use2018Keywords() &&
+            (formatter->use2019Keywords() &&
              dynamic_cast<const GeographicCRS *>(l_baseCRS.get()))
                 ? io::WKTConstants::BASEGEOGCRS
                 : io::WKTConstants::BASEGEODCRS,
-            formatter->use2018Keywords() && !l_baseCRS->identifiers().empty());
+            formatter->use2019Keywords() && !l_baseCRS->identifiers().empty());
         formatter->addQuotedString(l_baseCRS->nameStr());
         l_baseCRS->exportDatumOrDatumEnsembleToWkt(formatter);
         // insert ellipsoidal cs unit when the units of the map
@@ -2977,7 +2977,7 @@ void ProjectedCRS::_exportToWKT(io::WKTFormatter *formatter) const {
             geodeticCRSAxisList[0]->unit()._exportToWKT(formatter);
         }
         l_baseCRS->primeMeridian()->_exportToWKT(formatter);
-        if (formatter->use2018Keywords() &&
+        if (formatter->use2019Keywords() &&
             !(formatter->idOnTopLevelOnly() && formatter->topLevelHasId())) {
             l_baseCRS->formatID(formatter);
         }
@@ -4422,7 +4422,7 @@ void DerivedGeodeticCRS::_exportToWKT(io::WKTFormatter *formatter) const {
     formatter->addQuotedString(nameStr());
 
     auto l_baseCRS = baseCRS();
-    formatter->startNode((formatter->use2018Keywords() &&
+    formatter->startNode((formatter->use2019Keywords() &&
                           dynamic_cast<const GeographicCRS *>(l_baseCRS.get()))
                              ? io::WKTConstants::BASEGEOGCRS
                              : io::WKTConstants::BASEGEODCRS,
@@ -4560,14 +4560,14 @@ void DerivedGeographicCRS::_exportToWKT(io::WKTFormatter *formatter) const {
         io::FormattingException::Throw(
             "DerivedGeographicCRS can only be exported to WKT2");
     }
-    formatter->startNode(formatter->use2018Keywords()
+    formatter->startNode(formatter->use2019Keywords()
                              ? io::WKTConstants::GEOGCRS
                              : io::WKTConstants::GEODCRS,
                          !identifiers().empty());
     formatter->addQuotedString(nameStr());
 
     auto l_baseCRS = baseCRS();
-    formatter->startNode((formatter->use2018Keywords() &&
+    formatter->startNode((formatter->use2019Keywords() &&
                           dynamic_cast<const GeographicCRS *>(l_baseCRS.get()))
                              ? io::WKTConstants::BASEGEOGCRS
                              : io::WKTConstants::BASEGEODCRS,
@@ -4693,9 +4693,9 @@ DerivedProjectedCRSNNPtr DerivedProjectedCRS::create(
 //! @cond Doxygen_Suppress
 void DerivedProjectedCRS::_exportToWKT(io::WKTFormatter *formatter) const {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (!isWKT2 || !formatter->use2018Keywords()) {
+    if (!isWKT2 || !formatter->use2019Keywords()) {
         io::FormattingException::Throw(
-            "DerivedProjectedCRS can only be exported to WKT2:2018");
+            "DerivedProjectedCRS can only be exported to WKT2:2019");
     }
     formatter->startNode(io::WKTConstants::DERIVEDPROJCRS,
                          !identifiers().empty());
@@ -5348,12 +5348,12 @@ const char *DerivedCRSTemplate<DerivedCRSTraits>::className() const {
 
 static void DerivedCRSTemplateCheckExportToWKT(io::WKTFormatter *formatter,
                                                const std::string &crsName,
-                                               bool wkt2_2018_only) {
+                                               bool wkt2_2019_only) {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (!isWKT2 || (wkt2_2018_only && !formatter->use2018Keywords())) {
+    if (!isWKT2 || (wkt2_2019_only && !formatter->use2019Keywords())) {
         io::FormattingException::Throw(crsName +
                                        " can only be exported to WKT2" +
-                                       (wkt2_2018_only ? ":2018" : ""));
+                                       (wkt2_2019_only ? ":2019" : ""));
     }
 }
 
@@ -5363,7 +5363,7 @@ template <class DerivedCRSTraits>
 void DerivedCRSTemplate<DerivedCRSTraits>::_exportToWKT(
     io::WKTFormatter *formatter) const {
     DerivedCRSTemplateCheckExportToWKT(formatter, DerivedCRSTraits::CRSName(),
-                                       DerivedCRSTraits::wkt2_2018_only);
+                                       DerivedCRSTraits::wkt2_2019_only);
     baseExportToWKT(formatter, DerivedCRSTraits::WKTKeyword(),
                     DerivedCRSTraits::WKTBaseKeyword());
 }

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1416,7 +1416,7 @@ void DynamicGeodeticReferenceFrame::_exportToWKT(
     io::WKTFormatter *formatter) const // throw(FormattingException)
 {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (isWKT2 && formatter->use2018Keywords()) {
+    if (isWKT2 && formatter->use2019Keywords()) {
         formatter->startNode(io::WKTConstants::DYNAMIC, false);
         formatter->startNode(io::WKTConstants::FRAMEEPOCH, false);
         formatter->add(
@@ -1530,9 +1530,9 @@ void DatumEnsemble::_exportToWKT(
     io::WKTFormatter *formatter) const // throw(FormattingException)
 {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (!isWKT2 || !formatter->use2018Keywords()) {
+    if (!isWKT2 || !formatter->use2019Keywords()) {
         throw io::FormattingException(
-            "DatumEnsemble can only be exported to WKT2:2018");
+            "DatumEnsemble can only be exported to WKT2:2019");
     }
 
     auto l_datums = datums();
@@ -1941,7 +1941,7 @@ void DynamicVerticalReferenceFrame::_exportToWKT(
     io::WKTFormatter *formatter) const // throw(FormattingException)
 {
     const bool isWKT2 = formatter->version() == io::WKTFormatter::Version::WKT2;
-    if (isWKT2 && formatter->use2018Keywords()) {
+    if (isWKT2 && formatter->use2019Keywords()) {
         formatter->startNode(io::WKTConstants::DYNAMIC, false);
         formatter->startNode(io::WKTConstants::FRAMEEPOCH, false);
         formatter->add(
@@ -2067,7 +2067,7 @@ void TemporalDatum::_exportToWKT(
     }
     formatter->startNode(io::WKTConstants::TDATUM, !identifiers().empty());
     formatter->addQuotedString(nameStr());
-    if (formatter->use2018Keywords()) {
+    if (formatter->use2019Keywords()) {
         formatter->startNode(io::WKTConstants::CALENDAR, false);
         formatter->addQuotedString(calendar());
         formatter->endNode();

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -138,7 +138,7 @@ struct WKTFormatter::Private {
         bool forceUNITKeyword_ = false;
         bool outputCSUnitOnlyOnceIfSame_ = false;
         bool primeMeridianInDegree_ = false;
-        bool use2018Keywords_ = false;
+        bool use2019Keywords_ = false;
         bool useESRIDialect_ = false;
         OutputAxisRule outputAxis_ = WKTFormatter::OutputAxisRule::YES;
     };
@@ -299,16 +299,16 @@ WKTFormatter::WKTFormatter(Convention convention)
     : d(internal::make_unique<Private>()) {
     d->params_.convention_ = convention;
     switch (convention) {
-    case Convention::WKT2_2018:
-        d->params_.use2018Keywords_ = true;
+    case Convention::WKT2_2019:
+        d->params_.use2019Keywords_ = true;
         PROJ_FALLTHROUGH
     case Convention::WKT2:
         d->params_.version_ = WKTFormatter::Version::WKT2;
         d->params_.outputAxisOrder_ = true;
         break;
 
-    case Convention::WKT2_2018_SIMPLIFIED:
-        d->params_.use2018Keywords_ = true;
+    case Convention::WKT2_2019_SIMPLIFIED:
+        d->params_.use2019Keywords_ = true;
         PROJ_FALLTHROUGH
     case Convention::WKT2_SIMPLIFIED:
         d->params_.version_ = WKTFormatter::Version::WKT2;
@@ -689,8 +689,8 @@ WKTFormatter::Version WKTFormatter::version() const {
 
 // ---------------------------------------------------------------------------
 
-bool WKTFormatter::use2018Keywords() const {
-    return d->params_.use2018Keywords_;
+bool WKTFormatter::use2019Keywords() const {
+    return d->params_.use2019Keywords_;
 }
 
 // ---------------------------------------------------------------------------
@@ -2569,7 +2569,7 @@ WKTParser::Private::buildCS(const WKTNodeNNPtr &node, /* maybe null */
             return SphericalCS::create(csMap, axisList[0], axisList[1],
                                        axisList[2]);
         }
-    } else if (ci_equal(csType, "ordinal")) { // WKT2-2018
+    } else if (ci_equal(csType, "ordinal")) { // WKT2-2019
         return OrdinalCS::create(csMap, axisList);
     } else if (ci_equal(csType, "parametric")) {
         if (axisCount == 1) {
@@ -2582,15 +2582,15 @@ WKTParser::Private::buildCS(const WKTNodeNNPtr &node, /* maybe null */
                 axisList[0]); // FIXME: there are 3 possible subtypes of
                               // TemporalCS
         }
-    } else if (ci_equal(csType, "TemporalDateTime")) { // WKT2-2018
+    } else if (ci_equal(csType, "TemporalDateTime")) { // WKT2-2019
         if (axisCount == 1) {
             return DateTimeTemporalCS::create(csMap, axisList[0]);
         }
-    } else if (ci_equal(csType, "TemporalCount")) { // WKT2-2018
+    } else if (ci_equal(csType, "TemporalCount")) { // WKT2-2019
         if (axisCount == 1) {
             return TemporalCountCS::create(csMap, axisList[0]);
         }
-    } else if (ci_equal(csType, "TemporalMeasure")) { // WKT2-2018
+    } else if (ci_equal(csType, "TemporalMeasure")) { // WKT2-2019
         if (axisCount == 1) {
             return TemporalMeasureCS::create(csMap, axisList[0]);
         }
@@ -2729,7 +2729,7 @@ WKTParser::Private::buildGeodeticCRS(const WKTNodeNNPtr &node) {
     } else if (ci_equal(nodeName, WKTConstants::GEOGCRS) ||
                ci_equal(nodeName, WKTConstants::GEOGRAPHICCRS) ||
                ci_equal(nodeName, WKTConstants::BASEGEOGCRS)) {
-        // This is a WKT2-2018 GeographicCRS. An ellipsoidal CS is expected
+        // This is a WKT2-2019 GeographicCRS. An ellipsoidal CS is expected
         throw ParsingException(concat("ellipsoidal CS expected, but found ",
                                       cs->getWKT2Type(true)));
     }
@@ -2795,7 +2795,7 @@ CRSNNPtr WKTParser::Private::buildDerivedGeodeticCRS(const WKTNodeNNPtr &node) {
                                             derivingConversion,
                                             NN_NO_CHECK(ellipsoidalCS));
     } else if (ci_equal(nodeP->value(), WKTConstants::GEOGCRS)) {
-        // This is a WKT2-2018 GeographicCRS. An ellipsoidal CS is expected
+        // This is a WKT2-2019 GeographicCRS. An ellipsoidal CS is expected
         throw ParsingException(concat("ellipsoidal CS expected, but found ",
                                       cs->getWKT2Type(true)));
     }
@@ -4173,8 +4173,8 @@ WKTParser::Private::buildDerivedProjectedCRS(const WKTNodeNNPtr &node) {
 static bool isGeodeticCRS(const std::string &name) {
     return ci_equal(name, WKTConstants::GEODCRS) ||       // WKT2
            ci_equal(name, WKTConstants::GEODETICCRS) ||   // WKT2
-           ci_equal(name, WKTConstants::GEOGCRS) ||       // WKT2 2018
-           ci_equal(name, WKTConstants::GEOGRAPHICCRS) || // WKT2 2018
+           ci_equal(name, WKTConstants::GEOGCRS) ||       // WKT2 2019
+           ci_equal(name, WKTConstants::GEOGRAPHICCRS) || // WKT2 2019
            ci_equal(name, WKTConstants::GEOGCS) ||        // WKT1
            ci_equal(name, WKTConstants::GEOCCS);          // WKT1
 }
@@ -5921,7 +5921,7 @@ BaseObjectNNPtr WKTParser::createFromWKT(const std::string &wkt) {
             d->emitRecoverableWarning(errorMsg);
         }
     } else if (dialect == WKTGuessedDialect::WKT2_2015 ||
-               dialect == WKTGuessedDialect::WKT2_2018) {
+               dialect == WKTGuessedDialect::WKT2_2019) {
         auto errorMsg = pj_wkt2_parse(wkt);
         if (!errorMsg.empty()) {
             d->emitRecoverableWarning(errorMsg);
@@ -5961,7 +5961,7 @@ WKTParser::guessDialect(const std::string &wkt) noexcept {
         }
     }
 
-    const std::string *const wkt2_2018_only_keywords[] = {
+    const std::string *const wkt2_2019_only_keywords[] = {
         &WKTConstants::GEOGCRS,
         // contained in previous one
         // &WKTConstants::BASEGEOGCRS,
@@ -5971,19 +5971,19 @@ WKTParser::guessDialect(const std::string &wkt) noexcept {
         &WKTConstants::DERIVEDPROJCRS, &WKTConstants::BASEPROJCRS,
         &WKTConstants::GEOGRAPHICCRS, &WKTConstants::TRF, &WKTConstants::VRF};
 
-    for (const auto &pointerKeyword : wkt2_2018_only_keywords) {
+    for (const auto &pointerKeyword : wkt2_2019_only_keywords) {
         auto pos = ci_find(wkt, *pointerKeyword);
         if (pos != std::string::npos &&
             wkt[pos + pointerKeyword->size()] == '[') {
-            return WKTGuessedDialect::WKT2_2018;
+            return WKTGuessedDialect::WKT2_2019;
         }
     }
-    static const char *const wkt2_2018_only_substrings[] = {
+    static const char *const wkt2_2019_only_substrings[] = {
         "CS[TemporalDateTime,", "CS[TemporalCount,", "CS[TemporalMeasure,",
     };
-    for (const auto &substrings : wkt2_2018_only_substrings) {
+    for (const auto &substrings : wkt2_2019_only_substrings) {
         if (ci_find(wkt, substrings) != std::string::npos) {
-            return WKTGuessedDialect::WKT2_2018;
+            return WKTGuessedDialect::WKT2_2019;
         }
     }
 

--- a/src/proj.h
+++ b/src/proj.h
@@ -478,8 +478,11 @@ typedef char **PROJ_STRING_LIST;
 /** \brief Guessed WKT "dialect". */
 typedef enum
 {
-    /** \ref WKT2_2018 */
-    PJ_GUESSED_WKT2_2018,
+    /** \ref WKT2_2019 */
+    PJ_GUESSED_WKT2_2019,
+
+    /** Deprecated alias for PJ_GUESSED_WKT2_2019 */
+    PJ_GUESSED_WKT2_2018 = PJ_GUESSED_WKT2_2019,
 
     /** \ref WKT2_2015 */
     PJ_GUESSED_WKT2_2015,
@@ -575,10 +578,14 @@ typedef enum
     PJ_WKT2_2015,
     /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_SIMPLIFIED */
     PJ_WKT2_2015_SIMPLIFIED,
-    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2018 */
-    PJ_WKT2_2018,
-    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2018_SIMPLIFIED */
-    PJ_WKT2_2018_SIMPLIFIED,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2019 */
+    PJ_WKT2_2019,
+    /** Deprecated alias for PJ_WKT2_2019 */
+    PJ_WKT2_2018 = PJ_WKT2_2019,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2019_SIMPLIFIED */
+    PJ_WKT2_2019_SIMPLIFIED,
+    /** Deprecated alias for PJ_WKT2_2019 */
+    PJ_WKT2_2018_SIMPLIFIED = PJ_WKT2_2019_SIMPLIFIED,
     /** cf osgeo::proj::io::WKTFormatter::Convention::WKT1_GDAL */
     PJ_WKT1_GDAL,
     /** cf osgeo::proj::io::WKTFormatter::Convention::WKT1_ESRI */

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -42,8 +42,8 @@ echo "Testing projinfo -o WKT2_2015 EPSG:4326" >> ${OUT}
 $EXE -o WKT2_2015 EPSG:4326 >>${OUT}
 echo "" >>${OUT}
 
-echo "Testing projinfo -o WKT2_2018 EPSG:4326" >> ${OUT}
-$EXE -o WKT2_2018 EPSG:4326 >>${OUT}
+echo "Testing projinfo -o WKT2_2019 EPSG:4326" >> ${OUT}
+$EXE -o WKT2_2019 EPSG:4326 >>${OUT}
 echo "" >>${OUT}
 
 echo "Testing projinfo -o ALL EPSG:4326" >> ${OUT}

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -2,7 +2,7 @@ Testing projinfo EPSG:4326
 PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs +type=crs
 
-WKT2_2018 string:
+WKT2:2019 string:
 GEOGCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -23,7 +23,7 @@ GEOGCRS["WGS 84",
     ID["EPSG",4326]]
 
 Testing projinfo -o WKT1_GDAL EPSG:4326
-WKT1_GDAL:
+WKT1:GDAL string:
 GEOGCS["WGS 84",
     DATUM["WGS_1984",
         SPHEROID["WGS 84",6378137,298.257223563,
@@ -37,7 +37,7 @@ GEOGCS["WGS 84",
 
 
 Testing projinfo -o WKT2_2015 EPSG:4326
-WKT2_2015 string:
+WKT2:2015 string:
 GEODCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -55,8 +55,8 @@ GEODCRS["WGS 84",
     BBOX[-90,-180,90,180],
     ID["EPSG",4326]]
 
-Testing projinfo -o WKT2_2018 EPSG:4326
-WKT2_2018 string:
+Testing projinfo -o WKT2_2019 EPSG:4326
+WKT2:2019 string:
 GEOGCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -80,7 +80,7 @@ Testing projinfo -o ALL EPSG:4326
 PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs +type=crs
 
-WKT2_2015 string:
+WKT2:2015 string:
 GEODCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -98,7 +98,7 @@ GEODCRS["WGS 84",
     BBOX[-90,-180,90,180],
     ID["EPSG",4326]]
 
-WKT2_2018 string:
+WKT2:2019 string:
 GEOGCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -118,7 +118,7 @@ GEOGCRS["WGS 84",
         BBOX[-90,-180,90,180]],
     ID["EPSG",4326]]
 
-WKT1_GDAL:
+WKT1:GDAL string:
 GEOGCS["WGS 84",
     DATUM["WGS_1984",
         SPHEROID["WGS 84",6378137,298.257223563,
@@ -131,7 +131,7 @@ GEOGCS["WGS 84",
     AUTHORITY["EPSG","4326"]]
 
 
-WKT1_ESRI:
+WKT1:ESRI string:
 GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]
 
 
@@ -189,7 +189,7 @@ EPSG:16031, UTM zone 31N, 0 m, World - N hemisphere - 0°E to 6°E
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=utm +zone=31 +ellps=WGS84
 
-WKT2_2018 string:
+WKT2:2019 string:
 CONVERSION["UTM zone 31N",
     METHOD["Transverse Mercator",
         ID["EPSG",9807]],
@@ -221,7 +221,7 @@ unknown id, Ballpark geographic offset from NAD27 to NAD83, unknown accuracy, Wo
 PROJ string:
 +proj=noop
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["Ballpark geographic offset from NAD27 to NAD83",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -286,7 +286,7 @@ DERIVED_FROM(EPSG):1312, NAD27 to NAD83 (3), 1.0 m, Canada
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=ntv1_can.dat +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (3)",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -336,7 +336,7 @@ DERIVED_FROM(EPSG):1313, NAD27 to NAD83 (4), 1.5 m, Canada - NAD27
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=ntv2_0.gsb +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (4)",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -386,7 +386,7 @@ DERIVED_FROM(EPSG):1241, NAD27 to NAD83 (1), 0.15 m, USA - CONUS including EEZ
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=conus +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (1)",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -435,7 +435,7 @@ DERIVED_FROM(EPSG):1243, NAD27 to NAD83 (2), 0.5 m, USA - Alaska including EEZ
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=alaska +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (2)",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -484,7 +484,7 @@ EPSG:1462, NAD27 to NAD83 (5), 1.0 m, Canada - Quebec
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=GS2783v1.QUE +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (5)",
     VERSION["SGQ-Can QC NT1"],
     SOURCECRS[
@@ -536,7 +536,7 @@ EPSG:1573, NAD27 to NAD83 (6), 1.5 m, Canada - Quebec
 PROJ string:
 +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=QUE27-83.gsb +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["NAD27 to NAD83 (6)",
     VERSION["SGQ-Can QC NT2"],
     SOURCECRS[
@@ -588,7 +588,7 @@ unknown id, Ballpark geographic offset from NAD27 to NAD83, unknown accuracy, Wo
 PROJ string:
 +proj=noop
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["Ballpark geographic offset from NAD27 to NAD83",
     SOURCECRS[
         GEOGCRS["NAD27",
@@ -670,7 +670,7 @@ Alternative non-deprecated CRS:
 PROJ.4 string:
 +proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +pm=rome +units=m +no_defs +type=crs
 
-WKT2_2018 string:
+WKT2:2019 string:
 PROJCRS["Monte Mario (Rome) / Italy zone 1",
     BASEGEOGCRS["Monte Mario (Rome)",
         DATUM["Monte Mario (Rome)",
@@ -718,7 +718,7 @@ HEROID["WGS 84",6378137,298.257223563]],UNIT["degree",0.0174532925199433]]
 PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs +type=crs
 
-WKT2_2018 string:
+WKT2:2019 string:
 GEOGCRS["WGS 84",
     DATUM["World Geodetic System 1984",
         ELLIPSOID["WGS 84",6378137,298.257223563,
@@ -749,7 +749,7 @@ PROJ:EPSG_5613_TO_EPSG_4977, RH2000 height to SWEREF99, unknown accuracy, Sweden
 PROJ string:
 +proj=vgridshift +grids=SWEN17_RH2000.gtx +multiplier=1
 
-WKT2_2018 string:
+WKT2:2019 string:
 COORDINATEOPERATION["RH2000 height to SWEREF99",
     SOURCECRS[
         VERTCRS["RH2000 height",

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -333,13 +333,13 @@ TEST_F(CApi, proj_as_wkt) {
     ASSERT_NE(obj, nullptr);
 
     {
-        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2018, nullptr);
+        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2019, nullptr);
         ASSERT_NE(wkt, nullptr);
         EXPECT_TRUE(std::string(wkt).find("GEOGCRS[") == 0) << wkt;
     }
 
     {
-        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2018_SIMPLIFIED, nullptr);
+        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2019_SIMPLIFIED, nullptr);
         ASSERT_NE(wkt, nullptr);
         EXPECT_TRUE(std::string(wkt).find("GEOGCRS[") == 0) << wkt;
         EXPECT_TRUE(std::string(wkt).find("ANGULARUNIT[") == std::string::npos)
@@ -435,7 +435,7 @@ TEST_F(CApi, proj_as_wkt) {
     // unsupported option
     {
         const char *const options[] = {"unsupported=yes", nullptr};
-        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2018, options);
+        auto wkt = proj_as_wkt(m_ctxt, obj, PJ_WKT2_2019, options);
         EXPECT_EQ(wkt, nullptr);
     }
 }
@@ -1631,7 +1631,7 @@ TEST_F(CApi, proj_context_guess_wkt_dialect) {
                   "        AXIS[\"geodetic latitude (Lat)\",north],\n"
                   "        AXIS[\"geodetic longitude (Lon)\",east],\n"
                   "        UNIT[\"degree\",0.0174532925199433]]"),
-              PJ_GUESSED_WKT2_2018);
+              PJ_GUESSED_WKT2_2019);
 
     EXPECT_EQ(proj_context_guess_wkt_dialect(
                   nullptr,
@@ -2690,7 +2690,7 @@ TEST_F(CApi, proj_crs_alter_parameters_linear_unit) {
         ObjectKeeper keeper_alteredCRS(alteredCRS);
         ASSERT_NE(alteredCRS, nullptr);
 
-        auto wkt = proj_as_wkt(m_ctxt, alteredCRS, PJ_WKT2_2018, nullptr);
+        auto wkt = proj_as_wkt(m_ctxt, alteredCRS, PJ_WKT2_2019, nullptr);
         ASSERT_NE(wkt, nullptr);
         EXPECT_TRUE(std::string(wkt).find("500000") != std::string::npos)
             << wkt;
@@ -2704,7 +2704,7 @@ TEST_F(CApi, proj_crs_alter_parameters_linear_unit) {
         ObjectKeeper keeper_alteredCRS(alteredCRS);
         ASSERT_NE(alteredCRS, nullptr);
 
-        auto wkt = proj_as_wkt(m_ctxt, alteredCRS, PJ_WKT2_2018, nullptr);
+        auto wkt = proj_as_wkt(m_ctxt, alteredCRS, PJ_WKT2_2019, nullptr);
         ASSERT_NE(wkt, nullptr);
         EXPECT_TRUE(std::string(wkt).find("250000") != std::string::npos)
             << wkt;

--- a/test/unit/test_common.cpp
+++ b/test/unit/test_common.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -157,7 +157,7 @@ TEST(crs, GeographicCRS_datum_ensemble) {
             nullptr, ensemble_vdatum,
             EllipsoidalCS::createLatitudeLongitude(UnitOfMeasure::DEGREE));
         WKTFormatterNNPtr f(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018));
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019));
         crs->exportToWKT(f.get());
         auto expected =
             "GEOGCRS[\"unnamed\",\n"
@@ -187,7 +187,7 @@ TEST(crs, GeographicCRS_datum_ensemble) {
             ensemble_vdatum,
             EllipsoidalCS::createLatitudeLongitude(UnitOfMeasure::DEGREE));
         WKTFormatterNNPtr f(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018));
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019));
         crs->exportToWKT(f.get());
         auto expected = "GEOGCRS[\"unnamed\",\n"
                         "    ENSEMBLE[\"unnamed\",\n"
@@ -263,10 +263,10 @@ TEST(crs, EPSG_4326_as_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, EPSG_4326_as_WKT2_2018) {
+TEST(crs, EPSG_4326_as_WKT2_2019) {
     auto crs = GeographicCRS::EPSG_4326;
     WKTFormatterNNPtr f(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019));
     crs->exportToWKT(f.get());
     EXPECT_EQ(f->toString(),
               "GEOGCRS[\"WGS 84\",\n"
@@ -322,10 +322,10 @@ TEST(crs, EPSG_4326_as_WKT2_SIMPLIFIED_single_line) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, EPSG_4326_as_WKT2_2018_SIMPLIFIED) {
+TEST(crs, EPSG_4326_as_WKT2_2019_SIMPLIFIED) {
     auto crs = GeographicCRS::EPSG_4326;
     WKTFormatterNNPtr f(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018_SIMPLIFIED));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019_SIMPLIFIED));
     crs->exportToWKT(f.get());
     EXPECT_EQ(f->toString(),
               "GEOGCRS[\"WGS 84\",\n"
@@ -454,10 +454,10 @@ TEST(crs, EPSG_4979_as_WKT2_SIMPLIFIED) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, EPSG_4979_as_WKT2_2018_SIMPLIFIED) {
+TEST(crs, EPSG_4979_as_WKT2_2019_SIMPLIFIED) {
     auto crs = GeographicCRS::EPSG_4979;
     WKTFormatterNNPtr f(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018_SIMPLIFIED));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019_SIMPLIFIED));
     crs->exportToWKT(f.get());
     EXPECT_EQ(f->toString(),
               "GEOGCRS[\"WGS 84\",\n"
@@ -1069,7 +1069,7 @@ TEST(crs, geocentricCRS_as_WKT2) {
     EXPECT_EQ(crs->exportToWKT(WKTFormatter::create().get()), expected);
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 
     EXPECT_TRUE(crs->isEquivalentTo(crs.get()));
@@ -1614,7 +1614,7 @@ TEST(crs, projectedCRS_as_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, projectedCRS_as_WKT2_2018) {
+TEST(crs, projectedCRS_as_WKT2_2019) {
     auto crs = createProjected();
 
     auto expected =
@@ -1655,7 +1655,7 @@ TEST(crs, projectedCRS_as_WKT2_2018) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 // ---------------------------------------------------------------------------
@@ -1690,7 +1690,7 @@ TEST(crs, projectedCRS_as_WKT2_simplified) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, projectedCRS_as_WKT2_2018_simplified) {
+TEST(crs, projectedCRS_as_WKT2_2019_simplified) {
     auto crs = createProjected();
 
     auto expected =
@@ -1714,7 +1714,7 @@ TEST(crs, projectedCRS_as_WKT2_2018_simplified) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018_SIMPLIFIED)
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019_SIMPLIFIED)
                 .get()),
         expected);
 }
@@ -2845,7 +2845,7 @@ TEST(crs, usage) {
     ASSERT_TRUE(crs != nullptr);
 
     auto got_wkt = crs->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     auto expected = "GEODCRS[\"JGD2000\",\n"
                     "    DATUM[\"Japanese Geodetic Datum 2000\",\n"
                     "        ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
@@ -3061,7 +3061,7 @@ TEST(crs, verticalCRS_datum_ensemble) {
         PropertyMap().set(IdentifiedObject::NAME_KEY, "unnamed"), nullptr,
         ensemble, VerticalCS::createGravityRelatedHeight(UnitOfMeasure::METRE));
     WKTFormatterNNPtr f(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019));
     f->simulCurNodeHasId();
     crs->exportToWKT(f.get());
     auto expected = "VERTCRS[\"unnamed\",\n"
@@ -4017,7 +4017,7 @@ TEST(crs, derivedGeographicCRS_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, derivedGeographicCRS_WKT2_2018) {
+TEST(crs, derivedGeographicCRS_WKT2_2019) {
 
     auto expected = "GEOGCRS[\"WMO Atlantic Pole\",\n"
                     "    BASEGEOGCRS[\"WGS 84\",\n"
@@ -4049,7 +4049,7 @@ TEST(crs, derivedGeographicCRS_WKT2_2018) {
 
     EXPECT_EQ(
         createDerivedGeographicCRS()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4207,7 +4207,7 @@ TEST(crs, derivedGeodeticCRS_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, derivedGeodeticCRS_WKT2_2018) {
+TEST(crs, derivedGeodeticCRS_WKT2_2019) {
 
     auto expected = "GEODCRS[\"Derived geodetic CRS\",\n"
                     "    BASEGEOGCRS[\"WGS 84\",\n"
@@ -4234,7 +4234,7 @@ TEST(crs, derivedGeodeticCRS_WKT2_2018) {
 
     EXPECT_EQ(
         createDerivedGeodeticCRS()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4266,7 +4266,7 @@ static DerivedProjectedCRSNNPtr createDerivedProjectedCRS() {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, derivedProjectedCRS_WKT2_2018) {
+TEST(crs, derivedProjectedCRS_WKT2_2019) {
 
     auto expected =
         "DERIVEDPROJCRS[\"derived projectedCRS\",\n"
@@ -4310,7 +4310,7 @@ TEST(crs, derivedProjectedCRS_WKT2_2018) {
     auto crs = createDerivedProjectedCRS();
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 
     EXPECT_TRUE(crs->isEquivalentTo(crs.get()));
@@ -4381,7 +4381,7 @@ TEST(crs, dateTimeTemporalCRS_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, dateTimeTemporalCRS_WKT2_2018) {
+TEST(crs, dateTimeTemporalCRS_WKT2_2019) {
 
     auto expected = "TIMECRS[\"Temporal CRS\",\n"
                     "    TDATUM[\"Gregorian calendar\",\n"
@@ -4392,7 +4392,7 @@ TEST(crs, dateTimeTemporalCRS_WKT2_2018) {
 
     EXPECT_EQ(
         createDateTimeTemporalCRS()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4418,7 +4418,7 @@ static TemporalCRSNNPtr createTemporalCountCRSWithConvFactor() {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, temporalCountCRSWithConvFactor_WKT2_2018) {
+TEST(crs, temporalCountCRSWithConvFactor_WKT2_2019) {
 
     auto expected = "TIMECRS[\"GPS milliseconds\",\n"
                     "    TDATUM[\"GPS time origin\",\n"
@@ -4430,7 +4430,7 @@ TEST(crs, temporalCountCRSWithConvFactor_WKT2_2018) {
 
     EXPECT_EQ(
         createTemporalCountCRSWithConvFactor()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4458,7 +4458,7 @@ static TemporalCRSNNPtr createTemporalCountCRSWithoutConvFactor() {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, temporalCountCRSWithoutConvFactor_WKT2_2018) {
+TEST(crs, temporalCountCRSWithoutConvFactor_WKT2_2019) {
 
     auto expected = "TIMECRS[\"Calendar hours from 1979-12-29\",\n"
                     "    TDATUM[\"29 December 1979\",\n"
@@ -4470,7 +4470,7 @@ TEST(crs, temporalCountCRSWithoutConvFactor_WKT2_2018) {
 
     EXPECT_EQ(
         createTemporalCountCRSWithoutConvFactor()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4496,7 +4496,7 @@ static TemporalCRSNNPtr createTemporalMeasureCRSWithoutConvFactor() {
 
 // ---------------------------------------------------------------------------
 
-TEST(crs, temporalMeasureCRSWithoutConvFactor_WKT2_2018) {
+TEST(crs, temporalMeasureCRSWithoutConvFactor_WKT2_2019) {
 
     auto expected = "TIMECRS[\"Decimal Years CE\",\n"
                     "    TDATUM[\"Common Era\",\n"
@@ -4508,7 +4508,7 @@ TEST(crs, temporalMeasureCRSWithoutConvFactor_WKT2_2018) {
 
     EXPECT_EQ(
         createTemporalMeasureCRSWithoutConvFactor()->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4718,7 +4718,7 @@ TEST(crs, DerivedEngineeringCRS_WKT2) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
     EXPECT_THROW(
         createDerivedEngineeringCRS()->exportToWKT(
@@ -4775,7 +4775,7 @@ TEST(crs, DerivedParametricCRS_WKT2) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -4830,7 +4830,7 @@ TEST(crs, DeriveTemporalCRS_WKT2) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 

--- a/test/unit/test_datum.cpp
+++ b/test/unit/test_datum.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -273,7 +273,7 @@ TEST(datum, dynamic_geodetic_reference_frame) {
 
     EXPECT_EQ(drf->exportToWKT(WKTFormatter::create().get()), expected);
 
-    auto expected_wtk2_2018 =
+    auto expected_wtk2_2019 =
         "DYNAMIC[\n"
         "    FRAMEEPOCH[2018.5],\n"
         "    MODEL[\"My model\"]],\n"
@@ -284,8 +284,8 @@ TEST(datum, dynamic_geodetic_reference_frame) {
         "    ANCHOR[\"My anchor\"]]";
     EXPECT_EQ(
         drf->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
-        expected_wtk2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
+        expected_wtk2_2019);
 }
 
 // ---------------------------------------------------------------------------
@@ -355,7 +355,7 @@ TEST(datum, temporal_datum_time_origin_non_ISO8601) {
 
 // ---------------------------------------------------------------------------
 
-TEST(datum, temporal_datum_WKT2_2018) {
+TEST(datum, temporal_datum_WKT2_2019) {
     auto datum = TemporalDatum::create(
         PropertyMap().set(IdentifiedObject::NAME_KEY, "Gregorian calendar"),
         DateTime::create("0000-01-01"),
@@ -367,7 +367,7 @@ TEST(datum, temporal_datum_WKT2_2018) {
 
     EXPECT_EQ(
         datum->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -385,15 +385,15 @@ TEST(datum, dynamic_vertical_reference_frame) {
 
     EXPECT_EQ(drf->exportToWKT(WKTFormatter::create().get()), expected);
 
-    auto expected_wtk2_2018 = "DYNAMIC[\n"
+    auto expected_wtk2_2019 = "DYNAMIC[\n"
                               "    FRAMEEPOCH[2018.5],\n"
                               "    MODEL[\"My model\"]],\n"
                               "VDATUM[\"test\",\n"
                               "    ANCHOR[\"My anchor\"]]";
     EXPECT_EQ(
         drf->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
-        expected_wtk2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
+        expected_wtk2_2019);
 }
 
 // ---------------------------------------------------------------------------
@@ -412,7 +412,7 @@ TEST(datum, datum_ensemble) {
                  FormattingException);
     EXPECT_EQ(
         ensemble->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         "ENSEMBLE[\"test\",\n"
         "    MEMBER[\"World Geodetic System 1984\",\n"
         "        ID[\"EPSG\",6326]],\n"
@@ -436,7 +436,7 @@ TEST(datum, datum_ensemble_vertical) {
         PositionalAccuracy::create("100"));
     EXPECT_EQ(
         ensemble->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         "ENSEMBLE[\"unnamed\",\n"
         "    MEMBER[\"vdatum1\"],\n"
         "    MEMBER[\"vdatum2\"],\n"

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -705,7 +705,7 @@ TEST(factory, AuthorityFactory_createCoordinateOperation_helmert_8_CF) {
                     "        ID[\"EPSG\",1049]],\n";
 
     auto wkt = op->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     EXPECT_TRUE(wkt.find(expected) != std::string::npos) << wkt;
 }
 
@@ -818,7 +818,7 @@ TEST(factory, AuthorityFactory_createCoordinateOperation_helmert_15_CF) {
 
     EXPECT_EQ(
         op->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -924,7 +924,7 @@ TEST(
         "in grid file.\"]]";
     EXPECT_EQ(
         op->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 
@@ -940,7 +940,7 @@ TEST(
         "    PARAMETERFILE[\"Longitude difference file\",\"alaska.los\"],\n";
 
     auto wkt = op->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     EXPECT_TRUE(wkt.find(expected) != std::string::npos) << wkt;
 }
 
@@ -998,7 +998,7 @@ TEST(factory, AuthorityFactory_createCoordinateOperation_other_transformation) {
 
     EXPECT_EQ(
         op->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         expected);
 }
 

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -651,7 +651,7 @@ TEST(wkt_parse, wkt2_long_GEODETICCRS_EPSG_4326) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_GEOGCRS_EPSG_4326) {
+TEST(wkt_parse, wkt2_2019_GEOGCRS_EPSG_4326) {
     auto obj = WKTParser().createFromWKT("GEOGCRS" + contentWKT2_EPSG_4326);
     auto crs = nn_dynamic_pointer_cast<GeographicCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
@@ -660,7 +660,7 @@ TEST(wkt_parse, wkt2_2018_GEOGCRS_EPSG_4326) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_long_GEOGRAPHICCRS_EPSG_4326) {
+TEST(wkt_parse, wkt2_2019_long_GEOGRAPHICCRS_EPSG_4326) {
     auto obj =
         WKTParser().createFromWKT("GEOGRAPHICCRS" + contentWKT2_EPSG_4326);
     auto crs = nn_dynamic_pointer_cast<GeographicCRS>(obj);
@@ -1640,7 +1640,7 @@ TEST(wkt_parse, wkt2_projected) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_projected_with_id_in_basegeodcrs) {
+TEST(wkt_parse, wkt2_2019_projected_with_id_in_basegeodcrs) {
     auto wkt = "PROJCRS[\"WGS 84 / UTM zone 31N\",\n"
                "    BASEGEOGCRS[\"WGS 84\",\n"
                "        DATUM[\"World Geodetic System 1984\",\n"
@@ -1666,14 +1666,14 @@ TEST(wkt_parse, wkt2_2018_projected_with_id_in_basegeodcrs) {
 
     {
         auto got_wkt = crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
         EXPECT_TRUE(got_wkt.find("ID[\"EPSG\",4326]]") != std::string::npos)
             << got_wkt;
     }
 
     {
         auto got_wkt = crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018_SIMPLIFIED)
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019_SIMPLIFIED)
                 .get());
         EXPECT_TRUE(got_wkt.find("ID[\"EPSG\",4326]]") == std::string::npos)
             << got_wkt;
@@ -1682,7 +1682,7 @@ TEST(wkt_parse, wkt2_2018_projected_with_id_in_basegeodcrs) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_projected_no_id_but_id_in_basegeodcrs) {
+TEST(wkt_parse, wkt2_2019_projected_no_id_but_id_in_basegeodcrs) {
     auto wkt = "PROJCRS[\"WGS 84 / UTM zone 31N\",\n"
                "    BASEGEOGCRS[\"WGS 84\",\n"
                "        DATUM[\"World Geodetic System 1984\",\n"
@@ -1704,14 +1704,14 @@ TEST(wkt_parse, wkt2_2018_projected_no_id_but_id_in_basegeodcrs) {
     ASSERT_TRUE(crs != nullptr);
 
     auto got_wkt = crs->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     EXPECT_TRUE(got_wkt.find("ID[\"EPSG\",4326]]") != std::string::npos)
         << got_wkt;
 }
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_simplified_projected) {
+TEST(wkt_parse, wkt2_2019_simplified_projected) {
     auto wkt = "PROJCRS[\"WGS 84 / UTM zone 31N\",\n"
                "    BASEGEOGCRS[\"WGS 84\",\n"
                "        DATUM[\"World Geodetic System 1984\",\n"
@@ -1737,7 +1737,7 @@ TEST(wkt_parse, wkt2_2018_simplified_projected) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_projected_3D) {
+TEST(wkt_parse, wkt2_2019_projected_3D) {
     auto wkt =
         "PROJCRS[\"WGS 84 (G1762) / UTM zone 31N 3D\","
         "    BASEGEOGCRS[\"WGS 84\","
@@ -1777,13 +1777,13 @@ TEST(wkt_parse, wkt2_2018_projected_3D) {
         FormattingException);
 
     EXPECT_NO_THROW(crs->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()));
 }
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, wkt2_2018_projected_utm_3D) {
-    // Example from WKT2:2018
+TEST(wkt_parse, wkt2_2019_projected_utm_3D) {
+    // Example from WKT2:2019
     auto wkt =
         "PROJCRS[\"WGS 84 (G1762) / UTM zone 31N 3D\","
         "    BASEGEOGCRS[\"WGS 84\","
@@ -1822,7 +1822,7 @@ TEST(wkt_parse, wkt2_2018_projected_utm_3D) {
         FormattingException);
 
     EXPECT_NO_THROW(crs->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()));
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()));
 }
 
 // ---------------------------------------------------------------------------
@@ -2165,7 +2165,7 @@ TEST(wkt_parse, COMPOUNDCRS_spatio_parametric_2015) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, COMPOUNDCRS_spatio_parametric_2018) {
+TEST(wkt_parse, COMPOUNDCRS_spatio_parametric_2019) {
     auto obj = WKTParser().createFromWKT(
         "COMPOUNDCRS[\"ICAO layer 0\",\n"
         "    GEOGRAPHICCRS[\"WGS 84\",\n"
@@ -2220,7 +2220,7 @@ TEST(wkt_parse, COMPOUNDCRS_spatio_temporal_2015) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, COMPOUNDCRS_spatio_temporal_2018) {
+TEST(wkt_parse, COMPOUNDCRS_spatio_temporal_2019) {
     auto obj = WKTParser().createFromWKT(
         "COMPOUNDCRS[\"2D GPS position with civil time in ISO 8601 format\",\n"
         "    GEOGCRS[\"WGS 84 (G1762)\",\n"
@@ -2361,12 +2361,12 @@ TEST(wkt_parse, COORDINATEOPERATION) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, COORDINATEOPERATION_wkt2018) {
+TEST(wkt_parse, COORDINATEOPERATION_wkt2_2019) {
 
     std::string src_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         formatter->setOutputId(false);
         src_wkt = GeographicCRS::EPSG_4326->exportToWKT(formatter.get());
     }
@@ -2374,7 +2374,7 @@ TEST(wkt_parse, COORDINATEOPERATION_wkt2018) {
     std::string dst_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         formatter->setOutputId(false);
         dst_wkt = GeographicCRS::EPSG_4807->exportToWKT(formatter.get());
     }
@@ -2382,7 +2382,7 @@ TEST(wkt_parse, COORDINATEOPERATION_wkt2018) {
     std::string interpolation_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         formatter->setOutputId(false);
         interpolation_wkt =
             GeographicCRS::EPSG_4979->exportToWKT(formatter.get());
@@ -2429,7 +2429,7 @@ TEST(wkt_parse, COORDINATEOPERATION_wkt2018) {
 
     {
         auto outWkt = transf->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
         EXPECT_EQ(replaceAll(replaceAll(outWkt, "\n", ""), " ", ""),
                   replaceAll(replaceAll(wkt, "\n", ""), " ", ""));
     }
@@ -2493,7 +2493,7 @@ TEST(wkt_parse, CONCATENATEDOPERATION) {
             PositionalAccuracy::create("0.1")});
 
     auto wkt = concat_in->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
 
     auto obj = WKTParser().createFromWKT(wkt);
     auto concat = nn_dynamic_pointer_cast<ConcatenatedOperation>(obj);
@@ -2636,7 +2636,7 @@ TEST(wkt_parse, CONCATENATEDOPERATION_with_conversion_and_conversion) {
               "+step +proj=utm +zone=32 +ellps=WGS84");
 
     auto outWkt = concat->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     EXPECT_EQ(wkt, outWkt);
 }
 
@@ -2809,7 +2809,7 @@ TEST(wkt_parse,
               "+zone=11 +ellps=WGS84");
 
     auto outWkt = concat->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     EXPECT_EQ(wkt, outWkt);
 }
 
@@ -3348,7 +3348,7 @@ TEST(wkt_parse, DerivedGeographicCRS_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, DerivedGeographicCRS_WKT2_2018) {
+TEST(wkt_parse, DerivedGeographicCRS_WKT2_2019) {
     auto wkt = "GEOGCRS[\"WMO Atlantic Pole\",\n"
                "    BASEGEOGCRS[\"WGS 84\",\n"
                "        DATUM[\"World Geodetic System 1984\",\n"
@@ -3532,7 +3532,7 @@ TEST(wkt_parse, DerivedProjectedCRS_ordinal) {
 
     EXPECT_EQ(
         crs->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get()),
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get()),
         wkt);
 }
 
@@ -3595,7 +3595,7 @@ TEST(wkt_parse, dateTimeTemporalCRS_WKT2) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, dateTimeTemporalCRS_WKT2_2018) {
+TEST(wkt_parse, dateTimeTemporalCRS_WKT2_2019) {
     auto wkt = "TIMECRS[\"Temporal CRS\",\n"
                "    TDATUM[\"Gregorian calendar\",\n"
                "        CALENDAR[\"proleptic Gregorian\"],\n"
@@ -3622,7 +3622,7 @@ TEST(wkt_parse, dateTimeTemporalCRS_WKT2_2018) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, temporalCountCRSWithConvFactor_WKT2_2018) {
+TEST(wkt_parse, temporalCountCRSWithConvFactor_WKT2_2019) {
     auto wkt = "TIMECRS[\"GPS milliseconds\",\n"
                "    TDATUM[\"GPS time origin\",\n"
                "        TIMEORIGIN[1980-01-01T00:00:00.0Z]],\n"
@@ -3650,7 +3650,7 @@ TEST(wkt_parse, temporalCountCRSWithConvFactor_WKT2_2018) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, temporalCountCRSWithoutConvFactor_WKT2_2018) {
+TEST(wkt_parse, temporalCountCRSWithoutConvFactor_WKT2_2019) {
     auto wkt = "TIMECRS[\"Calendar hours from 1979-12-29\",\n"
                "    TDATUM[\"29 December 1979\",\n"
                "        CALENDAR[\"proleptic Gregorian\"],\n"
@@ -3677,7 +3677,7 @@ TEST(wkt_parse, temporalCountCRSWithoutConvFactor_WKT2_2018) {
 
 // ---------------------------------------------------------------------------
 
-TEST(wkt_parse, temporalMeasureCRSWithoutConvFactor_WKT2_2018) {
+TEST(wkt_parse, temporalMeasureCRSWithoutConvFactor_WKT2_2019) {
     auto wkt = "TIMECRS[\"Decimal Years CE\",\n"
                "    TIMEDATUM[\"Common Era\",\n"
                "        TIMEORIGIN[0000]],\n"
@@ -9017,7 +9017,7 @@ TEST(io, guessDialect) {
                   "        AXIS[\"geodetic latitude (Lat)\",north],\n"
                   "        AXIS[\"geodetic longitude (Lon)\",east],\n"
                   "        UNIT[\"degree\",0.0174532925199433]]"),
-              WKTParser::WKTGuessedDialect::WKT2_2018);
+              WKTParser::WKTGuessedDialect::WKT2_2019);
 
     EXPECT_EQ(
         WKTParser().guessDialect("TIMECRS[\"Temporal CRS\",\n"
@@ -9026,7 +9026,7 @@ TEST(io, guessDialect) {
                                  "        TIMEORIGIN[0000-01-01]],\n"
                                  "    CS[TemporalDateTime,1],\n"
                                  "        AXIS[\"time (T)\",future]]"),
-        WKTParser::WKTGuessedDialect::WKT2_2018);
+        WKTParser::WKTGuessedDialect::WKT2_2019);
 
     EXPECT_EQ(WKTParser().guessDialect(
                   "GEODCRS[\"WGS 84\",\n"

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************
@@ -446,28 +446,28 @@ TEST(operation, concatenated_operation) {
     std::string src_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         src_wkt = GeographicCRS::EPSG_4326->exportToWKT(formatter.get());
     }
 
     std::string dst_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         dst_wkt = GeographicCRS::EPSG_4979->exportToWKT(formatter.get());
     }
 
     std::string step1_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         step1_wkt = transf_1->exportToWKT(formatter.get());
     }
 
     std::string step2_wkt;
     {
         auto formatter =
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018);
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019);
         step2_wkt = transf_2->exportToWKT(formatter.get());
     }
 
@@ -485,7 +485,7 @@ TEST(operation, concatenated_operation) {
 
     EXPECT_EQ(replaceAll(replaceAll(concat->exportToWKT(
                                         WKTFormatter::create(
-                                            WKTFormatter::Convention::WKT2_2018)
+                                            WKTFormatter::Convention::WKT2_2019)
                                             .get()),
                                     " ", ""),
                          "\n", ""),
@@ -6559,7 +6559,7 @@ TEST(operation, compoundCRS_to_compoundCRS_context) {
         // Test that we can round-trip this through WKT and still get the same
         // PROJ string.
         auto wkt = list[0]->exportToWKT(
-            WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+            WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
         auto obj = WKTParser().createFromWKT(wkt);
         auto co = nn_dynamic_pointer_cast<CoordinateOperation>(obj);
         ASSERT_TRUE(co != nullptr);
@@ -6775,7 +6775,7 @@ TEST(operation, compoundCRS_from_WKT2_to_geogCRS_3D_context) {
         CoordinateOperationFactory::create()->createOperations(src, dst, ctxt);
     ASSERT_GE(list.size(), 1U);
     auto wkt2 = src->exportToWKT(
-        WKTFormatter::create(WKTFormatter::Convention::WKT2_2018).get());
+        WKTFormatter::create(WKTFormatter::Convention::WKT2_2019).get());
     auto obj = WKTParser().createFromWKT(wkt2);
     auto src_from_wkt2 = nn_dynamic_pointer_cast<CRS>(obj);
     ASSERT_TRUE(src_from_wkt2 != nullptr);
@@ -7019,10 +7019,10 @@ TEST(operation, createOperation_on_crs_with_canonical_bound_crs) {
         EXPECT_TRUE(op->isEquivalentTo(boundCRS->transformation().get()));
         {
             auto wkt1 = op->exportToWKT(
-                WKTFormatter::create(WKTFormatter::Convention::WKT2_2018)
+                WKTFormatter::create(WKTFormatter::Convention::WKT2_2019)
                     .get());
             auto wkt2 = boundCRS->transformation()->exportToWKT(
-                WKTFormatter::create(WKTFormatter::Convention::WKT2_2018)
+                WKTFormatter::create(WKTFormatter::Convention::WKT2_2019)
                     .get());
             EXPECT_EQ(wkt1, wkt2);
         }
@@ -7035,10 +7035,10 @@ TEST(operation, createOperation_on_crs_with_canonical_bound_crs) {
             op->isEquivalentTo(boundCRS->transformation()->inverse().get()));
         {
             auto wkt1 = op->exportToWKT(
-                WKTFormatter::create(WKTFormatter::Convention::WKT2_2018)
+                WKTFormatter::create(WKTFormatter::Convention::WKT2_2019)
                     .get());
             auto wkt2 = boundCRS->transformation()->inverse()->exportToWKT(
-                WKTFormatter::create(WKTFormatter::Convention::WKT2_2018)
+                WKTFormatter::create(WKTFormatter::Convention::WKT2_2019)
                     .get());
             EXPECT_EQ(wkt1, wkt2);
         }

--- a/test/unit/test_util.cpp
+++ b/test/unit/test_util.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  PROJ
- * Purpose:  Test ISO19111:2018 implementation
+ * Purpose:  Test ISO19111:2019 implementation
  * Author:   Even Rouault <even dot rouault at spatialys dot com>
  *
  ******************************************************************************


### PR DESCRIPTION
- C API: PJ_GUESSED_WKT2_2019 is added, PJ_GUESSED_WKT2_2018 aliased to it
- C API: PJ_WKT2_2019[_SIMPLIFIED] is added, PJ_WKT2_2018[_SIMPLIFIED] alias to it
- C++ API: similarly for WKTFormatter::Convention::WKT2_2019[_SIMPLIFIED]
Those above changes should be fully backward API and ABI compatible.

projinfo changes:
- accept WKT2_2019 as value for -o switch. WKT2_2018 is still accepted (undocumented)
- output now uses 'WKT2_2019 string:', so might break scripts that would rely on that.

Other internal code references to WKT2_2018 changes to WKT2_2019, included
in tests.