### PR TITLE
BUG: add SANITIZE_CTX for coordoperation is_instantiable and has_ballpark_transformation

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -6091,6 +6091,7 @@ PJ *proj_create_conversion_equal_earth(PJ_CONTEXT *ctx, double center_long,
 
 int proj_coordoperation_is_instantiable(PJ_CONTEXT *ctx,
                                         const PJ *coordoperation) {
+    SANITIZE_CTX(ctx);
     assert(coordoperation);
     auto op = dynamic_cast<const CoordinateOperation *>(
         coordoperation->iso_obj.get());
@@ -6133,6 +6134,7 @@ int proj_coordoperation_is_instantiable(PJ_CONTEXT *ctx,
 
 int proj_coordoperation_has_ballpark_transformation(PJ_CONTEXT *ctx,
                                                     const PJ *coordoperation) {
+    SANITIZE_CTX(ctx);
     assert(coordoperation);
     auto op = dynamic_cast<const CoordinateOperation *>(
         coordoperation->iso_obj.get());


### PR DESCRIPTION
This one was causing core dumping for me - had me digging through my code to find it and eventually I pinpointed the issue to these functions.