### PR TITLE
Better filtering based on extent and performance improvements

### DIFF
--- a/include/proj/internal/Makefile.am
+++ b/include/proj/internal/Makefile.am
@@ -8,4 +8,6 @@ noinst_HEADERS = \
 	internal.hpp \
 	io_internal.hpp \
 	lru_cache.hpp \
-	include_nlohmann_json.hpp
+	include_nlohmann_json.hpp \
+	tracing.hpp
+

--- a/include/proj/internal/tracing.hpp
+++ b/include/proj/internal/tracing.hpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+ *
+ * Project:  PROJ
+ * Purpose:  Tracing/profiling
+ * Author:   Even Rouault <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef TRACING_HH_INCLUDED
+#define TRACING_HH_INCLUDED
+
+//! @cond Doxygen_Suppress
+
+#include <string>
+
+#include "proj/util.hpp"
+
+#ifdef ENABLE_TRACING
+
+NS_PROJ_START
+
+namespace tracing {
+
+void logTrace(const std::string &str,
+              const std::string &component = std::string());
+
+class EnterBlock {
+  public:
+    EnterBlock(const std::string &msg);
+    ~EnterBlock();
+
+  private:
+    PROJ_OPAQUE_PRIVATE_DATA
+};
+
+#define TRACING_MERGE(a, b) a##b
+#define TRACING_UNIQUE_NAME(a) TRACING_MERGE(unique_name_, a)
+
+#define ENTER_BLOCK(x) EnterBlock TRACING_UNIQUE_NAME(__LINE__)(x)
+#define ENTER_FUNCTION() ENTER_BLOCK(__FUNCTION__ + std::string("()"))
+
+} // namespace tracing
+
+NS_PROJ_END
+
+using namespace NS_PROJ::tracing;
+
+#else // ENABLE_TRACING
+
+inline void logTrace(const std::string &, const std::string & = std::string()) {
+}
+
+#define ENTER_BLOCK(x)                                                         \
+    do {                                                                       \
+    } while (0);
+
+#define ENTER_FUNCTION()                                                       \
+    do {                                                                       \
+    } while (0)
+
+#endif // ENABLE_TRACING
+
+//! @endcond
+
+#endif // TRACING_HH_INCLUDED

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -1050,7 +1050,10 @@ class PROJ_GCC_DLL AuthorityFactory {
         const std::string &sourceCRSAuthName, const std::string &sourceCRSCode,
         const std::string &targetCRSAuthName, const std::string &targetCRSCode,
         bool usePROJAlternativeGridNames, bool discardIfMissingGrid,
-        bool discardSuperseded) const;
+        bool discardSuperseded, bool tryReverseOrder = false,
+        bool reportOnlyIntersectingTransformations = false,
+        const metadata::ExtentPtr &intersectingExtent1 = nullptr,
+        const metadata::ExtentPtr &intersectingExtent2 = nullptr) const;
 
     PROJ_DLL std::vector<operation::CoordinateOperationNNPtr>
     createFromCRSCodesWithIntermediates(
@@ -1059,7 +1062,10 @@ class PROJ_GCC_DLL AuthorityFactory {
         bool usePROJAlternativeGridNames, bool discardIfMissingGrid,
         bool discardSuperseded,
         const std::vector<std::pair<std::string, std::string>>
-            &intermediateCRSAuthCodes) const;
+            &intermediateCRSAuthCodes,
+        ObjectType allowedIntermediateObjectType = ObjectType::CRS,
+        const metadata::ExtentPtr &intersectingExtent1 = nullptr,
+        const metadata::ExtentPtr &intersectingExtent2 = nullptr) const;
 
     PROJ_DLL std::string getOfficialNameFromAlias(
         const std::string &aliasedName, const std::string &tableName,

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -299,8 +299,8 @@ osgeo::proj::io::AuthorityFactory::create(dropbox::oxygen::nn<std::shared_ptr<os
 osgeo::proj::io::AuthorityFactory::createEllipsoid(std::string const&) const
 osgeo::proj::io::AuthorityFactory::createExtent(std::string const&) const
 osgeo::proj::io::AuthorityFactory::createFromCoordinateReferenceSystemCodes(std::string const&, std::string const&) const
-osgeo::proj::io::AuthorityFactory::createFromCoordinateReferenceSystemCodes(std::string const&, std::string const&, std::string const&, std::string const&, bool, bool, bool) const
-osgeo::proj::io::AuthorityFactory::createFromCRSCodesWithIntermediates(std::string const&, std::string const&, std::string const&, std::string const&, bool, bool, bool, std::vector<std::pair<std::string, std::string>, std::allocator<std::pair<std::string, std::string> > > const&) const
+osgeo::proj::io::AuthorityFactory::createFromCoordinateReferenceSystemCodes(std::string const&, std::string const&, std::string const&, std::string const&, bool, bool, bool, bool, bool, std::shared_ptr<osgeo::proj::metadata::Extent> const&, std::shared_ptr<osgeo::proj::metadata::Extent> const&) const
+osgeo::proj::io::AuthorityFactory::createFromCRSCodesWithIntermediates(std::string const&, std::string const&, std::string const&, std::string const&, bool, bool, bool, std::vector<std::pair<std::string, std::string>, std::allocator<std::pair<std::string, std::string> > > const&, osgeo::proj::io::AuthorityFactory::ObjectType, std::shared_ptr<osgeo::proj::metadata::Extent> const&, std::shared_ptr<osgeo::proj::metadata::Extent> const&) const
 osgeo::proj::io::AuthorityFactory::createGeodeticCRS(std::string const&) const
 osgeo::proj::io::AuthorityFactory::createGeodeticDatum(std::string const&) const
 osgeo::proj::io::AuthorityFactory::createGeographicCRS(std::string const&) const

--- a/scripts/reformat_cpp.sh
+++ b/scripts/reformat_cpp.sh
@@ -15,7 +15,7 @@ esac
 
 TOPDIR="$SCRIPT_DIR/.."
 
-for i in "$TOPDIR"/include/proj/*.hpp "$TOPDIR"/include/proj/internal/*.hpp "$TOPDIR"/src/iso19111/*.cpp "$TOPDIR"/test/unit/*.cpp "$TOPDIR"/src/apps/projinfo.cpp; do
+for i in "$TOPDIR"/include/proj/*.hpp "$TOPDIR"/include/proj/internal/*.hpp "$TOPDIR"/src/iso19111/*.cpp "$TOPDIR"/test/unit/*.cpp "$TOPDIR"/src/apps/projinfo.cpp "$TOPDIR"/src/tracing.cpp; do
     if ! echo "$i" | grep -q "lru_cache.hpp"; then
         "$SCRIPT_DIR"/reformat.sh "$i";
     fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -210,7 +210,9 @@ libproj_la_SOURCES = \
 	wkt2_parser.h wkt2_parser.cpp \
 	wkt2_generated_parser.h wkt2_generated_parser.c \
 	\
-	proj_json_streaming_writer.cpp
+	proj_json_streaming_writer.cpp \
+	\
+	tracing.cpp
 
 
 # The sed hack is to please MSVC

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -993,7 +993,8 @@ bool SingleCRS::baseIsEquivalentTo(
 
     // TODO test DatumEnsemble
     return d->coordinateSystem->_isEquivalentTo(
-        otherSingleCRS->d->coordinateSystem.get(), criterion);
+               otherSingleCRS->d->coordinateSystem.get(), criterion) &&
+           getExtensionProj4() == otherSingleCRS->getExtensionProj4();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -284,6 +284,7 @@ set(SRC_LIBPROJ_CORE
   wkt_parser.hpp
   zpoly1.cpp
   proj_json_streaming_writer.cpp
+  tracing.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/proj_config.h
 )
 

--- a/src/tracing.cpp
+++ b/src/tracing.cpp
@@ -1,0 +1,224 @@
+/******************************************************************************
+ *
+ * Project:  PROJ
+ * Purpose:  Tracing/profiling
+ * Author:   Even Rouault <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifdef ENABLE_TRACING
+
+#ifndef FROM_PROJ_CPP
+#define FROM_PROJ_CPP
+#endif
+
+#include <stdlib.h>
+
+#include "proj/internal/internal.hpp"
+#include "proj/internal/tracing.hpp"
+
+//! @cond Doxygen_Suppress
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <sys/timeb.h>
+#else
+#include <sys/time.h> /* for gettimeofday() */
+#define CPLTimeVal timeval
+#define CPLGettimeofday(t, u) gettimeofday(t, u)
+#endif
+
+NS_PROJ_START
+
+using namespace internal;
+
+namespace tracing {
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+struct CPLTimeVal {
+    time_t tv_sec; /* seconds */
+    long tv_usec;  /* and microseconds */
+};
+
+// ---------------------------------------------------------------------------
+
+static void CPLGettimeofday(struct CPLTimeVal *tp, void * /* timezonep*/) {
+    struct _timeb theTime;
+
+    _ftime(&theTime);
+    tp->tv_sec = static_cast<time_t>(theTime.time);
+    tp->tv_usec = theTime.millitm * 1000;
+}
+#endif
+
+struct Singleton {
+    FILE *f = nullptr;
+    int callLevel = 0;
+    int minDelayMicroSec = 10 * 1000; // 10 millisec
+    long long startTimeStamp = 0;
+    std::string componentsWhiteList{};
+    std::string componentsBlackList{};
+
+    Singleton();
+    ~Singleton();
+
+    Singleton(const Singleton &) = delete;
+    Singleton &operator=(const Singleton &) = delete;
+
+    void logTraceRaw(const std::string &str);
+};
+
+// ---------------------------------------------------------------------------
+
+Singleton::Singleton() {
+    const char *traceFile = getenv("PROJ_TRACE_FILE");
+    if (traceFile)
+        f = fopen(traceFile, "wb");
+    if (!f)
+        f = stderr;
+
+    const char *minDelay = getenv("PROJ_TRACE_MIN_DELAY");
+    if (minDelay) {
+        minDelayMicroSec = atoi(minDelay);
+    }
+
+    const char *whiteList = getenv("PROJ_TRACE_WHITE_LIST");
+    if (whiteList) {
+        componentsWhiteList = whiteList;
+    }
+
+    const char *blackList = getenv("PROJ_TRACE_BLACK_LIST");
+    if (blackList) {
+        componentsBlackList = blackList;
+    }
+
+    CPLTimeVal ts;
+    CPLGettimeofday(&ts, nullptr);
+    startTimeStamp = static_cast<long long>(ts.tv_sec) * 1000000 + ts.tv_usec;
+
+    logTraceRaw("<log>");
+    ++callLevel;
+}
+
+// ---------------------------------------------------------------------------
+
+Singleton::~Singleton() {
+    --callLevel;
+    logTraceRaw("</log>");
+    fflush(f);
+
+    if (f != stderr)
+        fclose(f);
+}
+
+// ---------------------------------------------------------------------------
+
+static Singleton &getSingleton() {
+    static Singleton singleton;
+    return singleton;
+}
+
+// ---------------------------------------------------------------------------
+
+void Singleton::logTraceRaw(const std::string &str) {
+    CPLTimeVal ts;
+    CPLGettimeofday(&ts, nullptr);
+    const auto ts_usec =
+        static_cast<long long>(ts.tv_sec) * 1000000 + ts.tv_usec;
+    fprintf(f, "<!-- %03d.%06d --> ",
+            static_cast<int>((ts_usec - startTimeStamp) / 1000000),
+            static_cast<int>((ts_usec - startTimeStamp) % 1000000));
+    for (int i = 0; i < callLevel; i++)
+        fprintf(f, " ");
+    fprintf(f, "%s\n", str.c_str());
+    fflush(f);
+}
+
+// ---------------------------------------------------------------------------
+
+void logTrace(const std::string &str, const std::string &component) {
+    auto &singleton = getSingleton();
+    if (!singleton.componentsWhiteList.empty() &&
+        (component.empty() ||
+         singleton.componentsWhiteList.find(component) == std::string::npos)) {
+        return;
+    }
+    if (!singleton.componentsBlackList.empty() && !component.empty() &&
+        singleton.componentsBlackList.find(component) != std::string::npos) {
+        return;
+    }
+    std::string rawStr("<trace");
+    if (!component.empty()) {
+        rawStr += " component='" + component + '\'';
+    }
+    rawStr += '>';
+    rawStr += str;
+    rawStr += "</trace>";
+    singleton.logTraceRaw(rawStr);
+}
+
+// ---------------------------------------------------------------------------
+
+struct EnterBlock::Private {
+    std::string msg_{};
+    CPLTimeVal startTimeStamp_{};
+};
+
+// ---------------------------------------------------------------------------
+
+EnterBlock::EnterBlock(const std::string &msg) : d(new Private()) {
+    auto &singleton = getSingleton();
+    d->msg_ = msg;
+    CPLGettimeofday(&d->startTimeStamp_, nullptr);
+    singleton.logTraceRaw("<block_level_" + toString(singleton.callLevel) +
+                          ">");
+    ++singleton.callLevel;
+    singleton.logTraceRaw("<enter>" + d->msg_ + "</enter>");
+}
+
+// ---------------------------------------------------------------------------
+
+EnterBlock::~EnterBlock() {
+    auto &singleton = getSingleton();
+    CPLTimeVal endTimeStamp;
+    CPLGettimeofday(&endTimeStamp, nullptr);
+    int delayMicroSec = static_cast<int>(
+        (endTimeStamp.tv_usec - d->startTimeStamp_.tv_usec) +
+        1000000 * (endTimeStamp.tv_sec - d->startTimeStamp_.tv_sec));
+    std::string lengthStr;
+    if (delayMicroSec >= singleton.minDelayMicroSec) {
+        lengthStr = " length='" + toString(delayMicroSec / 1000) + "." +
+                    toString((delayMicroSec % 1000) / 100) + " msec'";
+    }
+    singleton.logTraceRaw("<leave" + lengthStr + ">" + d->msg_ + "</leave>");
+    --singleton.callLevel;
+    singleton.logTraceRaw("</block_level_" + toString(singleton.callLevel) +
+                          ">");
+}
+
+} // namespace tracing
+
+NS_PROJ_END
+
+//! @endcond
+
+#endif // ENABLE_TRACING


### PR DESCRIPTION
"projinfo -s EPSG:32129+5703 -t NAD83 --spatial-test intersects --summary" now returns 63 results in 300 ms, instead of 470 results, most of them using transformations irrelevant for the area of interest, in 680 ms