### PR TITLE
Database: register the BWTA2017.gsb grid (DHDN->ETRS89 for Baden-Wurtemberg)

### DIFF
--- a/data/sql/commit.sql
+++ b/data/sql/commit.sql
@@ -30,6 +30,12 @@ FOR EACH ROW BEGIN
     SELECT RAISE(ABORT, 'corrupt definition of authority_list')
         WHERE (SELECT 1 FROM authority_list LIMIT 1) = 0;
 
+    -- test to check that our custom grid transformation overrides are really needed
+    SELECT RAISE(ABORT, 'PROJ grid_transformation defined whereas EPSG has one')
+        WHERE EXISTS (SELECT 1 FROM grid_transformation g1, grid_transformation g2 WHERE
+            lower(g1.grid_name) = lower(g2.grid_name) AND
+            g1.auth_name = 'PROJ' AND g2.auth_name = 'EPSG');
+
     -- check geoid_model table
     SELECT RAISE(ABORT, 'missing GEOID99 in geoid_model')
         WHERE NOT EXISTS(SELECT 1 FROM geoid_model WHERE name = 'GEOID99');

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -125,6 +125,21 @@ INSERT INTO grid_alternatives(original_grid_name,
                               inverse_direction,
                               package_name,
                               url, direct_download, open_license, directory)
+                      VALUES ('BWTA2017.gsb',
+                              'BWTA2017.gsb', -- no change. Just document the package
+                              'NTv2',
+                              'hgridshift',
+                              0,
+                              'proj-datumgrid-europe',
+                              NULL, NULL, NULL, NULL);
+
+INSERT INTO grid_alternatives(original_grid_name,
+                              proj_grid_name,
+                              proj_grid_format,
+                              proj_method,
+                              inverse_direction,
+                              package_name,
+                              url, direct_download, open_license, directory)
                       VALUES ('nzgd2kgrid0005.gsb',
                               'nzgd2kgrid0005.gsb', -- no change. Just document the package
                               'NTv2',

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -49,3 +49,9 @@ INSERT INTO "grid_transformation" VALUES(
     NULL,
     'EPSG','8666','Geoid (height correction) model file','SWEN17_RH2000.gtx',
     NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
+
+----- Hopefully temporary entry for BWTA2017.gsb grid -----
+
+INSERT INTO "area" VALUES('PROJ','BWTA2017','Germany - Baden-Wurtemberg','Germany - Baden-Wurtemberg',47.5,49.83,7.49,10.51,0);
+-- Advertize a 0.8 accuracy slightly better than the 0.9 of BETA2007 for sort purposes
+INSERT INTO "grid_transformation" VALUES('PROJ','BWTA2017','DHDN to ETRS89 (BWTA2017)','DHDN to ETRS89 for Baden-Wurtemberg for ALKIS 2017. Using official BWTA2017 grid but this transformation entry has been created temporarily by PROJ. Accuracy indication not to be considered as authoritative','For applications requiring an accuracy of better than 1 metre.','EPSG','9615','NTv2','EPSG','4314','EPSG','4258','PROJ','BWTA2017',0.89,'EPSG','8656','Latitude and longitude difference file','BWTA2017.gsb',NULL,NULL,NULL,NULL,NULL,NULL,'-',0);

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -11580,11 +11580,13 @@ CoordinateOperationFactory::Private::findOpsInRegistryDirect(
 
             const auto authorities(getCandidateAuthorities(
                 authFactory, srcAuthName, targetAuthName));
+            std::vector<CoordinateOperationNNPtr> res;
             for (const auto &authority : authorities) {
+                const auto authName =
+                    authority == "any" ? std::string() : authority;
                 const auto tmpAuthFactory = io::AuthorityFactory::create(
-                    authFactory->databaseContext(),
-                    authority == "any" ? std::string() : authority);
-                auto res =
+                    authFactory->databaseContext(), authName);
+                auto resTmp =
                     tmpAuthFactory->createFromCoordinateReferenceSystemCodes(
                         srcAuthName, srcCode, targetAuthName, targetCode,
                         context.context->getUsePROJAlternativeGridNames(),
@@ -11593,6 +11595,10 @@ CoordinateOperationFactory::Private::findOpsInRegistryDirect(
                                 DISCARD_OPERATION_IF_MISSING_GRID,
                         context.context->getDiscardSuperseded(), true, false,
                         context.extent1, context.extent2);
+                res.insert(res.end(), resTmp.begin(), resTmp.end());
+                if (authName == "PROJ") {
+                    continue;
+                }
                 if (!res.empty()) {
                     resNonEmptyBeforeFiltering = true;
                     auto resFiltered =

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -143,6 +143,10 @@ echo 'Testing -s "AGD66" -t "WGS 84 (G1762)" --spatial-test intersects --summary
 $EXE -s "AGD66" -t "WGS 84 (G1762)" --spatial-test intersects --summary >>${OUT} 2>&1
 echo "" >>${OUT}
 
+echo 'Testing -s EPSG:31467 -t ETRS89 --spatial-test intersects --grid-check none --bbox 8,48,9,49 --summary. Should include both DHDN to ETRS89 (8) and DHDN to ETRS89 (BWTA2017)' >> ${OUT}
+$EXE -s EPSG:31467 -t ETRS89 --spatial-test intersects --grid-check none --bbox 8,48,9,49 --summary >>${OUT} 2>&1
+echo "" >>${OUT}
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testprojinfo_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testprojinfo_out.dist

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1071,3 +1071,10 @@ unknown id, AGD66 to GDA2020 (1) + Conversion from GDA2020 (geog2D) to GDA2020 (
 unknown id, AGD66 to WGS 84 (17) + WGS 84 to WGS 84 (G1762), 3 m, Australia - onshore
 unknown id, Ballpark geographic offset from AGD66 to WGS 84 (G1762), unknown accuracy, World, has ballpark transformation
 
+Testing -s EPSG:31467 -t ETRS89 --spatial-test intersects --grid-check none --bbox 8,48,9,49 --summary. Should include both DHDN to ETRS89 (8) and DHDN to ETRS89 (BWTA2017)
+Candidate operations found: 4
+unknown id, Inverse of 3-degree Gauss-Kruger zone 3 + DHDN to ETRS89 (BWTA2017), 0.89 m, Germany - Baden-Wurtemberg
+unknown id, Inverse of 3-degree Gauss-Kruger zone 3 + DHDN to ETRS89 (8), 0.9 m, Germany - onshore
+unknown id, Inverse of 3-degree Gauss-Kruger zone 3 + DHDN to ETRS89 (3), 1 m, Germany - West Germany S
+unknown id, Inverse of 3-degree Gauss-Kruger zone 3 + DHDN to ETRS89 (2), 3 m, Germany - West Germany all states
+


### PR DESCRIPTION
Relates to https://github.com/OSGeo/proj-datumgrid/pull/65 ,
https://github.com/OSGeo/proj-datumgrid/issues/22

As EPSG has no entry for it, we create a grid_transformation, as well as a
dedicated area of use based on the extent of the grid, under the PROJ authority.
With the hope to be able to remove it once EPSG has an entry...