### PR TITLE
set PROJ_LIB on test targets for CMake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,8 @@ build_script:
 
 test_script:
   - echo test_script
+  - set PROJ_LIB=%PROJ_DIR%\share\proj
+  - cd %PROJ_LIB%
   - curl -O https://download.osgeo.org/proj/proj-datumgrid-1.8.zip
   - 7z e -aoa -y proj-datumgrid-1.8.zip
   - cd %PROJ_BUILD%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,6 @@ build_script:
 
 test_script:
   - echo test_script
-  - set PROJ_LIB=%PROJ_DIR%\share\proj
-  - cd %PROJ_LIB%
   - curl -O https://download.osgeo.org/proj/proj-datumgrid-1.8.zip
   - 7z e -aoa -y proj-datumgrid-1.8.zip
   - cd %PROJ_BUILD%

--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -26,6 +26,8 @@ function(proj_add_test_script_sh SH_NAME BIN_USE)
         COMMAND ${PROJECT_SOURCE_DIR}/test/cli/${SH_NAME}
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${${BIN_USE}}
       )
+    set_tests_properties( ${testname}
+        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
     endif()
 
   endif()
@@ -41,5 +43,8 @@ function(proj_add_gie_test TESTNAME TESTCASE)
       COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${GIE_BIN}
       ${TESTFILE}
     )
+    set_tests_properties( ${TESTNAME}
+        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
+
 
 endfunction()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -70,6 +70,9 @@ target_link_libraries(proj_pj_transform_test
   GTest::gtest
   ${PROJ_LIBRARIES})
 add_test(NAME proj_pj_transform_test COMMAND proj_pj_transform_test)
+set_property(TEST proj_pj_transform_test
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
+
 
 add_executable(proj_errno_string_test
   main.cpp
@@ -78,6 +81,8 @@ target_link_libraries(proj_errno_string_test
   GTest::gtest
   ${PROJ_LIBRARIES})
 add_test(NAME proj_errno_string_test COMMAND proj_errno_string_test)
+set_property(TEST proj_errno_string_test
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
 
 add_executable(proj_angular_io_test
   main.cpp
@@ -86,6 +91,8 @@ target_link_libraries(proj_angular_io_test
   GTest::gtest
   ${PROJ_LIBRARIES})
 add_test(NAME proj_angular_io_test COMMAND proj_angular_io_test)
+set_property(TEST proj_angular_io_test
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
 
 add_executable(proj_context_test
   main.cpp
@@ -94,6 +101,8 @@ target_link_libraries(proj_context_test
   GTest::gtest
   ${PROJ_LIBRARIES})
 add_test(NAME proj_context_test COMMAND proj_context_test)
+set_property(TEST proj_context_test
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
 
 if(MSVC AND BUILD_LIBPROJ_SHARED)
   # ph_phi2_test not compatible of a .dll build
@@ -105,6 +114,8 @@ else()
     GTest::gtest
     ${PROJ_LIBRARIES})
   add_test(NAME pj_phi2_test COMMAND pj_phi2_test)
+  set_property(TEST pj_phi2_test
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
 endif()
 
 add_executable(proj_test_cpp_api
@@ -123,6 +134,9 @@ target_link_libraries(proj_test_cpp_api
   ${PROJ_LIBRARIES}
   ${SQLITE3_LIBRARY})
 add_test(NAME proj_test_cpp_api COMMAND proj_test_cpp_api)
+set_property(TEST proj_test_cpp_api
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
+
 
 add_executable(gie_self_tests
   main.cpp
@@ -131,3 +145,5 @@ target_link_libraries(gie_self_tests
   GTest::gtest
   ${PROJ_LIBRARIES})
 add_test(NAME gie_self_tests COMMAND gie_self_tests)
+set_property(TEST gie_self_tests
+        PROPERTY ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -86,7 +86,7 @@ VERBOSE=1 make -j${NPROC}
 make install
 # The cmake build is not able to generate the null file, so copy it at hand
 cp /tmp/proj_autoconf_install_from_dist_all/share/proj/null /tmp/proj_cmake_install/share/proj
-PROJ_LIB=/tmp/proj_cmake_install/share/proj ctest
+ctest
 find /tmp/proj_cmake_install
 cd ..
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -84,8 +84,6 @@ cd build_cmake
 cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj_cmake_install
 VERBOSE=1 make -j${NPROC}
 make install
-# The cmake build is not able to generate the null file, so copy it at hand
-cp /tmp/proj_autoconf_install_from_dist_all/share/proj/null /tmp/proj_cmake_install/share/proj
 ctest
 find /tmp/proj_cmake_install
 cd ..


### PR DESCRIPTION
Set PROJ_LIB so test script invocation does not have to manually set the directory.