### PR TITLE
Explain why sweep axis affects geolocation

### DIFF
--- a/docs/source/operations/projections/geos.rst
+++ b/docs/source/operations/projections/geos.rst
@@ -72,6 +72,9 @@ is rotating. The possible values are x or y, y being the default. Thus, the
 scanning geometry of the Meteosat series satellite should take sweep as y, and
 GOES should take sweep as x.
 
+The resulting position is different because
+`rotation in three dimensions is not commutative <https://math.stackexchange.com/q/2016937/31408>`_.
+
 Parameters
 ################################################################################
 


### PR DESCRIPTION
In the note on the sweep angle, add a line explaining why the sweep angle ultimately affects the geolocation, as it is not immediately or trivially obvious to see why it should matter what the outer or inner gimbal is.  To this end, link to a post on Mathematics Stack Exchange that explains this very well.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API