### PR TITLE
CMake: replace PROJ_TESTS with CTest's BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,13 +212,6 @@ if(MSVC OR CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_DEBUG_POSTFIX _d)
 endif()
 
-option(PROJ_TESTS "Enable build of collection of PROJ tests" ON)
-boost_report_value(PROJ_TESTS)
-if(PROJ_TESTS)
-  enable_testing()
-endif()
-include(ProjTest)
-
 # Put the libraries and binaries that get built into directories at the
 # top of the build tree rather than in hard-to-find leaf
 # directories. This simplifies manual testing and the use of the build
@@ -246,6 +239,22 @@ set(CMAKECONFIGDIR "${DEFAULT_CMAKEDIR}"
   CACHE PATH "The directory to install cmake config files into.")
 
 ################################################################################
+# Tests
+################################################################################
+include(CTest)
+
+# Support older option, to be removed by PROJ 8.0
+if(DEFINED PROJ_TESTS)
+  message(DEPRECATION "PROJ_TESTS has been replaced with BUILD_TESTING")
+  set(BUILD_TESTING ${PROJ_TESTS})
+endif()
+
+boost_report_value(BUILD_TESTING)
+if(BUILD_TESTING)
+  include(ProjTest)
+endif()
+
+################################################################################
 # Build configured components
 ################################################################################
 include_directories(${PROJ4_SOURCE_DIR}/src)
@@ -256,6 +265,6 @@ add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(man)
 add_subdirectory(cmake)
-if(PROJ_TESTS)
+if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -234,6 +234,10 @@ Tests are run with::
 The test suite requires that the proj-datumgrid package is installed
 in :envvar:`PROJ_LIB`.
 
+If tests are not required, PROJ can be built without the test suite using the following configuration::
+
+    cmake -DBUILD_TESTING=OFF ..
+
 
 Building on Windows with vcpkg and Visual Studio 2017 or 2019
 --------------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,9 @@ endif()
 
 if(BUILD_GEOD)
   include(bin_geod.cmake)
-  include(bin_geodtest.cmake)
+  if(BUILD_TESTING)
+    include(bin_geodtest.cmake)
+  endif()
   set(BIN_TARGETS ${BIN_TARGETS} geod)
 endif()
 


### PR DESCRIPTION
As mentioned in #1263 this PR replaces `PROJ_TESTS` with CTest's `BUILD_TESTING` option, which is more generic to CMake projects. CTest (when included) automatically creates a `BUILD_TESTING` option, with a default ON. Backwards compatibility to the older option `PROJ_TESTS` is supported, but shows a deprecation message.

For example, a speedy build that does not require tests, configure a build like this:
```
$ mkdir build && cd build
$ cmake -DBUILD_TESTING=OFF ..
...
$ make -j
...
$ ctest
Test project /path/to/PROJ/build
No tests were found!!!
```
(as expected)