### PR TITLE
Modify verbosity level of some debug/trace messages

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -253,9 +253,11 @@ similarly, but prefers the 2D resp. 3D interfaces if available.
 
             const auto& alt = P->alternativeCoordinateOperations[iBest];
             if( P->iCurCoordOp != iBest ) {
-                std::string msg("Using coordinate operation ");
-                msg += alt.name;
-                pj_log(P->ctx, PJ_LOG_TRACE, msg.c_str());
+                if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_DEBUG) {
+                    std::string msg("Using coordinate operation ");
+                    msg += alt.name;
+                    pj_log(P->ctx, PJ_LOG_DEBUG, msg.c_str());
+                }
                 P->iCurCoordOp = iBest;
             }
             PJ_COORD res = direction == PJ_FWD ?
@@ -263,7 +265,7 @@ similarly, but prefers the 2D resp. 3D interfaces if available.
             if( res.xyzt.x != HUGE_VAL ) {
                 return res;
             }
-            pj_log(P->ctx, PJ_LOG_TRACE,
+            pj_log(P->ctx, PJ_LOG_DEBUG,
                    "Did not result in valid result. "
                    "Attempting a retry with another operation.");
             if( iRetry == N_MAX_RETRY ) {
@@ -290,9 +292,11 @@ similarly, but prefers the 2D resp. 3D interfaces if available.
             if( coordOperation ) {
                 if( coordOperation->gridsNeeded(dbContext).empty() ) {
                     if( P->iCurCoordOp != i ) {
-                        std::string msg("Using coordinate operation ");
-                        msg += alt.name;
-                        pj_log(P->ctx, PJ_LOG_TRACE, msg.c_str());
+                        if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_DEBUG) {
+                            std::string msg("Using coordinate operation ");
+                            msg += alt.name;
+                            pj_log(P->ctx, PJ_LOG_DEBUG, msg.c_str());
+                        }
                         P->iCurCoordOp = i;
                     }
                     if( direction == PJ_FWD ) {

--- a/src/conversions/unitconvert.cpp
+++ b/src/conversions/unitconvert.cpp
@@ -470,7 +470,7 @@ PJ *CONVERSION(unitconvert,0) {
         const char* normalized_name = nullptr;
         f = get_unit_conversion_factor(name, &xy_in_is_linear, &normalized_name);
         if (f != 0.0) {
-            proj_log_debug(P, "xy_in unit: %s", normalized_name);
+            proj_log_trace(P, "xy_in unit: %s", normalized_name);
         } else {
             f = pj_param (P->ctx, P->params, "dxy_in").f;
             if (f == 0.0 || 1.0 / f == 0.0)
@@ -485,7 +485,7 @@ PJ *CONVERSION(unitconvert,0) {
         const char* normalized_name = nullptr;
         f = get_unit_conversion_factor(name, &xy_out_is_linear, &normalized_name);
         if (f != 0.0) {
-            proj_log_debug(P, "xy_out unit: %s", normalized_name);
+            proj_log_trace(P, "xy_out unit: %s", normalized_name);
         } else {
             f = pj_param (P->ctx, P->params, "dxy_out").f;
             if (f == 0.0 || 1.0 / f == 0.0)
@@ -506,7 +506,7 @@ PJ *CONVERSION(unitconvert,0) {
         const char* normalized_name = nullptr;
         f = get_unit_conversion_factor(name, &z_in_is_linear, &normalized_name);
         if (f != 0.0) {
-            proj_log_debug(P, "z_in unit: %s", normalized_name);
+            proj_log_trace(P, "z_in unit: %s", normalized_name);
         } else {
             f = pj_param (P->ctx, P->params, "dz_in").f;
             if (f == 0.0 || 1.0 / f == 0.0)
@@ -519,7 +519,7 @@ PJ *CONVERSION(unitconvert,0) {
         const char* normalized_name = nullptr;
         f = get_unit_conversion_factor(name, &z_out_is_linear, &normalized_name);
         if (f != 0.0) {
-            proj_log_debug(P, "z_out unit: %s", normalized_name);
+            proj_log_trace(P, "z_out unit: %s", normalized_name);
         } else {
             f = pj_param (P->ctx, P->params, "dz_out").f;
             if (f == 0.0 || 1.0 / f == 0.0)
@@ -540,7 +540,7 @@ PJ *CONVERSION(unitconvert,0) {
         if (!s) return pj_default_destructor(P, PJD_ERR_UNKNOWN_UNIT_ID); /* unknown unit conversion id */
 
         Q->t_in_id = i;
-        proj_log_debug(P, "t_in unit: %s", time_units[i].name);
+        proj_log_trace(P, "t_in unit: %s", time_units[i].name);
     }
 
     s = nullptr;
@@ -550,7 +550,7 @@ PJ *CONVERSION(unitconvert,0) {
         if (!s) return pj_default_destructor(P, PJD_ERR_UNKNOWN_UNIT_ID); /* unknown unit conversion id */
 
         Q->t_out_id = i;
-        proj_log_debug(P, "t_out unit: %s", time_units[i].name);
+        proj_log_trace(P, "t_out unit: %s", time_units[i].name);
     }
 
     return P;

--- a/src/ell_set.cpp
+++ b/src/ell_set.cpp
@@ -116,9 +116,9 @@ int pj_ellipsoid (PJ *P) {
     if (0 != ellps_spherification (P))
         return 4;
 
-    proj_log_debug (P, "pj_ellipsoid - final: a=%.3f f=1/%7.3f, errno=%d",
+    proj_log_trace (P, "pj_ellipsoid - final: a=%.3f f=1/%7.3f, errno=%d",
                         P->a,  P->f!=0? 1/P->f: 0,  proj_errno (P));
-    proj_log_debug (P, "pj_ellipsoid - final: %s %s %s %s",
+    proj_log_trace (P, "pj_ellipsoid - final: %s %s %s %s",
                         P->def_size?           P->def_size: empty,
                         P->def_shape?          P->def_shape: empty,
                         P->def_spherification? P->def_spherification: empty,

--- a/src/transformations/helmert.cpp
+++ b/src/transformations/helmert.cpp
@@ -665,18 +665,18 @@ PJ *TRANSFORMATION(helmert, 0) {
     }
 
     /* Let's help with debugging */
-    if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_DEBUG) {
-        proj_log_debug(P, "Helmert parameters:");
-        proj_log_debug(P, "x=  %8.5f  y=  %8.5f  z=  %8.5f", Q->xyz.x, Q->xyz.y, Q->xyz.z);
-        proj_log_debug(P, "rx= %8.5f  ry= %8.5f  rz= %8.5f",
+    if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_TRACE) {
+        proj_log_trace(P, "Helmert parameters:");
+        proj_log_trace(P, "x=  %8.5f  y=  %8.5f  z=  %8.5f", Q->xyz.x, Q->xyz.y, Q->xyz.z);
+        proj_log_trace(P, "rx= %8.5f  ry= %8.5f  rz= %8.5f",
                 Q->opk.o / ARCSEC_TO_RAD, Q->opk.p / ARCSEC_TO_RAD, Q->opk.k / ARCSEC_TO_RAD);
-        proj_log_debug(P, "s=  %8.5f  exact=%d%s", Q->scale, Q->exact,
+        proj_log_trace(P, "s=  %8.5f  exact=%d%s", Q->scale, Q->exact,
                        Q->no_rotation ? "" :
                        Q->is_position_vector ? "  convention=position_vector" :
                        "  convention=coordinate_frame");
-        proj_log_debug(P, "dx= %8.5f  dy= %8.5f  dz= %8.5f",   Q->dxyz.x, Q->dxyz.y, Q->dxyz.z);
-        proj_log_debug(P, "drx=%8.5f  dry=%8.5f  drz=%8.5f",   Q->dopk.o, Q->dopk.p, Q->dopk.k);
-        proj_log_debug(P, "ds= %8.5f  t_epoch=%8.5f", Q->dscale, Q->t_epoch);
+        proj_log_trace(P, "dx= %8.5f  dy= %8.5f  dz= %8.5f",   Q->dxyz.x, Q->dxyz.y, Q->dxyz.z);
+        proj_log_trace(P, "drx=%8.5f  dry=%8.5f  drz=%8.5f",   Q->dopk.o, Q->dopk.p, Q->dopk.k);
+        proj_log_trace(P, "ds= %8.5f  t_epoch=%8.5f", Q->dscale, Q->t_epoch);
     }
 
     if (Q->no_rotation) {
@@ -729,15 +729,15 @@ PJ *TRANSFORMATION(molobadekas, 0) {
 
 
     /* Let's help with debugging */
-    if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_DEBUG) {
-        proj_log_debug(P, "Molodensky-Badekas parameters:");
-        proj_log_debug(P, "x=  %8.5f  y=  %8.5f  z=  %8.5f", Q->xyz_0.x, Q->xyz_0.y, Q->xyz_0.z);
-        proj_log_debug(P, "rx= %8.5f  ry= %8.5f  rz= %8.5f",
+    if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_TRACE) {
+        proj_log_trace(P, "Molodensky-Badekas parameters:");
+        proj_log_trace(P, "x=  %8.5f  y=  %8.5f  z=  %8.5f", Q->xyz_0.x, Q->xyz_0.y, Q->xyz_0.z);
+        proj_log_trace(P, "rx= %8.5f  ry= %8.5f  rz= %8.5f",
                 Q->opk.o / ARCSEC_TO_RAD, Q->opk.p / ARCSEC_TO_RAD, Q->opk.k / ARCSEC_TO_RAD);
-        proj_log_debug(P, "s=  %8.5f  exact=%d%s", Q->scale, Q->exact,
+        proj_log_trace(P, "s=  %8.5f  exact=%d%s", Q->scale, Q->exact,
                        Q->is_position_vector ? "  convention=position_vector" :
                        "  convention=coordinate_frame");
-        proj_log_debug(P, "px= %8.5f  py= %8.5f  pz= %8.5f",   Q->refp.x, Q->refp.y, Q->refp.z);
+        proj_log_trace(P, "px= %8.5f  py= %8.5f  pz= %8.5f",   Q->refp.x, Q->refp.y, Q->refp.z);
     }
 
     /* as an optimization, we incorporate the refp in the translation terms */


### PR DESCRIPTION
- unitconvert, ell_set and helmert were using debug level, which is
  too verbose. Using trace instead
- proj_trans() was using trace to indicate the operation it selects.
  Changing it to debug