### PR TITLE
Fix errors running gie-based tests in Debug mode on Windows

### DIFF
--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -36,7 +36,7 @@ endfunction()
 
 function(proj_add_gie_test TESTNAME TESTCASE)
 
-    set(GIE_BIN "gie")
+    set(GIE_BIN $<TARGET_FILE_NAME:gie>)
     set(TESTFILE ${CMAKE_SOURCE_DIR}/test/${TESTCASE})
     add_test(NAME ${TESTNAME}
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test


### PR DESCRIPTION
In Debug mode on Windows, the gie executable is actually built as "gie_d", so all the gie tests fail because they can't find the executable.