### PR TITLE
Build: require SQLite 3.11 (refs #1718)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ if(NOT SQLITE3_FOUND)
   message(SEND_ERROR "sqlite3 dependency not found!")
 endif()
 
+# Would build and run with older versons, but with horrible performance
+# See https://github.com/OSGeo/PROJ/issues/1718
+IF("${SQLITE3_VERSION}" VERSION_LESS "3.11")
+  message(SEND_ERROR "sqlite3 >= 3.11 required!")
+ENDIF()
+
 ################################################################################
 # threading configuration
 ################################################################################

--- a/cmake/FindSqlite3.cmake
+++ b/cmake/FindSqlite3.cmake
@@ -10,6 +10,7 @@
 # and following variables are set:
 #    SQLITE3_INCLUDE_DIR
 #    SQLITE3_LIBRARY
+#    SQLITE3_VERSION
 
 
 # find_path and find_library normally search standard locations
@@ -53,9 +54,21 @@ if(SQLITE3_INCLUDE_DIR AND SQLITE3_LIBRARY)
   set(SQLITE3_FOUND TRUE)
 endif()
 
+# Extract version information from the header file
+if(SQLITE3_INCLUDE_DIR)
+    file(STRINGS ${SQLITE3_INCLUDE_DIR}/sqlite3.h _ver_line
+         REGEX "^#define SQLITE_VERSION  *\"[0-9]+\\.[0-9]+\\.[0-9]+\""
+         LIMIT_COUNT 1)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+"
+           SQLITE3_VERSION "${_ver_line}")
+    unset(_ver_line)
+endif()
+
+
 if(SQLITE3_FOUND)
   if(NOT SQLITE3_FIND_QUIETLY)
     message(STATUS "Found Sqlite3: ${SQLITE3_LIBRARY}")
+    message(STATUS "Sqlite3 version: ${SQLITE3_VERSION}")
   endif()
 
 else()

--- a/configure.ac
+++ b/configure.ac
@@ -280,7 +280,11 @@ dnl Check for sqlite3 library and binary
 dnl ---------------------------------------------------------------------------
 
 if test "x$SQLITE3_CFLAGS$SQLITE3_LIBS" = "x" ; then
-    PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.7])
+
+    dnl Would build and run with older versons, but with horrible performance
+    dnl See https://github.com/OSGeo/PROJ/issues/1718
+
+    PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.11])
 fi
 AC_SUBST(SQLITE3_CFLAGS,$SQLITE3_CFLAGS)
 AC_SUBST(SQLITE3_LIBS,$SQLITE3_LIBS)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -119,14 +119,19 @@ Compilation and installation from source code
 The classical way of installing PROJ is via the source code distribution. The
 most recent version is available from the :ref:`download page<current_release>`.
 
-PROJ requires C and C++11 compilers. It also requires SQLite3 (headers,
-library and executable).
-
 You will need that and at least the standard *proj-datumgrid* package for a
 successful installation.
 
 The following guides show how to compile and install the software using the
 Autotools and CMake build systems.
+
+Build requirements
+--------------------------------------------------------------------------------
+
+- C99 compiler
+- C++11 compiler
+- SQLite3 >= 3.11 (headers, library and executable)
+- GNU make for autotools build or CMake >= 3.5
 
 Autotools
 --------------------------------------------------------------------------------


### PR DESCRIPTION
PROJ can build and run against older version (3.7 for example), but it has
been found that performance is horrible. With 3.11 (Ubuntu 16.04), it is
fine, so sets this as the minimum version.