### PR TITLE
proj.pc.in: add SQLITE3_LIBS to Libs.Private

### DIFF
--- a/proj.pc.in
+++ b/proj.pc.in
@@ -9,5 +9,5 @@ Description: Cartographic Projections Library.
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj
-Libs.Private: -lstdc++
+Libs.Private: @SQLITE3_LIBS@ -lstdc++
 Cflags: -I${includedir}


### PR DESCRIPTION
Add @SQLITE3_LIBS@ to Libs.Private so applications linking statically
with proj (such as libgeotiff) will know that they have to link with
-lsqlite3

Fixes:
 - http://autobuild.buildroot.org/results/737db533c16f285a02118ab048e8427d3e35803d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>