### PR TITLE
Build: Only export symbols if building DLL

### DIFF
--- a/src/geodesic.h
+++ b/src/geodesic.h
@@ -158,7 +158,7 @@
                       GEODESIC_VERSION_PATCH)
 
 #if !defined(GEOD_DLL)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(PROJ_MSVC_DLL_EXPORT)
 #define GEOD_DLL __declspec(dllexport)
 #elif defined(__GNUC__)
 #define GEOD_DLL __attribute__ ((visibility("default")))

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -443,7 +443,7 @@ endif()
 include_directories(${SQLITE3_INCLUDE_DIR})
 target_link_libraries(${PROJ_CORE_TARGET} ${SQLITE3_LIBRARY})
 
-if(MSVC)
+if(MSVC AND BUILD_LIBPROJ_SHARED)
   target_compile_definitions(${PROJ_CORE_TARGET}
     PRIVATE PROJ_MSVC_DLL_EXPORT=1)
 endif()


### PR DESCRIPTION
If you build Proj as a static library (e.g., using vcpkg), then subsequently build a DLL linking to the Proj libraries, all the Proj symbols get exported in your DLL.