### PR TITLE
Optimize pipelines involving horizontal shift grid, vertical shift grid, inverse horizontal shift grid (take 2)

### DIFF
--- a/docs/source/operations/pipeline.rst
+++ b/docs/source/operations/pipeline.rst
@@ -128,3 +128,34 @@ Optional
 .. option:: +inv
 
     Invert a step in a pipeline.
+
+.. option:: +omit_fwd
+
+    .. versionadded:: 6.3.0
+
+    Skip a step of the pipeline when it is followed in the forward path.
+
+    The following example shows a combined use of :ref:`push <push>` and :ref:`pop <pop>` operators,
+    with ``omit_fwd`` and ``omit_inv`` options, to implement a vertical adjustment that must
+    be done in a interpolation CRS that is different from the horizontal CRS
+    used in input and output. +omit_fwd in the forward path avoid a useless
+    inverse horizontal transformation and relies on the pop operator to restore
+    initial horizontal coordinates. +omit_inv serves the similar purpose when
+    the pipeline is executed in the reverse direction
+
+    ::
+
+        +proj=pipeline
+        +step +proj=unitconvert +xy_in=deg +xy_out=rad
+        +step +proj=push +v_1 +v_2
+        +step +proj=hgridshift +grids=nvhpgn.gsb +omit_inv
+        +step +proj=vgridshift +grids=g1999u05.gtx +multiplier=1
+        +step +inv +proj=hgridshift +grids=nvhpgn.gsb +omit_fwd
+        +step +proj=pop +v_1 +v_2
+        +step +proj=unitconvert +xy_in=rad +xy_out=deg
+
+.. option:: +omit_inv
+
+    .. versionadded:: 6.3.0
+
+    Skip a step of the pipeline when it is followed in the reverse path.

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -6284,6 +6284,15 @@ struct Step {
     };
 
     std::vector<KeyValue> paramValues{};
+
+    bool hasKey(const char *keyName) const {
+        for (const auto &kv : paramValues) {
+            if (kv.key == keyName) {
+                return true;
+            }
+        }
+        return false;
+    }
 };
 
 Step::KeyValue::KeyValue(const char *keyIn, const std::string &valueIn)
@@ -6813,7 +6822,9 @@ const std::string &PROJStringFormatter::toString() const {
 
     if (d->steps_.size() > 1 ||
         (d->steps_.size() == 1 &&
-         (d->steps_.front().inverted || !d->globalParamValues_.empty()))) {
+         (d->steps_.front().inverted || d->steps_.front().hasKey("omit_inv") ||
+          d->steps_.front().hasKey("omit_fwd") ||
+          !d->globalParamValues_.empty()))) {
         d->appendToResult("+proj=pipeline");
 
         for (const auto &paramValue : d->globalParamValues_) {

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -386,6 +386,55 @@ operation   +proj=pop +v_3
 accept      12 56 0 0
 expect      12 56 0 0
 
+-------------------------------------------------------------------------------
+Test Pipeline +omit_inv
+-------------------------------------------------------------------------------
+
+operation   +proj=pipeline
+                +step +proj=affine +xoff=1 +yoff=1 +omit_inv
+
+accept      2 49 0 0
+expect      3 50 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      2 49 0 0
+
+
+operation   +proj=pipeline
+                +step +inv +proj=affine +xoff=1 +yoff=1 +omit_inv
+
+accept      2 49 0 0
+expect      1 48 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      2 49 0 0
+
+-------------------------------------------------------------------------------
+Test Pipeline +omit_fwd
+-------------------------------------------------------------------------------
+
+operation   +proj=pipeline
+                +step +proj=affine +xoff=1 +yoff=1 +omit_fwd
+
+accept      2 49 0 0
+expect      2 49 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      1 48 0 0
+
+
+operation   +proj=pipeline
+                +step +inv +proj=affine +xoff=1 +yoff=1 +omit_fwd
+
+accept      2 49 0 0
+expect      2 49 0 0
+
+direction inverse
+accept      2 49 0 0
+expect      3 50 0 0
 
 -------------------------------------------------------------------------------
 Test bugfix of https://github.com/OSGeo/proj.4/issues/1002


### PR DESCRIPTION
Cancels and replaces https://github.com/OSGeo/PROJ/pull/1744

3 commits:
- first commit is mostly a code cleanup/improvement in the pipeline implementation so as to be able to implement easily the next commit. Should have no user visible effect
- second commit adds +omit_fwd and +omit_inv keywords (resurecting an idea of the initial implementation of https://github.com/OSGeo/PROJ/pull/453/files)
- third commit uses that capability to optimize  constructs like
      +step +proj=hgridshift +grids=foo
      +step +proj=vgridshift +grids=bar
     +step +inv +proj=hgridshift +grids=foo

Such steps are used for CRS to CRS transformations where applying the vertical grid
requires to do a transformation to an interpolating CRS. One can notice that
in the last step will just restore the horizontal coordinates before the first step, so
doing an inverse hgridshift is overkill.

So this is optimized as:

+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo +omit_inv
+step +proj=vgridshift +grids=bar
+step +inv +proj=hgridshift +grids=foo +omit_fwd
+step +proj=pop +v_1 +v_2

In the forward path, this will be equivalent to:
+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo
+step +proj=vgridshift +grids=bar
+step +proj=pop +v_1 +v_2

And similarly in the reverse path, this will be quivalent to:
+step +proj=push +v_1 +v_2
+step +proj=hgridshift +grids=foo
+step +inv +proj=vgridshift +grids=bar
+step +proj=pop +v_1 +v_2