### PR TITLE
Reintroduce backport bot, now using a dedicated PROJ bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,20 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport Bot
+        if: contains( join(github.event.pull_request.labels.*.name), 'backport')
+        uses: Gaurav0/backport@v1.0.24
+        with:
+          bot_username: PROJ-BOT
+          bot_token: c1c49a5799d0a3a3885db8a4792880cbe509c1d6
+          bot_token_key: b01bdebf64595ed77207019258316df1b05ff6ac
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've set up a dedicated GitHub user, PROJ-BOT, that can functions as a backporting bot. I've copied the setup from QGIS which seems to finally have cracked the nut. Hopefully it works as the previous bot.

 - [x] Closes #1741 

Not applicable:
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API