### PR TITLE
Make sure tests pass if extra grids are present

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,9 @@ build_script:
   - if "%platform%" == "x86" SET BUILD_LIBPROJ_SHARED=OFF
   - echo "%VS_FULL%"
 #
+  - cd %APPVEYOR_BUILD_FOLDER%\data
+  - curl -O https://download.osgeo.org/proj/proj-datumgrid-1.8.zip
+  - 7z e -aoa -y proj-datumgrid-1.8.zip
   - set PROJ_BUILD=%APPVEYOR_BUILD_FOLDER%\build
   - mkdir %PROJ_BUILD%
   - cd %PROJ_BUILD%
@@ -51,9 +54,6 @@ build_script:
 test_script:
   - echo test_script
   - set PROJ_LIB=%PROJ_DIR%\share\proj
-  - cd %PROJ_LIB%
-  - curl -O https://download.osgeo.org/proj/proj-datumgrid-1.8.zip
-  - 7z e -aoa -y proj-datumgrid-1.8.zip
   - cd %PROJ_BUILD%
   - ctest -V -C Release
   - set PATH=%PATH%;%PROJ_DIR%\bin

--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -27,7 +27,7 @@ function(proj_add_test_script_sh SH_NAME BIN_USE)
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${${BIN_USE}}
       )
     set_tests_properties( ${testname}
-        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
+        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
     endif()
 
   endif()
@@ -44,7 +44,7 @@ function(proj_add_gie_test TESTNAME TESTCASE)
       ${TESTFILE}
     )
     set_tests_properties( ${TESTNAME}
-        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data")
+        PROPERTIES ENVIRONMENT "PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
 
 
 endfunction()

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -44,6 +44,7 @@ add_custom_command(
   OUTPUT ${PROJ_DB}
   COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJ_DB}
   COMMAND ${EXE_SQLITE3} -init ${ALL_SQL_IN} ${PROJ_DB} .quit
+  COMMAND ${CMAKE_COMMAND} -E copy ${PROJ_DB} ${CMAKE_CURRENT_BINARY_DIR}/for_tests
   # note: we didn't port yet the foreign_key_check done in Makefile.am
   DEPENDS generate_all_sql_in ${ALL_SQL_IN}
   COMMENT "Generating proj.db"
@@ -57,6 +58,33 @@ if(NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
     configure_file(${FILE} ${FILE} COPYONLY)
   endforeach()
 endif()
+
+# Copy select resource files in a for_tests subdirectory so that we are not
+# influenced by the presence of other grids
+# Note: this is done at configure/cmake time, not build time.
+# So if you install new grids in the source data/ subdirectory, run cmake again
+set(DATA_FOR_TESTS
+    null
+    GL27
+    nad27
+    nad83
+    ntv1_can.dat
+    MD
+    ntf_r93.gsb
+    egm96_15.gtx
+    ntv2_0.gsb
+    conus
+    alaska
+    nzgd2kgrid0005.gsb
+    ITRF2000
+    BETA2007.gsb)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/for_tests)
+foreach(FILE ${DATA_FOR_TESTS})
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${FILE} ${CMAKE_CURRENT_BINARY_DIR}/for_tests/${FILE} COPYONLY)
+    endif()
+endforeach()
 
 #
 #install

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -96,12 +96,39 @@ proj.db: $(DATAPATH)/sql/*.sql
 	fi
 
 # For out-of-tree builds, link all file of the source data dir to the generated data
+# Also link select resource files in a for_tests subdirectory so that we are not
+# influenced by the presence of other grids
 check-local:
 	@if [ ! -f GL27 ]; then \
 		for x in $(DATAPATH)/*; do \
 			ln -sf $$x .; \
 		done \
-	fi
+	fi; \
+	rm -rf for_tests; \
+	mkdir for_tests; \
+	for x in $(DATAPATH)/null \
+		 $(DATAPATH)/GL27 \
+		 $(DATAPATH)/nad27 \
+		 $(DATAPATH)/nad83 \
+		 $(DATAPATH)/ntv1_can.dat \
+		 $(DATAPATH)/MD \
+		 $(DATAPATH)/ntf_r93.gsb \
+		 $(DATAPATH)/egm96_15.gtx \
+		 $(DATAPATH)/ntv2_0.gsb \
+		 $(DATAPATH)/conus \
+		 $(DATAPATH)/alaska \
+		 $(DATAPATH)/nzgd2kgrid0005.gsb \
+		 $(DATAPATH)/ITRF2000 \
+		 $(DATAPATH)/BETA2007.gsb; \
+	do \
+		if test -f "$$x" ; then \
+			ln -sf "../$$x" for_tests; \
+		else \
+			echo "WARNING: grid $$x missing: some tests will be skipped"; \
+		fi \
+	done; \
+	ln -sf ../proj.db for_tests
 
 clean-local:
 	$(RM) proj.db
+	$(RM) -rf for_tests

--- a/test/cli/Makefile.am
+++ b/test/cli/Makefile.am
@@ -1,5 +1,5 @@
 # Executables paths passed to test scripts
-PROJ_LIB ?= ../../data
+PROJ_LIB = ../../data/for_tests
 THIS_DIR = $(top_srcdir)/test/cli
 EXEPATH = ../../src
 PROJEXE = $(EXEPATH)/proj

--- a/test/gie/Makefile.am
+++ b/test/gie/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST = 4D-API_cs2cs-style.gie \
 	unitconvert.gie \
 	DHDN_ETRS89.gie
 
-PROJ_LIB ?= ../../data
+PROJ_LIB ?= ../../data/for_tests
 
 4D-API-cs2cs-style: 4D-API_cs2cs-style.gie
 	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<

--- a/test/gigs/Makefile.am
+++ b/test/gigs/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST = \
 	5201.gie \
 	5208.gie
 
-PROJ_LIB ?= ../../data
+PROJ_LIB ?= ../../data/for_tests
 
 5101.1: 5101.1-jhs.gie
 	PROJ_LIB=$(PROJ_LIB) $(GIEEXE) $<

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -7,7 +7,7 @@ noinst_HEADERS = gtest_include.h test_primitives.hpp
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_srcdir)/test @GTEST_CFLAGS@ @SQLITE3_CFLAGS@
 AM_CXXFLAGS = @CXX_WFLAGS@ @NO_ZERO_AS_NULL_POINTER_CONSTANT_FLAG@
 
-PROJ_LIB ?= ../../data
+PROJ_LIB ?= ../../data/for_tests
 
 noinst_PROGRAMS = pj_transform_test
 noinst_PROGRAMS += pj_phi2_test

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -107,6 +107,10 @@ make check
 (cd src && make multistresstest && make test228)
 PROJ_LIB=../data src/multistresstest
 make install
+
+# Test make clean target
+make clean
+
 find /tmp/proj_autoconf_install_grids
 cd ..
 


### PR DESCRIPTION
Should fix the issue reported in https://lists.osgeo.org/pipermail/proj/2020-January/009188.html
Some extra north-american grids present in data/ can affect the results of
some tests, so create a data/for_tests/ subdirectory in which we copy only
select grids.