### PR TITLE
projinfo: no longer call createBoundCRSToWGS84IfPossible() for WKT1:GDAL

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -77,6 +77,9 @@ The following control parameters can appear in any order:
 
     .. note:: WKT2_2019 was previously called WKT2_2018.
 
+    .. note:: Before PROJ 6.3.0, WKT1:GDAL was implicitly calling --boundcrs-to-wgs84.
+              This is no longer the case.
+
 .. option:: -k crs|operation|ellipsoid
 
     When used to query a single object with a AUTHORITY:CODE, determines the (k)ind of the object

--- a/docs/source/usage/differences.rst
+++ b/docs/source/usage/differences.rst
@@ -114,3 +114,12 @@ exclusive with :option:`+t_epoch`. :option:`+dt` is used when deformation
 for a set amount of time is needed and :option:`+t_epoch` is used (in
 conjunction with the observation time of the input coordinate) when
 deformation from a specific epoch to the observation time is needed.
+
+Version 6.3.0
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+projinfo
+--------
+
+Before PROJ 6.3.0, WKT1:GDAL was implicitly calling --boundcrs-to-wgs84, to
+add a TOWGS84[] node in some cases. This is no longer the case.

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -423,24 +423,13 @@ static void outputObject(
                     std::cout << "WKT1:GDAL string:" << std::endl;
                 }
 
-                auto crs = nn_dynamic_pointer_cast<CRS>(obj);
-                std::shared_ptr<IWKTExportable> objToExport;
-                if (crs) {
-                    objToExport = nn_dynamic_pointer_cast<IWKTExportable>(
-                        crs->createBoundCRSToWGS84IfPossible(
-                            dbContext, allowUseIntermediateCRS));
-                }
-                if (!objToExport) {
-                    objToExport = wktExportable;
-                }
-
                 auto formatter =
                     WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL);
                 if (outputOpt.singleLine) {
                     formatter->setMultiLine(false);
                 }
                 formatter->setStrict(outputOpt.strict);
-                auto wkt = objToExport->exportToWKT(formatter.get());
+                auto wkt = wktExportable->exportToWKT(formatter.get());
                 if (outputOpt.c_ify) {
                     wkt = c_ify_string(wkt);
                 }


### PR DESCRIPTION
To align with GDAL 3.0.3 behaviour, no longer automatically try to create
a boundCRS to WGS84 when exporting to WKT1:GDAL. The user has to
explicitly specify --boundcrs-to-wgs84 if he wishes this behaviour.