### PR TITLE
Add .gitattributes to normalize line endings of Unix scripts to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+#
+# Configure line ending normalisation for this repository.
+#
+* text=auto
+*.ac text eol=lf
+*.am text eol=lf
+*.m4 text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
This should fix the shell scripts in case of `git clone` runs under Windows while build runs under Unix environment.

Follows https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings