### PR TITLE
CompoundCRS::identify(): avoid exception when horiz/vertical part is a BoundCRS

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5803,7 +5803,9 @@ static std::string buildSqlLookForAuthNameCode(
 
     std::set<std::string> authorities;
     for (const auto &crs : list) {
-        const auto &ids = crs.first->identifiers();
+        auto boundCRS = dynamic_cast<crs::BoundCRS *>(crs.first.get());
+        const auto &ids = boundCRS ? boundCRS->baseCRS()->identifiers()
+                                   : crs.first->identifiers();
         if (!ids.empty()) {
             authorities.insert(*(ids[0]->codeSpace()));
         }
@@ -5822,7 +5824,9 @@ static std::string buildSqlLookForAuthNameCode(
         params.emplace_back(auth_name);
         bool firstGeodCRSForAuth = true;
         for (const auto &crs : list) {
-            const auto &ids = crs.first->identifiers();
+            auto boundCRS = dynamic_cast<crs::BoundCRS *>(crs.first.get());
+            const auto &ids = boundCRS ? boundCRS->baseCRS()->identifiers()
+                                       : crs.first->identifiers();
             if (!ids.empty() && *(ids[0]->codeSpace()) == auth_name) {
                 if (!firstGeodCRSForAuth) {
                     sql += ',';

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -3493,6 +3493,17 @@ TEST(crs, compoundCRS_identify_db) {
         EXPECT_EQ(res.front().first->getEPSGCode(), 8769);
         EXPECT_EQ(res.front().second, 70);
     }
+    {
+        auto obj = PROJStringParser().createFromPROJString(
+            "+proj=tmerc +lat_0=0 +lon_0=72.05 +k=1 +x_0=3500000 "
+            "+y_0=-5811057.63 +ellps=krass "
+            "+towgs84=23.57,-140.95,-79.8,0,-0.35,-0.79,-0.22 "
+            "+geoidgrids=egm08_25.gtx +units=m +no_defs +type=crs");
+        auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        // Just check we don't get an exception
+        crs->identify(factory);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The exception only affects C++ users. It was caught by the C layer.