### PR TITLE
Remove -ld option from proj and cs2cs

### DIFF
--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -91,10 +91,6 @@ The following control parameters can appear in any order:
 
     List of all distance units that can be selected with the *+units* parameter.
 
-.. option:: -ld
-
-    List of datums that can be selected with the *+datum* parameter.
-
 .. option:: -r
 
     This options reverses the order of the expected input from

--- a/docs/source/apps/proj.rst
+++ b/docs/source/apps/proj.rst
@@ -97,10 +97,6 @@ The following control parameters can appear in any order
 
     List of all distance units that can be selected with the *+units* parameter.
 
-.. option:: -ld
-
-    List of datums that can be selected with the *+datum* parameter.
-
 .. option:: -r
 
     This options reverses the order of the expected input from

--- a/docs/source/usage/differences.rst
+++ b/docs/source/usage/differences.rst
@@ -123,3 +123,19 @@ projinfo
 
 Before PROJ 6.3.0, WKT1:GDAL was implicitly calling --boundcrs-to-wgs84, to
 add a TOWGS84[] node in some cases. This is no longer the case.
+
+
+Version 7.0.0
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+proj
+--------
+
+Removed ``-ld`` option from application, since it promoted use of deprecated
+paramters like ``+towgs`` and ``+datum``.
+
+cs2cs
+--------
+
+Removed ``-ld`` option from application, since it promoted use of deprecated
+paramters like ``+towgs`` and ``+datum``.

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -430,19 +430,6 @@ int main(int argc, char **argv) {
                         for (lu = proj_list_units(); lu->id; ++lu)
                             (void)printf("%12s %-20s %s\n", lu->id,
                                          lu->to_meter, lu->name);
-                    } else if (arg[1] == 'd') { /* list datums */
-                        const struct PJ_DATUMS *ld;
-
-                        printf("__datum_id__ __ellipse___ "
-                               "__definition/"
-                               "comments______________________________\n");
-                        for (ld = pj_get_datums_ref(); ld->id; ++ld) {
-                            printf("%12s %-12s %-30s\n", ld->id, ld->ellipse_id,
-                                   ld->defn);
-                            if (ld->comments != nullptr &&
-                                strlen(ld->comments) > 0)
-                                printf("%25s %s\n", " ", ld->comments);
-                        }
                     } else if (arg[1] == 'm') { /* list prime meridians */
                         const struct PJ_PRIME_MERIDIANS *lpm;
 

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -385,17 +385,6 @@ int main(int argc, char **argv) {
                     for (lu = proj_list_units(); lu->id ; ++lu)
                         (void)printf("%12s %-20s %s\n",
                                      lu->id, lu->to_meter, lu->name);
-                } else if (arg[1] == 'd') { /* list datums */
-                    const struct PJ_DATUMS *ld;
-
-                    printf("__datum_id__ __ellipse___ __definition/comments______________________________\n" );
-                    for (ld = pj_get_datums_ref(); ld->id ; ++ld)
-                    {
-                        printf("%12s %-12s %-30s\n",
-                               ld->id, ld->ellipse_id, ld->defn);
-                        if( ld->comments != nullptr && strlen(ld->comments) > 0 )
-                            printf( "%25s %s\n", " ", ld->comments );
-                    }
                 } else
                     emess(1,"invalid list option: l%c",arg[1]);
                 exit(0);


### PR DESCRIPTION
It promotes use of deprecated paramters +datum and +towgs84 which we
don't want to encourage.

Closes #1308

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #xxxx
 - [ ] Tests added [*N/A*]
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API