### PR TITLE
Remove sentence saying that coordinate system might by null

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -962,9 +962,7 @@ const datum::DatumEnsemblePtr &SingleCRS::datumEnsemble() PROJ_PURE_DEFN {
 
 /** \brief Return the cs::CoordinateSystem associated with the CRS.
  *
- * This might be null, in which case datumEnsemble() return will not be null.
- *
- * @return a CoordinateSystem that might be null.
+ * @return a CoordinateSystem.
  */
 const cs::CoordinateSystemNNPtr &SingleCRS::coordinateSystem() PROJ_PURE_DEFN {
     return d->coordinateSystem;


### PR DESCRIPTION
The sentence "This might be null, in which case `datumEnsemble()` return will not be
null" It is true for `datum()`, but does not apply to `coordinateSystem()`.