### PR TITLE
proj.pc.in: add Libs.Private

### DIFF
--- a/proj.pc.in
+++ b/proj.pc.in
@@ -9,4 +9,5 @@ Description: Cartographic Projections Library.
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj
+Libs.Private: -lstdc++
 Cflags: -I${includedir}


### PR DESCRIPTION
Add -lstdc++ to Libs.Private to allow packages such as libgeotiff to
retrieve this dependency when linking statically with proj

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>