### PR TITLE
grid_alernatives.sql: point to specific revisions of the proj-datumgrid-XXXX packages

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -10,32 +10,32 @@
 
 INSERT INTO grid_packages VALUES ('proj-datumgrid',
                                   'Package with grids of general interest',
-                                  'https://download.osgeo.org/proj/proj-datumgrid-latest.zip',
+                                  'https://download.osgeo.org/proj/proj-datumgrid-1.8.zip',
                                   1,
                                   1);
 
 INSERT INTO grid_packages VALUES ('proj-datumgrid-north-america',
                                   'Package with grids of interest for North-America',
-                                  'https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.zip',
+                                  'https://download.osgeo.org/proj/proj-datumgrid-north-america-1.3.zip',
                                   1,
                                   1);
 
 INSERT INTO grid_packages VALUES ('proj-datumgrid-europe',
                                   'Package with grids of interest for Europe',
-                                  'https://download.osgeo.org/proj/proj-datumgrid-europe-latest.zip',
+                                  'https://download.osgeo.org/proj/proj-datumgrid-europe-1.5.zip',
                                   1,
                                   1);
 
 INSERT INTO grid_packages VALUES ('proj-datumgrid-oceania',
                                   'Package with grids of interest for Oceania',
-                                  'https://download.osgeo.org/proj/proj-datumgrid-oceania-latest.zip',
+                                  'https://download.osgeo.org/proj/proj-datumgrid-oceania-1.1.zip',
                                   1,
                                   1);
 
  -- not released yet at the time of writing
 INSERT INTO grid_packages VALUES ('proj-datumgrid-world',
                                   'Package with grids of global extent (too large to be included in proj-datumgrid)',
-                                  'https://download.osgeo.org/proj/proj-datumgrid-world-latest.zip',
+                                  'https://download.osgeo.org/proj/proj-datumgrid-world-1.0.zip',
                                   1,
                                   1);
 


### PR DESCRIPTION
Due to potential future shift to GTiff format, we don't want users of PROJ 6.3
being pointed to grids they won't be able to use.
So point to
- proj-datumgrid-1.8: already existing, unlikely to change before 6.3
- proj-datumgrid-north-america-1.3: to be released
- proj-datumgrid-europe-1.5: to be released
- proj-datumgrid-oceania-1.1: to be released
- proj-datumgrid-world-1.0: already existing, unlikely to change before 6.3