### PR TITLE
Fix proj_assign_context()/pj_set_ctx() with pipelines and alternative coord operations

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -60,6 +60,14 @@ void pj_set_ctx( projPJ pj, projCtx ctx )
     if (pj==nullptr)
         return;
     pj->ctx = ctx;
+    if( pj->is_pipeline )
+    {
+        pj_pipeline_assign_context_to_steps(pj, ctx);
+    }
+    for( const auto &alt: pj->alternativeCoordinateOperations )
+    {
+        pj_set_ctx(alt.pj, ctx);
+    }
 }
 
 /************************************************************************/

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -136,7 +136,11 @@ static PJ_LPZ    pipeline_reverse_3d (PJ_XYZ xyz, PJ *P);
 static PJ_XY     pipeline_forward (PJ_LP lp, PJ *P);
 static PJ_LP     pipeline_reverse (PJ_XY xy, PJ *P);
 
-
+void pj_pipeline_assign_context_to_steps( PJ* P, PJ_CONTEXT* ctx )
+{
+    for (int i = 1; i <= static_cast<struct pj_opaque*>(P->opaque)->steps; i++)
+        proj_assign_context(static_cast<struct pj_opaque*>(P->opaque)->pipeline[i], ctx);
+}
 
 
 static PJ_COORD pipeline_forward_4d (PJ_COORD point, PJ *P) {

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -922,6 +922,8 @@ std::string pj_double_quote_string_param_if_needed(const std::string& str);
 PJ *pj_create_internal (PJ_CONTEXT *ctx, const char *definition);
 PJ *pj_create_argv_internal (PJ_CONTEXT *ctx, int argc, char **argv);
 
+void pj_pipeline_assign_context_to_steps( PJ* P, PJ_CONTEXT* ctx );
+
 /* classic public API */
 #include "proj_api.h"
 


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/1989

pj_set_ctx() only changes the context to the main object. It should also
recurse down to the steps of the pipeline and the alternative coordinate
operations hold in alternativeCoordinateOperations

In the GDAL use case with multithreaded reprojection, and objects being transferred
between thread, this would cause a failed coordinate transformation to affect
an unrelated transformation of another thread...