### PR TITLE
Optimize pipelines involving horizontal shift grid, vertical shift grid, inverse horizontal shift grid

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -837,6 +837,8 @@ pj_init_ctx_with_allow_init_epsg(projCtx ctx, int argc, char **argv, int allow_i
     else
         PIN->from_greenwich = 0.0;
 
+    PIN->only_on_forward = pj_param(ctx, start, "bonly_on_forward").i != 0;
+
     /* Private object for the geodesic functions */
     PIN->geod = static_cast<struct geod_geodesic*>(pj_calloc (1, sizeof (struct geod_geodesic)));
     if (nullptr==PIN->geod)

--- a/src/inv.cpp
+++ b/src/inv.cpp
@@ -145,6 +145,9 @@ PJ_LP pj_inv(PJ_XY xy, PJ *P) {
     PJ_COORD coo = {{0,0,0,0}};
     coo.xy = xy;
 
+    if( P->only_on_forward )
+        return coo.lp;
+
     last_errno = proj_errno_reset(P);
 
     if (!P->skip_inv_prepare)
@@ -179,6 +182,9 @@ PJ_LPZ pj_inv3d (PJ_XYZ xyz, PJ *P) {
     PJ_COORD coo = {{0,0,0,0}};
     coo.xyz = xyz;
 
+    if( P->only_on_forward )
+        return coo.lpz;
+
     last_errno = proj_errno_reset(P);
 
     if (!P->skip_inv_prepare)
@@ -209,6 +215,9 @@ PJ_LPZ pj_inv3d (PJ_XYZ xyz, PJ *P) {
 
 
 PJ_COORD pj_inv4d (PJ_COORD coo, PJ *P) {
+    if( P->only_on_forward )
+        return coo;
+
     int last_errno = proj_errno_reset(P);
 
     if (!P->skip_inv_prepare)

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -6278,6 +6278,10 @@ struct Step {
             return key == otherKey && value == otherVal;
         }
 
+        bool operator==(const KeyValue &other) const noexcept {
+            return key == other.key && value == other.value;
+        }
+
         bool operator!=(const KeyValue &other) const noexcept {
             return key != other.key || value != other.value;
         }
@@ -6787,6 +6791,46 @@ const std::string &PROJStringFormatter::toString() const {
                         changeDone = true;
                         break;
                     }
+                }
+            }
+
+            // +step +proj=hgridshift +grids=grid_A
+            // +step +proj=vgridshift [...] <== curStep
+            // +step +inv +proj=hgridshift +grids=grid_A
+            // ==>
+            // +step +proj=push +v_1 +v_2
+            // +step +proj=hgridshift +grids=grid_A +only_on_forward
+            // +step +proj=vgridshift [...]
+            // +step +inv +proj=hgridshift +grids=grid_A +only_on_forward
+            // +step +proj=pop +v_1 +v_2
+            if (i + 1 < d->steps_.size() && prevStep.name == "hgridshift" &&
+                prevStepParamCount == 1 && curStep.name == "vgridshift") {
+                auto iterNext = iterCur;
+                ++iterNext;
+                auto &nextStep = *iterNext;
+                if (nextStep.name == "hgridshift" &&
+                    nextStep.inverted != prevStep.inverted &&
+                    nextStep.paramValues.size() == 1 &&
+                    prevStep.paramValues[0] == nextStep.paramValues[0]) {
+                    Step pushStep;
+                    pushStep.name = "push";
+                    pushStep.paramValues.emplace_back("v_1");
+                    pushStep.paramValues.emplace_back("v_2");
+                    d->steps_.insert(iterPrev, pushStep);
+
+                    prevStep.paramValues.emplace_back("only_on_forward");
+
+                    nextStep.paramValues.emplace_back("only_on_forward");
+
+                    Step popStep;
+                    popStep.name = "pop";
+                    popStep.paramValues.emplace_back("v_1");
+                    popStep.paramValues.emplace_back("v_2");
+                    ++iterNext;
+                    d->steps_.insert(iterNext, popStep);
+
+                    changeDone = true;
+                    break;
                 }
             }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -388,6 +388,10 @@ PJ *OPERATION(pipeline,0) {
     P->destructor  =  destructor;
     P->is_pipeline =  1;
 
+    // as pj_init_ctx_with_allow_init_epsg() will have interpreted the
+    // +only_on_forward of step for the pipeline itself...
+    P->only_on_forward = false;
+
     /* Currently, the pipeline driver is a raw bit mover, enabling other operations */
     /* to collaborate efficiently. All prep/fin stuff is done at the step levels. */
     P->skip_fwd_prepare  = 1;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -328,6 +328,7 @@ struct PJconsts {
     struct geod_geodesic *geod = nullptr;    /* For geodesic computations */
     void *opaque = nullptr;                  /* Projection specific parameters, Defined in PJ_*.c */
     int inverted = 0;                        /* Tell high level API functions to swap inv/fwd */
+    bool only_on_forward = false;            /* Tell high level API functions to only apply in forward */
 
 
     /*************************************************************************************

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -386,6 +386,31 @@ operation   +proj=pop +v_3
 accept      12 56 0 0
 expect      12 56 0 0
 
+-------------------------------------------------------------------------------
+Test Pipeline +only_on_forward
+-------------------------------------------------------------------------------
+
+operation   +proj=pipeline
+                +step +proj=affine +xoff=1 +yoff=1 +only_on_forward
+
+accept      2 49 0 0
+expect      3 50 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      2 49 0 0
+
+
+operation   +proj=pipeline
+                +step +inv +proj=affine +xoff=1 +yoff=1 +only_on_forward
+
+accept      2 49 0 0
+expect      2 49 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      3 50 0 0
+
 
 -------------------------------------------------------------------------------
 Test bugfix of https://github.com/OSGeo/proj.4/issues/1002

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -6832,6 +6832,95 @@ TEST(io, projstringformatter_axisswap_unitconvert_axisswap) {
 
 // ---------------------------------------------------------------------------
 
+TEST(io, projstringformatter_optim_hgridshift_vgridshift_hgridshift_inv) {
+    // Nominal case
+    {
+        auto fmt = PROJStringFormatter::create();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+
+        fmt->addStep("vgridshift");
+        fmt->addParam("grids", "bar");
+
+        fmt->startInversion();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+        fmt->stopInversion();
+
+        EXPECT_EQ(fmt->toString(),
+                  "+proj=pipeline "
+                  "+step +proj=push +v_1 +v_2 "
+                  "+step +proj=hgridshift +grids=foo +only_on_forward "
+                  "+step +proj=vgridshift +grids=bar "
+                  "+step +inv +proj=hgridshift +grids=foo +only_on_forward "
+                  "+step +proj=pop +v_1 +v_2");
+    }
+
+    // Variant with first hgridshift inverted, and second forward
+    {
+        auto fmt = PROJStringFormatter::create();
+
+        fmt->startInversion();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+        fmt->stopInversion();
+
+        fmt->addStep("vgridshift");
+        fmt->addParam("grids", "bar");
+
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+
+        EXPECT_EQ(fmt->toString(),
+                  "+proj=pipeline "
+                  "+step +proj=push +v_1 +v_2 "
+                  "+step +inv +proj=hgridshift +grids=foo +only_on_forward "
+                  "+step +proj=vgridshift +grids=bar "
+                  "+step +proj=hgridshift +grids=foo +only_on_forward "
+                  "+step +proj=pop +v_1 +v_2");
+    }
+
+    // Do not apply ! not same grid name
+    {
+        auto fmt = PROJStringFormatter::create();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+
+        fmt->addStep("vgridshift");
+        fmt->addParam("grids", "bar");
+
+        fmt->startInversion();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo2");
+        fmt->stopInversion();
+
+        EXPECT_EQ(fmt->toString(), "+proj=pipeline "
+                                   "+step +proj=hgridshift +grids=foo "
+                                   "+step +proj=vgridshift +grids=bar "
+                                   "+step +inv +proj=hgridshift +grids=foo2");
+    }
+
+    // Do not apply ! missing inversion
+    {
+        auto fmt = PROJStringFormatter::create();
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+
+        fmt->addStep("vgridshift");
+        fmt->addParam("grids", "bar");
+
+        fmt->addStep("hgridshift");
+        fmt->addParam("grids", "foo");
+
+        EXPECT_EQ(fmt->toString(), "+proj=pipeline "
+                                   "+step +proj=hgridshift +grids=foo "
+                                   "+step +proj=vgridshift +grids=bar "
+                                   "+step +proj=hgridshift +grids=foo");
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(io, projparse_longlat) {
 
     auto expected = "GEODCRS[\"unknown\",\n"


### PR DESCRIPTION
Add a +only_on_forward flag to mark that a step must only be applied in forward path

This is used to optimize constructs like

+step +proj=hgridshift +grids=foo
+step +proj=vgridshift +grids=bar
+step +inv +proj=hgridshift +grids=foo

Such steps are used for CRS to CRS transformations where applying the vertical grid
requires to do a transformation to an interpolating CRS. One can notice that
in the last step will just restore the horizontal coordinates before the first step, so
doing an inverse hgridshift is overkill.

So this is optimized as:

+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo +only_on_forward
+step +proj=vgridshift +grids=bar
+step +inv +proj=hgridshift +grids=foo +only_on_forward
+step +proj=pop +v_1 +v_2

In the forward path, this will be equivalent to:
+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo
+step +proj=vgridshift +grids=bar
+step +proj=pop +v_1 +v_2

And similarly in the reverse path, this will be quivalent to:
+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo
+step +inv +proj=vgridshift +grids=bar
+step +proj=pop +v_1 +v_2

Following +inv +only_on_forward in the forward path means that
the step will not be executed
Follwing +inv +only_on_forward in the reverse path means that the
step will be execute (as inverse operation)
