### PR TITLE
Doc: configure the 'Edit on GitHub' button

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -243,3 +243,6 @@ If the previous active version was, let's say, 6.1 and the new version is, let's
 then checkout 6.1 branch, and in travis/after_success.sh, remove the code
 that causes commits to 6.1 to cause a website refresh, that is remove the
 code under `if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "6.1"; then`.
+
+Also edit docs/source/conf.py to change the active branch for documentation
+in the `github_version` variable.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,6 +171,12 @@ html_logo = '../images/logo.png'
 html_static_path = ['_static']
 
 html_context = {
+    'display_github': True,
+    'theme_vcs_pageview_mode': 'edit',
+    'github_user': 'OSGeo',
+    'github_repo': 'PROJ',
+    # TODO: edit when switching active branch
+    'github_version': '/6.2/docs/source/',
     'css_files': [
         '_static/theme_overrides.css',  # override wide tables in RTD theme
     ],


### PR DESCRIPTION
Similarly to https://gdal.org/

I've make the URL to point to the 6.2 branch as this is the version we display currently. Pull requests will thus be against that branch, so we'll probably need a "backport master" label to forward to master.