### PR TITLE
PROJStringParser::createFromPROJString(): avoid potential infinite recursion (fixes #1574)

### DIFF
--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -706,7 +706,7 @@ struct projCtx_t {
     const char* (*file_finder) (PJ_CONTEXT *, const char*, void* user_data) = nullptr;
     void* file_finder_user_data = nullptr;
 
-    std::string curStringInCreateFromPROJString{};
+    int projStringParserCreateFromPROJStringRecursionCounter = 0; // to avoid potential infinite recursion in PROJStringParser::createFromPROJString()
 
     projCtx_t() = default;
     projCtx_t(const projCtx_t&);


### PR DESCRIPTION
The exact circumstances are a bit difficult to explain, but they involve
using a non-default context, enabling proj_context_use_proj4_init_rules() on it,
using proj_create(ctxt, "+init=epsg:XXXX +type=crs"), whereas PROJ_LIB is
defined to a directory that has a 'epsg' file in it.