### PR TITLE
Document need for quotes when a pipeline grid path contains spaces

### DIFF
--- a/docs/source/operations/transformations/deformation.rst
+++ b/docs/source/operations/transformations/deformation.rst
@@ -93,6 +93,9 @@ Parameters
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
 
+    If a grid is specified with a path that contains spaces, the value should
+    be quoted.  e.g. `+xy_grids="/my path/has/spaces.ct2"`
+
     Grids for the horizontal component of a deformation model are expected to be
     in CTable2 format.
 
@@ -101,6 +104,9 @@ Parameters
     Comma-separated list of grids to load. If a grid is prefixed by an `@` the
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
+
+    If a grid is specified with a path that contains spaces, the value should
+    be quoted.  e.g. `+z_grids="/my path/has/spaces.gtx"`
 
     Grids for the vertical component of a deformation model are expected to be
     in GTX format.

--- a/docs/source/operations/transformations/deformation.rst
+++ b/docs/source/operations/transformations/deformation.rst
@@ -93,7 +93,7 @@ Parameters
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
 
-    Grids for the horizontal component of a deformation model is expected to be
+    Grids for the horizontal component of a deformation model are expected to be
     in CTable2 format.
 
 .. option:: +z_grids=<list>
@@ -102,8 +102,8 @@ Parameters
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
 
-    Grids for the vertical component of a deformation model is expected to be
-    in either GTX format.
+    Grids for the vertical component of a deformation model are expected to be
+    in GTX format.
 
 .. option:: +t_epoch=<value>
 

--- a/docs/source/operations/transformations/deformation.rst
+++ b/docs/source/operations/transformations/deformation.rst
@@ -93,7 +93,7 @@ Parameters
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
 
-    Grids for the horizontla component of a deformation model is expected to be
+    Grids for the horizontal component of a deformation model is expected to be
     in CTable2 format.
 
 .. option:: +z_grids=<list>

--- a/docs/source/operations/transformations/hgridshift.rst
+++ b/docs/source/operations/transformations/hgridshift.rst
@@ -104,6 +104,9 @@ Required
     Comma-separated list of grids to load. If a grid is prefixed by an `@` the
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
+    
+    If a grid is specified with a path that contains spaces, the value should
+    be quoted.  e.g. `+grids="/my path/has/spaces.gsb"`
 
     Grids are expected to be in CTable2, NTv1 or NTv2 format.
 

--- a/docs/source/operations/transformations/vgridshift.rst
+++ b/docs/source/operations/transformations/vgridshift.rst
@@ -103,6 +103,9 @@ Required
     grid is considered optional and PROJ will the not complain if the grid is
     not available.
 
+    If a grid is specified with a path that contains spaces, the value should
+    be quoted.  e.g. `+grids="/my path/has/spaces.gtx"`
+
     Grids are expected to be in GTX format.
 
 Optional


### PR DESCRIPTION
Not certain whether this is appropriate when you are dealing with lists of grids, but it definitely helps for a single grid.