### PR TITLE
Upgrade Travis CI distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# This is the config file for building proj.4 and running its test suite
+# This is the config file for building proj and running its test suite
 # with Travis-ci.org
 language: cpp
 
@@ -15,9 +15,8 @@ matrix:
   include:
 
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
-      sudo: required
       services:
         - docker
       env:
@@ -25,9 +24,8 @@ matrix:
         - DETAILS="linux, gcc"
 
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
-      sudo: required
       services:
         - docker
       env:
@@ -40,12 +38,15 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages: ['g++-7','make','autoconf','automake']
+          packages:
+            - g++-7
+            - make
+            - autoconf
+            - automake
 
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: clang
-      sudo: required
       services:
         - docker
       env:
@@ -58,17 +59,15 @@ matrix:
         - DETAILS="osx"
 
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
-      sudo: required
       env:
         - BUILD_NAME=mingw32
         - DETAILS="mingw32"
 
     - os: linux
       compiler: gcc
-      dist: trusty
-      sudo: required
+      dist: xenial
       env:
         - BUILD_NAME=csa
         - DETAILS="CLang Static Analyzer"

--- a/docs/source/community/code_contributions.rst
+++ b/docs/source/community/code_contributions.rst
@@ -117,18 +117,19 @@ Preliminary step: install clang. For example:
 
     wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
     tar xJf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+    mv clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04 clang+llvm-6
 
 Run configure under the scan-build utility of clang:
 
 ::
 
-    ./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build ./configure
+    ./clang+llvm-6/bin/scan-build ./configure
 
 Build under scan-build:
 
 ::
 
-    ./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build make [-j8]
+    ./clang+llvm-6/bin/scan-build make [-j8]
 
 If CSA finds errors, they will be emitted during the build. And in which case,
 at the end of the build process, scan-build will emit a warning message
@@ -137,7 +138,7 @@ is with someling like
 
 ::
 
-    ./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-view /tmp/scan-build-2018-03-15-121416-17476-1
+    ./clang+llvm-6/bin/scan-view /tmp/scan-build-2018-03-15-121416-17476-1
 
 
 This will open a web browser with the interactive report.

--- a/docs/source/community/code_contributions.rst
+++ b/docs/source/community/code_contributions.rst
@@ -88,12 +88,7 @@ cppcheck static analyzer
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can run locally ``scripts/cppcheck.sh`` that is a wrapper script around the
-cppcheck utility. It is known to work with cppcheck 1.61 of Ubuntu Trusty 14.0,
-since this is what is currently used on Travis-CI
-(``travis/linux_gcc/before_install.sh``).
-At the time of writing, this also works with cppcheck 1.72 of Ubuntu Xenial
-16.04, and latest cppcheck
-master.
+cppcheck utility. This tool is used as part of the quality control of the code.
 
 cppcheck can have false positives. In general, it is preferable to rework the
 code a bit to make it more 'obvious' and avoid those false positives. When not
@@ -115,9 +110,9 @@ Preliminary step: install clang. For example:
 
 ::
 
-    wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-    tar xJf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-    mv clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04 clang+llvm-6
+    wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    tar xJf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    mv clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04 clang+llvm-6
 
 Run configure under the scan-build utility of clang:
 

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Note: tested with cppcheck 1.72 as shipped with Ubuntu 16.04
-# as well as with cppcheck 1.76.1
+# Note: tested with cppcheck 1.61 as shipped with Ubuntu 14.04
+echo `cppcheck --version`
 
 LOG_FILE=/tmp/cppcheck_proj.txt
 

--- a/travis/before_install_apt.sh
+++ b/travis/before_install_apt.sh
@@ -4,4 +4,4 @@
 # "global" before_install script.
 
 sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
+sudo apt-get install -qq python3-pip python3-setuptools

--- a/travis/before_install_apt.sh
+++ b/travis/before_install_apt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# All Debian-like before_install scripts starts by running this
+# "global" before_install script.
+
+sudo apt-get update -qq
+sudo apt-get install -qq python3-pip

--- a/travis/before_install_pip.sh
+++ b/travis/before_install_pip.sh
@@ -5,5 +5,6 @@
 
 # Configure Python pip
 pip3 install --user --upgrade pip
+echo `pip3 --version`
 pip3 config --user set global.progress_bar off
 pip3 install --user jsonschema

--- a/travis/csa/before_install.sh
+++ b/travis/csa/before_install.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 set -e
-sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
 
-./travis/before_install.sh
+./travis/before_install_apt.sh
+./travis/before_install_pip.sh
 
 sudo apt-get install -qq sqlite3 libsqlite3-dev
 
-wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-tar xJf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+CLANG_LLVM=clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04
+wget http://releases.llvm.org/6.0.0/$CLANG_LLVM.tar.xz
+tar xJf $CLANG_LLVM.tar.xz
+mv $CLANG_LLVM clang+llvm-6

--- a/travis/csa/before_install.sh
+++ b/travis/csa/before_install.sh
@@ -7,7 +7,7 @@ set -e
 
 sudo apt-get install -qq sqlite3 libsqlite3-dev
 
-CLANG_LLVM=clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04
+CLANG_LLVM=clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04
 wget http://releases.llvm.org/6.0.0/$CLANG_LLVM.tar.xz
 tar xJf $CLANG_LLVM.tar.xz
 mv $CLANG_LLVM clang+llvm-6

--- a/travis/csa/install.sh
+++ b/travis/csa/install.sh
@@ -5,7 +5,7 @@ set -e
 # prepare build files
 ./autogen.sh
 
-CXXFLAGS="-std=c++11" ./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build -o scanbuildoutput -plist -v ./configure
-./clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04/bin/scan-build -o scanbuildoutput -plist -v make -j2
+CXXFLAGS="-std=c++11" ./clang+llvm-6/bin/scan-build -o scanbuildoutput -plist -v ./configure
+./clang+llvm-6/bin/scan-build -o scanbuildoutput -plist -v make -j2
 
 if grep -r "\.c" scanbuildoutput | grep "<string>" | grep -v -e "<key>" -e _generated_parser; then echo "error" && /bin/false; else echo "ok"; fi 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -34,8 +34,8 @@ cd $TAR_DIRECTORY
 # autoconf build from generated tarball
 mkdir build_autoconf
 cd build_autoconf
-if [ -f /usr/lib/jvm/java-7-openjdk-amd64/include/jni.h ]; then
-    CXXFLAGS="-I/usr/lib/jvm/java-7-openjdk-amd64/include -I/usr/lib/jvm/java-7-openjdk-amd64/include/linux $CXXFLAGS" ../configure --prefix=/tmp/proj_autoconf_install_from_dist_all --with-jni
+if [ -f $JAVA_HOME/include/jni.h ]; then
+    CXXFLAGS="-I$JAVA_HOME/include -I$JAVA_HOME/include/linux $CXXFLAGS" ../configure --prefix=/tmp/proj_autoconf_install_from_dist_all --with-jni
 else
     ../configure --prefix=/tmp/proj_autoconf_install_from_dist_all
 fi

--- a/travis/linux_clang/before_install.sh
+++ b/travis/linux_clang/before_install.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 set -e
-sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
 
-./travis/before_install.sh
+./travis/before_install_apt.sh
+./travis/before_install_pip.sh
 
 sudo apt-get install -qq sqlite3 libsqlite3-dev

--- a/travis/linux_gcc/before_install.sh
+++ b/travis/linux_gcc/before_install.sh
@@ -6,19 +6,22 @@ set -e
 ./travis/before_install_pip.sh
 
 sudo apt-get install -qq \
-        cppcheck \
         lcov \
         doxygen graphviz \
-        openjdk-7-jdk \
         sqlite3 libsqlite3-dev
+
+# Install Cppcheck to maintain version 1.61
+LIBTINYXML=libtinyxml2-0.0.0_0~git20120518.1.a2ae54e-1_amd64.deb
+CPPCHECK=cppcheck_1.61-1_amd64.deb
+wget -q http://security.ubuntu.com/ubuntu/pool/universe/t/tinyxml2/$LIBTINYXML
+wget -q http://security.ubuntu.com/ubuntu/pool/universe/c/cppcheck/$CPPCHECK
+sudo dpkg -i $LIBTINYXML
+sudo dpkg -i $CPPCHECK
 
 scripts/cppcheck.sh
 scripts/doxygen.sh
 
-# Force sphinxcontrib-bibtex version to 0.4.2, because 1.0.0 requires
-# sphinx >= 2.0 which is only available on Python >= 3.5, and this config
-# has only 3.4
-pip3 install --user sphinxcontrib-bibtex==0.4.2
+pip3 install --user sphinxcontrib-bibtex
 pip3 install --user cpp-coveralls
 
 ./travis/docker.sh

--- a/travis/linux_gcc/before_install.sh
+++ b/travis/linux_gcc/before_install.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 set -e
-sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
 
-./travis/before_install.sh
+./travis/before_install_apt.sh
+./travis/before_install_pip.sh
 
-sudo apt-get install -y cppcheck
-sudo apt-get install -qq lcov
-sudo apt-get install -qq doxygen graphviz
-sudo apt-get install -qq sqlite3 libsqlite3-dev
-sudo apt-get install -qq openjdk-7-jdk
+sudo apt-get install -qq \
+        cppcheck \
+        lcov \
+        doxygen graphviz \
+        openjdk-7-jdk \
+        sqlite3 libsqlite3-dev
 
 scripts/cppcheck.sh
 scripts/doxygen.sh

--- a/travis/linux_gcc7/before_install.sh
+++ b/travis/linux_gcc7/before_install.sh
@@ -6,10 +6,8 @@ set -e
 ./travis/before_install_pip.sh
 
 sudo apt-get install -qq \
-        cppcheck \
         lcov \
         doxygen graphviz \
-        openjdk-7-jdk \
         sqlite3 libsqlite3-dev
 
 #scripts/cppcheck.sh

--- a/travis/linux_gcc7/before_install.sh
+++ b/travis/linux_gcc7/before_install.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 set -e
-sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
 
-./travis/before_install.sh
+./travis/before_install_apt.sh
+./travis/before_install_pip.sh
 
-sudo apt-get update -qq
-sudo apt-get install -y cppcheck
-sudo apt-get install -qq lcov
-sudo apt-get install -qq doxygen graphviz
-sudo apt-get install -qq sqlite3 libsqlite3-dev
-sudo apt-get install -qq openjdk-7-jdk
+sudo apt-get install -qq \
+        cppcheck \
+        lcov \
+        doxygen graphviz \
+        openjdk-7-jdk \
+        sqlite3 libsqlite3-dev
 
 #scripts/cppcheck.sh
 #scripts/doxygen.sh

--- a/travis/mingw32/before_install.sh
+++ b/travis/mingw32/before_install.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
 set -e
-sudo apt-get update -qq
-sudo apt-get install -qq python3-pip
 
-./travis/before_install.sh
+./travis/before_install_apt.sh
+./travis/before_install_pip.sh
 
-sudo apt-get install wget
-sudo apt-get install binutils-mingw-w64-x86-64
-sudo apt-get install gcc-mingw-w64-x86-64
-sudo apt-get install g++-mingw-w64-x86-64
-sudo apt-get install g++-mingw-w64
-sudo apt-get install mingw-w64-tools
-sudo apt-get install -y wine1.4-amd64
-sudo apt-get install sqlite3
+sudo apt-get install -qq \
+        wget \
+        binutils-mingw-w64-x86-64 \
+        gcc-mingw-w64-x86-64 \
+        g++-mingw-w64-x86-64 \
+        mingw-w64-tools \
+        wine1.4-amd64 \
+        sqlite3

--- a/travis/mingw32/install.sh
+++ b/travis/mingw32/install.sh
@@ -5,24 +5,29 @@ set -e
 export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
+MINGW_ARCH=x86_64-w64-mingw32
+MINGW_PREFIX=/usr/lib/gcc/$MINGW_ARCH/4.8
+
 # prepare wine environment
+WINE_SYSDIR=$HOME/.wine/drive_c/windows
 wine64 cmd /c dir
-ln -s /usr/lib/gcc/x86_64-w64-mingw32/4.8/libstdc++-6.dll  $HOME/.wine/drive_c/windows
-ln -s /usr/lib/gcc/x86_64-w64-mingw32/4.8/libgcc_s_sjlj-1.dll  $HOME/.wine/drive_c/windows
-ln -s /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll  $HOME/.wine/drive_c/windows
+ln -s $MINGW_PREFIX/libstdc++-6.dll $WINE_SYSDIR
+ln -s $MINGW_PREFIX/libgcc_s_sjlj-1.dll $WINE_SYSDIR
+ln -s /usr/$MINGW_ARCH/lib/libwinpthread-1.dll $WINE_SYSDIR
 
 # build sqlite3
 wget https://sqlite.org/2018/sqlite-autoconf-3250100.tar.gz
 tar xzf sqlite-autoconf-3250100.tar.gz
-(cd sqlite-autoconf-3250100 &&  CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 && make -j2 && sudo make install)
-ln -s /usr/x86_64-w64-mingw32/bin/libsqlite3-0.dll  $HOME/.wine/drive_c/windows
+(cd sqlite-autoconf-3250100 && CC="ccache $MINGW_ARCH-gcc" CXX="ccache $MINGW_ARCH-g++" LD=$MINGW_ARCH-ld
+./configure --host=$MINGW_ARCH --prefix=/usr/$MINGW_ARCH && make -j2 && sudo make install)
+ln -s /usr/$MINGW_ARCH/bin/libsqlite3-0.dll $WINE_SYSDIR
 
 # prepare build files
 ./autogen.sh
 # autoconf build
 mkdir build_autoconf
 cd build_autoconf
-CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install
+CC="ccache $MINGW_ARCH-gcc" CXX="ccache $MINGW_ARCH-g++" LD=$MINGW_ARCH-ld ../configure --host=$MINGW_ARCH --prefix=/tmp/proj_autoconf_install
 make -j2
 make install
 make dist-all
@@ -38,7 +43,7 @@ cd ..
 # autoconf build with grids
 mkdir build_autoconf_grids
 cd build_autoconf_grids
-CC="ccache x86_64-w64-mingw32-gcc" CXX="ccache x86_64-w64-mingw32-g++" LD=x86_64-w64-mingw32-ld ../configure --host=x86_64-w64-mingw32 --prefix=/tmp/proj_autoconf_install_nad
+CC="ccache $MINGW_ARCH-gcc" CXX="ccache $MINGW_ARCH-g++" LD=$MINGW_ARCH-ld ../configure --host=$MINGW_ARCH --prefix=/tmp/proj_autoconf_install_nad
 make -j2
 make install
 find /tmp/proj_autoconf_install_nad

--- a/travis/mingw32/install.sh
+++ b/travis/mingw32/install.sh
@@ -6,12 +6,13 @@ export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 MINGW_ARCH=x86_64-w64-mingw32
-MINGW_PREFIX=/usr/lib/gcc/$MINGW_ARCH/4.8
+MINGW_PREFIX=/usr/lib/gcc/$MINGW_ARCH/5.3-posix
 
 # prepare wine environment
 WINE_SYSDIR=$HOME/.wine/drive_c/windows
 wine64 cmd /c dir
 ln -s $MINGW_PREFIX/libstdc++-6.dll $WINE_SYSDIR
+ln -s $MINGW_PREFIX/libgcc_s_seh-1.dll $WINE_SYSDIR
 ln -s $MINGW_PREFIX/libgcc_s_sjlj-1.dll $WINE_SYSDIR
 ln -s /usr/$MINGW_ARCH/lib/libwinpthread-1.dll $WINE_SYSDIR
 

--- a/travis/osx/before_install.sh
+++ b/travis/osx/before_install.sh
@@ -4,14 +4,15 @@ set -e
 
 export PATH=$HOME/Library/Python/3.6/bin:$PATH
 
-./travis/before_install.sh
-
 brew update
 brew install ccache
 brew install sqlite3
 brew install doxygen
 brew install md5sha1sum
 
+./travis/before_install_pip.sh
+
 pip3 install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
 which sphinx-build
+
 (cd docs; make html)


### PR DESCRIPTION
This PR updates the Travis CI distribution from [`trusty`](https://docs.travis-ci.com/user/reference/trusty/) to [`xenial`](https://docs.travis-ci.com/user/reference/xenial/). The motivation behind this is that Ubuntu Trusty 14.04 is no longer maintained, and therefore an unlikely system in widespread use today. Issues like #1627 are symptoms of using outdated test VMs.

The first commit rearranges the testing scripts, but does not upgrade anything. And the second commit upgrades the test components. The upgrades include:
* From openjdk-7 via apt to openjdk-11 via Travis CI xenial's $JAVA_HOME
* From mingw 4.8 -> 5.3, as supported by xenial
* clang+llvm for csa kept at version 6.0.0, but for ubuntu-16.04
* Furthermore xenial implicitly has many upgrades, specifically:
  - gcc 4.8.4 -> 5.4.0
  - clang 4.0.0 -> 5.0.0
  - cmake 3.9.2 -> 3.12.4
  - python 3.4.3 -> 3.5.2

A few remarks:
* A few upgrades included here may need approval from PSC (e.g. [RFC 2](https://github.com/OSGeo/PROJ/blob/master/docs/source/community/rfc/rfc-2.rst) describes test environment components and their version numbers); let me know and I'll start that discussion on the email list.
* Cppcheck from the `linux_gcc` test was effectively disabled due to too many false positives. This is a temporary measure to take a look at what is going on, for instance [scripts/cppcheck.sh](https://github.com/OSGeo/PROJ/blob/master/scripts/cppcheck.sh) is tested with cppcheck 1.72 as shipped with Ubuntu 16.04 (xenial), but several of the uninitvar errors seem strange.