### PR TITLE
Doc: add in install.rst tutorials to build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,79 +33,13 @@ The following command line utilities are included in the PROJ package:
 > More information on the utilities can be found on the [PROJ website](https://proj.org/apps).
 
 ## Installation
-### Build dependencies
 
-PROJ requires C and C++11 compilers.
-It also requires SQLite3 (headers, library and executable).  The minimum 
-version of SQLite3 required is 3.11
+Consult the [Installation](https://proj.org/install.html) page of the official
+documentation.
+For builds on the master branch, [install.rst](https://github.com/OSGeo/PROJ/blob/master/docs/source/install.rst)
+might be more up-to-date.
 
-### Building with CMake
-
-    cd proj
-    mkdir build
-    cd build
-    cmake ..
-    cmake --build .
-
-On Windows, one may need to specify generator:
-
-    cmake -G "Visual Studio 15 2017" ..
-
-If the SQLite3 dependency is installed in a custom location, specify the
-paths to the include directory and the library:
-
-    cmake -DSQLITE3_INCLUDE_DIR=/opt/SQLite/include -DSQLITE3_LIBRARY=/opt/SQLite/lib/libsqlite3.so ..
-
-Tests are run with
-
-    ctest
-
-The test suite requires that the proj-datumgrid package is installed
-in `PROJ_LIB`.
-
-### Building on Unix/Linux
-
-FSF's configuration procedure is used to ease installation of the
-PROJ system.
-
-The default destination path prefix for installed files is `/usr/local`.
-Results from the installation script will be placed into subdirectories
-`bin`, `include`, `lib`, `man/man1` and `man/man3`.
-If this default path prefix is proper, then execute:
-
-    ./configure
-
-See the note below if you are building PROJ directly from the git repository.
-
-If another path prefix is required, then execute:
-
-    ./configure --prefix=/my/path
-
-In either case, the directory of the prefix path must exist and be
-writable by the installer.
-After executing configure, execute:
-
-    make
-    make install
-
-The install target will create, if necessary, all required sub-directories.
-
-Tests are run with
-
-    make check
-
-The test suite requires that the proj-datumgrid package is installed
-in `PROJ_LIB`.
-
-#### Building from the git repository
-
-If you are building from the git repository you have to first run
-
-    ./autogen.sh
-
-which will generate a configure script that can be used as described above.
-
-### Distribution files and format
+## Distribution files and format
 
 Sources are distributed in one or more files.  The principle elements
 of the system are stored in a compressed tar file named `proj-x.y.z.tar.gz` where
@@ -135,6 +69,6 @@ where PROJ will find them after installation. The default location of
 be changed to a different directory. On Windows you have to define
 `PROJ_LIB` yourself.
 
-### Citing PROJ in publications
+## Citing PROJ in publications
 
 See [CITATION](CITATION)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -141,6 +141,8 @@ Build requirements
 - C99 compiler
 - C++11 compiler
 - SQLite3 >= 3.11 (headers, library and executable)
+- libtiff >= 4.0 (headers and library)
+- optional (but recommended): curl >= 7.29.0
 - GNU make for autotools build or CMake >= 3.5
 
 Autotools
@@ -231,3 +233,126 @@ Tests are run with::
 
 The test suite requires that the proj-datumgrid package is installed
 in :envvar:`PROJ_LIB`.
+
+
+Building on Windows with vcpkg and Visual Studio 2017 or 2019
+--------------------------------------------------------------------------------
+
+This method is the preferred one to generate Debug and Release builds.
+
+Install git
++++++++++++
+
+Install `git <https://git-scm.com/download/win>`_
+
+Install Vcpkg
++++++++++++++
+
+Assuming there is a c:\\dev directory
+
+::
+
+    cd c:\dev
+    git clone https://github.com/Microsoft/vcpkg.git
+
+    cd vcpkg
+    .\bootstrap-vcpkg.bat
+
+Install PROJ dependencies
++++++++++++++++++++++++++
+
+::
+
+    vcpkg.exe install sqlite3[core,tool]:x86-windows tiff:x86-windows curl:x86-windows
+    vcpkg.exe install sqlite3[core,tool]:x64-windows tiff:x64-windows curl:x64-windows
+
+.. note:: The tiff and curl dependencies are only needed since PROJ 7.0
+
+Checkout PROJ sources
++++++++++++++++++++++
+
+::
+
+    cd c:\dev
+    git clone https://github.com/OSGeo/PROJ.git
+
+Build PROJ
+++++++++++
+
+::
+
+    cd c:\dev\PROJ
+    mkdir build_vs2019
+    cd build_vs2019
+    cmake -DCMAKE_TOOLCHAIN_FILE=C:\dev\vcpkg\scripts\buildsystems\vcpkg.cmake ..
+    cmake --build . --config Debug -j 8
+
+
+Run PROJ tests
+++++++++++++++
+
+::
+
+    cd c:\dev\PROJ\build_vs2019
+    ctest -V --build-config Debug
+
+
+Building on Windows with Conda dependencies and Visual Studio 2017 or 2019
+--------------------------------------------------------------------------------
+
+Variant of the above method but using Conda for SQLite3, TIFF and CURL dependencies.
+It is less appropriate for Debug builds of PROJ than the method based on vcpkg.
+
+Install git
++++++++++++
+
+Install `git <https://git-scm.com/download/win>`_
+
+Install miniconda
++++++++++++++++++
+
+Install `miniconda <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_
+
+Install PROJ dependencies
++++++++++++++++++++++++++
+
+Start a Conda enabled console and assuming there is a c:\\dev directory
+
+::
+
+    cd c:\dev
+    conda create --name proj
+    conda activate proj
+    conda install sqlite libtiff curl cmake
+
+.. note:: The libtiff and curl dependencies are only needed since PROJ 7.0
+
+Checkout PROJ sources
++++++++++++++++++++++
+
+::
+
+    cd c:\dev
+    git clone https://github.com/OSGeo/PROJ.git
+
+Build PROJ
+++++++++++
+
+From a Conda enabled console
+
+::
+
+    conda activate proj
+    cd c:\dev\PROJ
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+    cmake -S . -B _build.vs2019 -DCMAKE_LIBRARY_PATH:FILEPATH="%CONDA_PREFIX%/Library/lib" -DCMAKE_INCLUDE_PATH:FILEPATH="%CONDA_PREFIX%/Library/include"
+    cmake --build _build.vs2019 --config Release -j 8
+
+Run PROJ tests
+++++++++++++++
+
+::
+
+    cd c:\dev\PROJ
+    cd _build.vs2019
+    ctest -V --build-config Release


### PR DESCRIPTION
Fixes #1776

Content based on https://github.com/OSGeo/PROJ/wiki/Building-with-VS-and-vcpkg
which should be retired to avoid duplication of information

README.md is also modified to point to install.rst
