### PR TITLE
support EPSG:102100 (fixes #1730)

### DIFF
--- a/data/other.extra
+++ b/data/other.extra
@@ -51,3 +51,5 @@
 #  Funny epsgish code for google mercator - you should really use EPSG:3857
 #
 <900913> +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs <>
+# ESRI code sometimes applied to EPSG, again use EPSG:3857
+<102100> +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs <>

--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -6,6 +6,8 @@ INSERT INTO "other_transformation" VALUES('PROJ','CRS84_TO_EPSG_4326','OGC:CRS84
 
 -- alias of EPSG:3857
 INSERT INTO "projected_crs" VALUES('EPSG','900913','Google Maps Global Mercator',NULL,NULL,'EPSG','4499','EPSG','4326','EPSG','3856','EPSG','3544',NULL,1);
+-- ESRI alias of EPSG:3857
+INSERT INTO "projected_crs" VALUES('EPSG','102100','ESRI Global Mercator',NULL,NULL,'EPSG','4499','EPSG','4326','EPSG','3856','EPSG','3544',NULL,1);
 
 -- ('EPSG','7001','ETRS89 to NAP height (1)') lacks an interpolationCRS with Amersfoort / EPSG:4289
 -- See https://salsa.debian.org/debian-gis-team/proj-rdnap/blob/debian/2008-8/Use%20of%20RDTRANS2008%20and%20NAPTRANS2008.pdf


### PR DESCRIPTION
Untested by me other than it appears to build :/

The motivation here is that I continue to see (right or wrong) lots of in-the-wild usage of `EPSG:102100` against my WMS (mapserver).  Ditto for `EPSG:900913`, which is already aliased like this in PROJ.