### PR TITLE
Fix two sentences that seem to be copy-and-paste forgotten.

### DIFF
--- a/include/proj/metadata.hpp
+++ b/include/proj/metadata.hpp
@@ -55,8 +55,7 @@ namespace metadata {
 
 /** \brief Standardized resource reference.
  *
- * Local names are names which are directly accessible to and maintained by a
- * NameSpace within which they are local, indicated by the scope.
+ * A citation contains a title.
  *
  * \remark Simplified version of [Citation]
  * (http://www.geoapi.org/3.0/javadoc/org/opengis/metadata/citation/Citation.html)

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -553,7 +553,7 @@ Ellipsoid::inverseFlattening() PROJ_PURE_DEFN {
  * has been defined with this value.
  *
  * @see computeSemiMinorAxis() that will always return a valid value of the
- * inverse flattening, whether the ellipsoid has been defined through inverse
+ * semi-minor axis, whether the ellipsoid has been defined through inverse
  * flattening or semi-minor axis.
  *
  * @return the semi-minor axis of the ellipsoid, or empty.


### PR DESCRIPTION
Those sentences were applying to other objects (`LocalName`) or methods (`computeInverseFlattening()`).