### PR TITLE
added issue & pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ labels: bug
 <!-- Please search existing issues to avoid creating duplicates. -->
 
 
-#### Code Sample, a copy-pastable example if possible
+#### Example of problem
 Demonstrate the problem you have found, either by using PROJ tools like `cs2cs`, `cct` or `projinfo` **or** add a code snippet that highlights the problem using the PROJ C/C++ API.
 A "Minimal, Complete and Verifiable Example" will make it much easier for maintainers to help you:
 http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+
+#### Code Sample, a copy-pastable example if possible
+
+A "Minimal, Complete and Verifiable Example" will make it much easier for maintainers to help you:
+http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+
+```c
+# Your code here
+
+```
+#### Problem description
+
+[this should explain **why** the current behavior is a problem and why the expected output is a better solution.]
+
+#### Expected Output
+
+
+#### Environment Information
+ - PROJ version (`proj`)
+ - Operation System Information (`python -c "import platform; print(platform.platform())"`)
+
+#### Installation method
+ - conda, apt-get, from source, etc...

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ labels: bug
 
 
 #### Code Sample, a copy-pastable example if possible
-
+Demonstrate the problem you have found, either by using PROJ tools like `cs2cs`, `cct` or `projinfo` **or** add a code snippet that highlights the problem using the PROJ C/C++ API.
 A "Minimal, Complete and Verifiable Example" will make it much easier for maintainers to help you:
 http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
 
 #### Environment Information
  - PROJ version (`proj`)
- - Operation System Information (`python -c "import platform; print(platform.platform())"`)
+ - Operation System Information
 
 #### Installation method
  - conda, apt-get, from source, etc...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: proposal
+labels: feature request
 ---
 
 <!-- Describe the feature you'd like. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,7 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: proposal
+---
+
+<!-- Describe the feature you'd like. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Additional places to ask questions are on the PROJ mailing list (https://lists.osgeo.org/mailman/listinfo/proj) or GIS Stack Exchange (https://gis.stackexchange.com/questions/tagged/proj).
+labels: question
+---
+
+<!--
+Additional places to ask questions are on the PROJ mailing list (https://lists.osgeo.org/mailman/listinfo/proj) or GIS Stack Exchange (https://gis.stackexchange.com/questions/tagged/proj).
+-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,0 @@
----
-name: Question
-about: Additional places to ask questions are on the PROJ mailing list (https://lists.osgeo.org/mailman/listinfo/proj) or GIS Stack Exchange (https://gis.stackexchange.com/questions/tagged/proj).
-labels: question
----
-
-<!--
-Additional places to ask questions are on the PROJ mailing list (https://lists.osgeo.org/mailman/listinfo/proj) or GIS Stack Exchange (https://gis.stackexchange.com/questions/tagged/proj).
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!-- Feel free to remove check-list items aren't relevant to your change -->
+
+ - [ ] Closes #xxxx
+ - [ ] Tests added
+ - [ ] Fully documented, including `NEWS`, `docs/source/news.rst` for all changes and `docs/source/*.rst` for new API

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,5 @@
 
  - [ ] Closes #xxxx
  - [ ] Tests added
- - [ ] Fully documented, including `NEWS`, `docs/source/news.rst` for all changes and `docs/source/*.rst` for new API
+ - [ ] Added clear title that can be used to generate release notes
+ - [ ] Fully documented, including updating `docs/source/*.rst` for new API


### PR DESCRIPTION
I noticed #1814 and thought the pull request template might be a helpful intermediate solution as you incrementally update the NEWS & the API in each PR as you go so it is not a big change in the end. Not sure how well this method would work for backporting :man_shrugging:. Also added issue templates while I was there. Here is an idea for how the issue templates would look: https://github.com/pyproj4/pyproj/issues/new/choose.

This probably will need tweaking based on how y'all do things. Definitely don't have to use it, but it is here if you would like to.