### PR TITLE
import/export PROJJSON: support a interpolation_crs key to geoid_model

### DIFF
--- a/data/projjson.schema.json
+++ b/data/projjson.schema.json
@@ -936,6 +936,7 @@
           "type": "object",
           "properties": {
             "name": { "type": "string" },
+            "interpolation_crs": { "$ref": "#/definitions/crs" },
             "id": { "$ref": "#/definitions/id" }
           },
           "required" : [ "name" ],

--- a/schemas/v0.2/projjson.schema.json
+++ b/schemas/v0.2/projjson.schema.json
@@ -936,6 +936,7 @@
           "type": "object",
           "properties": {
             "name": { "type": "string" },
+            "interpolation_crs": { "$ref": "#/definitions/crs" },
             "id": { "$ref": "#/definitions/id" }
           },
           "required" : [ "name" ],

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -3029,7 +3029,8 @@ PJ *proj_create_vertical_crs_ex(
                     ? std::dynamic_pointer_cast<CRS>(geoid_geog_crs->iso_obj)
                     : nullptr;
             const auto model(Transformation::create(
-                propsModel, vertCRSWithoutGeoid, GeographicCRS::EPSG_4979,
+                propsModel, vertCRSWithoutGeoid,
+                GeographicCRS::EPSG_4979, // arbitrarily chosen. Ignored
                 interpCRS,
                 OperationMethod::create(PropertyMap(),
                                         std::vector<OperationParameterNNPtr>()),

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -2584,6 +2584,15 @@ void VerticalCRS::_exportToJSON(
         auto objectContext2(formatter->MakeObjectContext(nullptr, false));
         writer.AddObjKey("name");
         writer.Add(model->nameStr());
+
+        if (model->identifiers().empty()) {
+            const auto &interpCRS = model->interpolationCRS();
+            if (interpCRS) {
+                writer.AddObjKey("interpolation_crs");
+                interpCRS->_exportToJSON(formatter);
+            }
+        }
+
         model->formatID(formatter);
     }
 

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -5129,8 +5129,16 @@ VerticalCRSNNPtr JSONParser::buildVerticalCRS(const json &j) {
         auto propsModel = buildProperties(geoidModelJ);
         const auto dummyCRS = VerticalCRS::create(
             PropertyMap(), datum, datumEnsemble, NN_NO_CHECK(verticalCS));
+        CRSPtr interpolationCRS;
+        if (geoidModelJ.contains("interpolation_crs")) {
+            auto interpolationCRSJ =
+                getObject(geoidModelJ, "interpolation_crs");
+            interpolationCRS = buildCRS(interpolationCRSJ).as_nullable();
+        }
         const auto model(Transformation::create(
-            propsModel, dummyCRS, dummyCRS, nullptr,
+            propsModel, dummyCRS,
+            GeographicCRS::EPSG_4979, // arbitrarily chosen. Ignored,
+            interpolationCRS,
             OperationMethod::create(PropertyMap(),
                                     std::vector<OperationParameterNNPtr>()),
             {}, {}));

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -4320,6 +4320,27 @@ TEST_F(CApi, proj_create_vertical_crs_ex_with_geog_crs) {
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
               "+step +proj=axisswap +order=2,1");
+
+    // Check that we get the same results after an export of compoundCRS to
+    // PROJJSON and a re-import from it.
+    auto projjson = proj_as_projjson(m_ctxt, compound, nullptr);
+    ASSERT_NE(projjson, nullptr);
+    auto compound_from_projjson = proj_create(m_ctxt, projjson);
+    ObjectKeeper keeper_compound_from_projjson(compound_from_projjson);
+    ASSERT_NE(compound_from_projjson, nullptr);
+
+    auto P2 = proj_create_crs_to_crs_from_pj(m_ctxt, compound_from_projjson,
+                                             geog_crs, nullptr, nullptr);
+    ObjectKeeper keeper_P2(P2);
+    ASSERT_NE(P2, nullptr);
+
+    auto name_bis = proj_get_name(P2);
+    ASSERT_TRUE(name_bis != nullptr);
+    EXPECT_EQ(std::string(name_bis), std::string(name));
+
+    auto proj_5_bis = proj_as_proj_string(m_ctxt, P2, PJ_PROJ_5, nullptr);
+    ASSERT_NE(proj_5_bis, nullptr);
+    EXPECT_EQ(std::string(proj_5_bis), std::string(proj_5));
 }
 
 } // namespace

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -10951,6 +10951,82 @@ TEST(json_import, vertical_crs_with_geoid_model) {
 
 // ---------------------------------------------------------------------------
 
+TEST(json_import, vertical_crs_with_geoid_model_and_interpolation_crs) {
+    auto json = "{\n"
+                "  \"$schema\": \"foo\",\n"
+                "  \"type\": \"VerticalCRS\",\n"
+                "  \"name\": \"foo\",\n"
+                "  \"datum\": {\n"
+                "    \"type\": \"VerticalReferenceFrame\",\n"
+                "    \"name\": \"bar\"\n"
+                "  },\n"
+                "  \"coordinate_system\": {\n"
+                "    \"subtype\": \"vertical\",\n"
+                "    \"axis\": [\n"
+                "      {\n"
+                "        \"name\": \"Gravity-related height\",\n"
+                "        \"abbreviation\": \"H\",\n"
+                "        \"direction\": \"up\",\n"
+                "        \"unit\": \"metre\"\n"
+                "      }\n"
+                "    ]\n"
+                "  },\n"
+                "  \"geoid_model\": {\n"
+                "    \"name\": \"baz\",\n"
+                "    \"interpolation_crs\": {\n"
+                "      \"type\": \"GeographicCRS\",\n"
+                "      \"name\": \"NAD83(2011)\",\n"
+                "      \"datum\": {\n"
+                "        \"type\": \"GeodeticReferenceFrame\",\n"
+                "        \"name\": \"NAD83 (National Spatial Reference System "
+                "2011)\",\n"
+                "        \"ellipsoid\": {\n"
+                "          \"name\": \"GRS 1980\",\n"
+                "          \"semi_major_axis\": 6378137,\n"
+                "          \"inverse_flattening\": 298.257222101\n"
+                "        }\n"
+                "      },\n"
+                "      \"coordinate_system\": {\n"
+                "        \"subtype\": \"ellipsoidal\",\n"
+                "        \"axis\": [\n"
+                "          {\n"
+                "            \"name\": \"Geodetic latitude\",\n"
+                "            \"abbreviation\": \"Lat\",\n"
+                "            \"direction\": \"north\",\n"
+                "            \"unit\": \"degree\"\n"
+                "          },\n"
+                "          {\n"
+                "            \"name\": \"Geodetic longitude\",\n"
+                "            \"abbreviation\": \"Lon\",\n"
+                "            \"direction\": \"east\",\n"
+                "            \"unit\": \"degree\"\n"
+                "          },\n"
+                "          {\n"
+                "            \"name\": \"Ellipsoidal height\",\n"
+                "            \"abbreviation\": \"h\",\n"
+                "            \"direction\": \"up\",\n"
+                "            \"unit\": \"metre\"\n"
+                "          }\n"
+                "        ]\n"
+                "      },\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 6319\n"
+                "      }\n"
+                "    }\n"
+                "  }\n"
+                "}";
+
+    // No database
+    auto obj = createFromUserInput(json, nullptr);
+    auto vcrs = nn_dynamic_pointer_cast<VerticalCRS>(obj);
+    ASSERT_TRUE(vcrs != nullptr);
+    EXPECT_EQ(vcrs->exportToJSON(&(JSONFormatter::create()->setSchema("foo"))),
+              json);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(json_import, parametric_crs) {
     auto json = "{\n"
                 "  \"$schema\": \"foo\",\n"


### PR DESCRIPTION
for faithful serialization of the geoid_geog_crs parameter of proj_create_vertical_crs_ex()