### PR TITLE
Make EPSG:102100 resolve to ESRI:102100 (fixes #1730)

### DIFF
--- a/data/sql/commit.sql
+++ b/data/sql/commit.sql
@@ -36,6 +36,9 @@ FOR EACH ROW BEGIN
             lower(g1.grid_name) = lower(g2.grid_name) AND
             g1.auth_name = 'PROJ' AND g2.auth_name = 'EPSG');
 
+    SELECT RAISE(ABORT, 'Arg! there is now a EPSG:102100 object. Hack in createFromUserInput() will no longer work')
+        WHERE EXISTS(SELECT 1 FROM crs_view WHERE auth_name == 'EPSG' AND code = '102100');
+
     -- check geoid_model table
     SELECT RAISE(ABORT, 'missing GEOID99 in geoid_model')
         WHERE NOT EXISTS(SELECT 1 FROM geoid_model WHERE name = 'GEOID99');

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -5673,6 +5673,14 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
         try {
             return factory->createCoordinateReferenceSystem(code);
         } catch (...) {
+
+            // Convenience for well-known misused code
+            // See https://github.com/OSGeo/PROJ/issues/1730
+            if (ci_equal(authName, "EPSG") && code == "102100") {
+                factory = AuthorityFactory::create(dbContextNNPtr, "ESRI");
+                return factory->createCoordinateReferenceSystem(code);
+            }
+
             const auto authorities = dbContextNNPtr->getAuthorities();
             for (const auto &authCandidate : authorities) {
                 if (ci_equal(authCandidate, authName)) {

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -9324,6 +9324,20 @@ TEST(io, createFromUserInput) {
 
 // ---------------------------------------------------------------------------
 
+TEST(io, createFromUserInput_hack_EPSG_102100) {
+    auto dbContext = DatabaseContext::create();
+    auto obj = createFromUserInput("EPSG:102100", dbContext);
+    auto crs = nn_dynamic_pointer_cast<CRS>(obj);
+    ASSERT_TRUE(crs != nullptr);
+    const auto &ids = crs->identifiers();
+    ASSERT_EQ(ids.size(), 1U);
+    // we do not lie on the real authority
+    EXPECT_EQ(*ids[0]->codeSpace(), "ESRI");
+    EXPECT_EQ(ids[0]->code(), "102100");
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(io, guessDialect) {
     EXPECT_EQ(WKTParser().guessDialect("LOCAL_CS[\"foo\"]"),
               WKTParser::WKTGuessedDialect::WKT1_GDAL);


### PR DESCRIPTION
Probably a more acceptable resolution of #1730 than PR #1784, as we don't add a new entry in the database, but at runtime resolve EPSG:102100 to ESRI:102100
A database check is also added so that if some day there was a EPSG:102100 we'd be warned that we'd have to remove the hack