### PR TITLE
ProjectedCRS::identify(): fix wrong identification of some ESRI WKT linked to units

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -3728,6 +3728,15 @@ ProjectedCRS::identify(const io::AuthorityFactoryPtr &authorityFactory) const {
                         res.emplace_back(crsNN, eqName ? 90 : 70);
                     } else if (crs->nameStr() == thisName &&
                                CRS::getPrivate()->implicitCS_ &&
+                               coordinateSystem()
+                                   ->axisList()[0]
+                                   ->unit()
+                                   ._isEquivalentTo(
+                                       crs->coordinateSystem()
+                                           ->axisList()[0]
+                                           ->unit(),
+                                       util::IComparable::Criterion::
+                                           EQUIVALENT) &&
                                l_baseCRS->_isEquivalentTo(
                                    crs->baseCRS().get(),
                                    util::IComparable::Criterion::

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -2393,6 +2393,37 @@ TEST(crs, projectedCRS_identify_db) {
         EXPECT_EQ(res.front().first->getEPSGCode(), 6646);
         EXPECT_EQ(res.front().second, 70);
     }
+    {
+        // Identify from a WKT ESRI that has the same name has ESRI:102039
+        // but uses us-ft instead of metres!
+        auto obj = WKTParser().attachDatabaseContext(dbContext).createFromWKT(
+            "PROJCS[\"USA_Contiguous_Albers_Equal_Area_Conic_USGS_version\","
+            "GEOGCS[\"GCS_North_American_1983\","
+            "DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\","
+            "6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],"
+            "UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Albers\"],"
+            "PARAMETER[\"False_Easting\",0.0],"
+            "PARAMETER[\"False_Northing\",0.0],"
+            "PARAMETER[\"Central_Meridian\",-96.0],"
+            "PARAMETER[\"Standard_Parallel_1\",29.5],"
+            "PARAMETER[\"Standard_Parallel_2\",45.5],"
+            "PARAMETER[\"Latitude_Of_Origin\",23.0],"
+            "UNIT[\"Foot_US\",0.3048006096012192]]");
+        auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        auto factoryAll = AuthorityFactory::create(dbContext, std::string());
+        auto res = crs->identify(factoryAll);
+        EXPECT_GE(res.size(), 1U);
+        bool found = false;
+        for (const auto &pair : res) {
+            if (pair.first->identifiers()[0]->code() == "102039") {
+                found = true;
+                EXPECT_EQ(pair.second, 25);
+                break;
+            }
+        }
+        EXPECT_TRUE(found);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes bug reported in https://lists.osgeo.org/pipermail/gdal-dev/2020-January/051481.html
