### PR TITLE
Require C99 compiler see #1621

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "Requiring C++${CMAKE_CXX_STANDARD} - done")
 
+# Set C99 version
+# Make CMAKE_C_STANDARD available as cache option overridable by user
+set(CMAKE_C_STANDARD 99
+  CACHE STRING "C standard version to use (default is 99)")
+message(STATUS "Requiring C${CMAKE_C_STANDARD}")
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+message(STATUS "Requiring C${CMAKE_C_STANDARD} - done")
+
 # Set global -fvisibility=hidden
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -52,7 +61,6 @@ elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Wmissing-prototypes
     -Wfloat-conversion
-    -Wc99-extensions
     -Wc11-extensions
   )
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
@@ -133,21 +141,6 @@ if(MSVC)
 else()
   set(CMAKE_REQUIRED_LIBRARIES m)
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
-endif()
-# Check whether the C99 math function: hypot, atanh, etc. are available.
-check_c_source_compiles("
-#include <math.h>
-int main() {
-  int q;
-  return (int)(hypot(3.0, 4.0) + atanh(0.8) + copysign(1.0, -0.0) +
-               cbrt(8.0) + remainder(100.0, 90.0) +
-               remquo(100.0, 90.0, &q));
-}
-" C99_MATH)
-if(C99_MATH)
-  add_definitions(-DHAVE_C99_MATH=1)
-else()
-  add_definitions(-DHAVE_C99_MATH=0)
 endif()
 
 if(Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)

--- a/INSTALL
+++ b/INSTALL
@@ -59,7 +59,7 @@ the `configure' script does not know about.  You can give `configure'
 initial values for variables by setting them in the environment.  Using
 a Bourne-compatible shell, you can do that on the command line like
 this:
-     CC=c89 CFLAGS=-O2 LIBS=-lposix ./configure
+     CC=c99 CFLAGS=-O2 LIBS=-lposix ./configure
 
 Or on systems that have the `env' program, you can do it like this:
      env CPPFLAGS=-I/usr/local/include LDFLAGS=-s ./configure

--- a/cmake/project-config-version.cmake.in
+++ b/cmake/project-config-version.cmake.in
@@ -11,6 +11,16 @@ else ()
   set (CMAKE_CROSSCOMPILING_STR "OFF")
 endif ()
 
+if (MSVC)
+  # For checking the compatibility of MSVC_TOOLSET_VERSION; see
+  # https://docs.microsoft.com/en-us/cpp/porting/overview-of-potential-upgrade-issues-visual-cpp
+  # Assume major version number is obtained by dropping the last decimal
+  # digit.  LIBR, resp. PROJ, refer to @PROJECT_NAME@, resp. the package
+  # trying to find and link against @PROJECT_NAME@.
+  math (EXPR _MSVC_PROJ_MAJOR "${MSVC_TOOLSET_VERSION}/10")
+  math (EXPR _MSVC_LIBR_MAJOR  "@MSVC_TOOLSET_VERSION@/10")
+endif ()
+
 if (NOT PACKAGE_FIND_NAME STREQUAL "@PROJECT_NAME@")
   # Check package name (in particular, because of the way cmake finds
   # package config files, the capitalization could easily be "wrong").
@@ -24,9 +34,13 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
   # since a multi-architecture library is built for that platform).
   set (REASON "sizeof(*void) =  @CMAKE_SIZEOF_VOID_P@")
   set (PACKAGE_VERSION_UNSUITABLE TRUE)
-elseif (MSVC AND NOT MSVC_VERSION STREQUAL "@MSVC_VERSION@")
+elseif (MSVC AND NOT (
+    # toolset version must be at least as great as @PROJECT_NAME@'s
+    ${MSVC_TOOLSET_VERSION} GREATER_EQUAL @MSVC_TOOLSET_VERSION@
+      # and major versions must match
+      AND _MSVC_PROJ_MAJOR EQUAL _MSVC_LIBR_MAJOR ))
   # Reject if there's a mismatch in MSVC compiler versions
-  set (REASON "_MSC_VER = @MSVC_VERSION@")
+  set (REASON "MSVC_TOOLSET_VERSION = @MSVC_TOOLSET_VERSION@")
   set (PACKAGE_VERSION_UNSUITABLE TRUE)
 elseif (NOT CMAKE_CROSSCOMPILING_STR STREQUAL "@CMAKE_CROSSCOMPILING_STR@")
   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AM_CONFIG_HEADER(src/proj_config.h)
 
 dnl Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_C99
 AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 AC_PROG_INSTALL
@@ -81,20 +82,6 @@ AX_CHECK_COMPILE_FLAG([-Wfloat-conversion], [C_WFLAGS="$C_WFLAGS -Wfloat-convers
 
 dnl clang >= 3.2
 AX_CHECK_COMPILE_FLAG([-Wdocumentation -Wno-documentation-deprecated-sync], [C_WFLAGS="$C_WFLAGS -Wdocumentation -Wno-documentation-deprecated-sync" CXX_WFLAGS="$CXX_WFLAGS -Wdocumentation -Wno-documentation-deprecated-sync"],,[$ERROR_ON_UNKNOWN_OPTIONS])
-
-dnl gnu89 is a reasonable target to get MSVC compatibility.
-dnl but only apply it with gcc, since clang will throw a lot of warnings
-SAVED_CFLAGS=$CFLAGS
-CFLAGS="$CFLAGS $ERROR_ON_UNKNOWN_OPTIONS -std=gnu89"
-AC_MSG_CHECKING([if -std=gnu89 can be enabled])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-  [[#if defined(__clang__) || !defined(__GNUC__)
-    #error "not gcc"
-    #endif]])],
-  [C_WFLAGS="$C_WFLAGS -std=gnu89"]
-  [AC_MSG_RESULT([yes])],
-  [AC_MSG_RESULT([no])])
-CFLAGS=$SAVED_CFLAGS
 
 dnl C++ specific stuff
 
@@ -197,19 +184,6 @@ dnl like (a + b) + c and from simplifying 0.0 + x to x (which is wrong if
 dnl x = -0.0).
 AX_CHECK_COMPILE_FLAG([-fp-model precise],
         [CFLAGS="$CFLAGS -fp-model precise"],,[-Werror])
-dnl Check for C99 math functions
-save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -Wall -Werror"
-AC_MSG_CHECKING([for C99 math functions])
-AC_LINK_IFELSE([AC_LANG_PROGRAM(
-        [#include <math.h>],
-        [int q;
-         return (int)(hypot(3.0, 4.0) + atanh(0.8) + copysign(1.0, -0.0) +
-                      cbrt(8.0) + remainder(100.0, 90.0) +
-                      remquo(100.0, 90.0, &q));])],
-        [AC_MSG_RESULT([yes]);C99_MATH="-DHAVE_C99_MATH=1"],
-        [AC_MSG_RESULT([no]);C99_MATH="-DHAVE_C99_MATH=0"])
-CFLAGS="$save_CFLAGS $C99_MATH"
 
 AC_SEARCH_LIBS([sqrt], [m])
 

--- a/src/geodesic.c
+++ b/src/geodesic.c
@@ -27,7 +27,12 @@
 #include <math.h>
 
 #if !defined(HAVE_C99_MATH)
+#if defined(PROJ_LIB)
+/* PROJ requires C99 so HAVE_C99_MATH is implicit */
+#define HAVE_C99_MATH 1
+#else
 #define HAVE_C99_MATH 0
+#endif
 #endif
 
 #if !defined(__cplusplus)

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -76,10 +76,6 @@
 
 #define STATIC_ASSERT(COND) ((void)sizeof(char[(COND) ? 1 : -1]))
 
-#if !defined(HAVE_C99_MATH)
-#define HAVE_C99_MATH 0
-#endif
-
 #ifndef PJ_TODEG
 #define PJ_TODEG(rad)  ((rad)*180.0/M_PI)
 #endif

--- a/travis/linux_gcc/install.sh
+++ b/travis/linux_gcc/install.sh
@@ -5,4 +5,4 @@ set -e
 export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
-CC="ccache gcc" CXX="ccache g++" CFLAGS="-std=c89 -Werror" CXXFLAGS="-Werror" ./travis/install.sh
+CC="ccache gcc" CXX="ccache g++" CFLAGS="-std=c99 -Werror" CXXFLAGS="-Werror" ./travis/install.sh

--- a/travis/linux_gcc7/install.sh
+++ b/travis/linux_gcc7/install.sh
@@ -5,4 +5,4 @@ set -e
 export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
-CC="ccache $CC" CXX="ccache $CXX" CFLAGS="-std=c89 -Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" ./travis/install.sh
+CC="ccache $CC" CXX="ccache $CXX" CFLAGS="-std=c99 -Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" ./travis/install.sh


### PR DESCRIPTION
Require C99 compiler see #1621

* cmake and autoconf now stipulate C99
* change c89 to c99 in travis jobs
* remove HAVE_C99_MATH checks

(unrelated) relax Visual Studio compatibility check in cmake/project-config-version.cmake.in (VS 2019 can use a VS 2015 library but not vice versa).