### PR TITLE
Only call pkg-config in configure when necessary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -279,7 +279,9 @@ dnl ---------------------------------------------------------------------------
 dnl Check for sqlite3 library and binary
 dnl ---------------------------------------------------------------------------
 
-PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.7])
+if test "x$SQLITE3_CFLAGS$SQLITE3_LIBS" = "x" ; then
+    PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.7])
+fi
 AC_SUBST(SQLITE3_CFLAGS,$SQLITE3_CFLAGS)
 AC_SUBST(SQLITE3_LIBS,$SQLITE3_LIBS)
 


### PR DESCRIPTION
It's currently not possible to build PROJ4 on macOS because of a problem with pkg-config (see issue #1529).

This PR changes the configure script to only call pkg-config when the variables $SQLITE3_CFLAGS and $SQLITE3_LIBS are not set.

This allows building PROJ when pkg-config is not available.