### PR TITLE
EPSG codes for YEAR and SECOND are interchanged

### DIFF
--- a/src/iso19111/static.cpp
+++ b/src/iso19111/static.cpp
@@ -343,12 +343,12 @@ const UnitOfMeasure UnitOfMeasure::MICRORADIAN("microradian", 1e-6,
 /** \brief Second, unit of measure of type TIME (SI unit). */
 const UnitOfMeasure UnitOfMeasure::SECOND("second", 1.0,
                                           UnitOfMeasure::Type::TIME,
-                                          Identifier::EPSG, "1029");
+                                          Identifier::EPSG, "1040");
 
 /** \brief Year, unit of measure of type TIME */
 const UnitOfMeasure UnitOfMeasure::YEAR("year", 31556925.445,
                                         UnitOfMeasure::Type::TIME,
-                                        Identifier::EPSG, "1040");
+                                        Identifier::EPSG, "1029");
 
 /** \brief Metre per year, unit of measure of type LINEAR. */
 const UnitOfMeasure UnitOfMeasure::METRE_PER_YEAR("metres per year",


### PR DESCRIPTION
EPSG registry gives EPSG::1040 for second and EPSG::1029 for year.