### PR TITLE
createOperations(): fix double vertical unit conversion from CompoundCRS to other CRS when the horizontal part of the projected CRS uses non-metre unit

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -3332,13 +3332,16 @@ void ProjectedCRS::addUnitConvertAndAxisSwap(io::PROJStringFormatter *formatter,
         if (!formatter->getCRSExport()) {
             formatter->addStep("unitconvert");
             formatter->addParam("xy_in", "m");
-            formatter->addParam("z_in", "m");
+            if (!formatter->omitZUnitConversion())
+                formatter->addParam("z_in", "m");
             if (projUnit.empty()) {
                 formatter->addParam("xy_out", toSI);
-                formatter->addParam("z_out", toSI);
+                if (!formatter->omitZUnitConversion())
+                    formatter->addParam("z_out", toSI);
             } else {
                 formatter->addParam("xy_out", projUnit);
-                formatter->addParam("z_out", projUnit);
+                if (!formatter->omitZUnitConversion())
+                    formatter->addParam("z_out", projUnit);
             }
         } else {
             if (projUnit.empty()) {


### PR DESCRIPTION
Fix issue reported on https://lists.osgeo.org/pipermail/proj/2019-October/008939.html