### PR TITLE
ob_tran doc: fix/clarify semantics of o_lat_p/o_lon_p

### DIFF
--- a/docs/source/operations/projections/ob_tran.rst
+++ b/docs/source/operations/projections/ob_tran.rst
@@ -19,9 +19,10 @@ oblique projection by means of the General Oblique Transformation. The user
 performs the oblique transformation by selecting the oblique projection
 ``+proj=ob_tran``, specifying the translation factors, :option:`+o_lat_p`, and
 :option:`+o_lon_p`, and the projection to be used, :option:`+o_proj`. In the
-example of the Fairgrieve projection the latitude and longitude of the pole of
-the new coordinates, :math:`\alpha` and :math:`\beta` respectively, are to be placed
-at 45°N and 90°W and use the :ref:`moll` projection. Because the central meridian
+example of the Fairgrieve projection, the latitude and longitude of the North pole
+of the unrotated geographic CRS, :math:`\alpha` and :math:`\beta` respectively,
+expressed in the rotated geographic CRS, are to be placed
+at 45°N and 90°W  and the :ref:`moll` projection is used. Because the central meridian
 of the translated coordinates will follow the :math:`\beta` meridian it is
 necessary to translate the translated system so that the Greenwich meridian
 will pass through the center of the projection by offsetting the central meridian.
@@ -50,11 +51,11 @@ New pole
 
 .. option:: +o_lat_p=<latitude>
 
-    Latitude of new pole for oblique projection.
+    Latitude of the North pole of the unrotated source CRS, expressed in the rotated geographic CRS.
 
 .. option:: +o_lon_p=<longitude>
 
-    Longitude of new pole for oblique projection.
+    Longitude of the North pole of the unrotated source CRS, expressed in the rotated geographic CRS.
 
 Rotate about point
 ................................................................................

--- a/src/projections/ob_tran.cpp
+++ b/src/projections/ob_tran.cpp
@@ -31,8 +31,10 @@ static PJ_XY o_forward(PJ_LP lp, PJ *P) {             /* spheroid */
     coslam = cos(lp.lam);
     sinphi = sin(lp.phi);
     cosphi = cos(lp.phi);
+    /* Formula (5-8b) of Snyder's "Map projections: a working manual" */
     lp.lam = adjlon(aatan2(cosphi * sin(lp.lam), Q->sphip * cosphi * coslam +
         Q->cphip * sinphi) + Q->lamp);
+    /* Formula (5-7) */
     lp.phi = aasin(P->ctx,Q->sphip * sinphi - Q->cphip * cosphi * coslam);
 
     return Q->link->fwd(lp, Q->link);
@@ -62,7 +64,9 @@ static PJ_LP o_inverse(PJ_XY xy, PJ *P) {             /* spheroid */
         coslam = cos(lp.lam -= Q->lamp);
         sinphi = sin(lp.phi);
         cosphi = cos(lp.phi);
+        /* Formula (5-9) */
         lp.phi = aasin(P->ctx,Q->sphip * sinphi + Q->cphip * cosphi * coslam);
+        /* Formula (5-10b) */
         lp.lam = aatan2(cosphi * sin(lp.lam), Q->sphip * cosphi * coslam -
             Q->cphip * sinphi);
     }


### PR DESCRIPTION
This is a super confusing topic, but from experiments, and in particular with
the example of Fairgrieve projection, o_lat_p and o_lon_p are the coordinates
of the North pole of the unrotated geographic CRS expressed in the rotated
geographic CRS.
This is different from defining a 'new pole', which would be the coordinates
of the rotated North pole expressed in the unrotated CRS.

@kbevers I'd appreciate your review of this. This is a topic I'm stumbling upon when dealing with raster formats such as GRIB, netCDF or PDS/ISIS3 that have different conventions than PROJ ob_tran & Snyder formulas. The term "new pole" is confusing/wrong to me. "New pole" to me would sound like the North pole of the rotated grid, which to the best of my understanding&experiments, is not the case.