### PR TITLE
Fix wrong use of derivingConversionRef() that caused GDAL bug

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -3574,7 +3574,7 @@ PJ *proj_crs_create_projected_3D_crs_from_2D(PJ_CONTEXT *ctx,
                         crs_name ? crs_name
                                  : cpp_projected_2D_crs->nameStr().c_str()),
                     NN_NO_CHECK(cpp_geog_3D_CRS),
-                    cpp_projected_2D_crs->derivingConversionRef(), newCS));
+                    cpp_projected_2D_crs->derivingConversion(), newCS));
         } catch (const std::exception &e) {
             proj_log_error(ctx, __FUNCTION__, e.what());
             if (ctx->cpp_context) {

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2497,7 +2497,7 @@ AuthorityFactory::createProjectedCRS(const std::string &code) const {
                 pj_add_type_crs_if_needed(text_definition), d->context());
             auto projCRS = dynamic_cast<const crs::ProjectedCRS *>(obj.get());
             if (projCRS) {
-                const auto &conv = projCRS->derivingConversionRef();
+                const auto conv = projCRS->derivingConversion();
                 auto newConv =
                     (conv->nameStr() == "unnamed")
                         ? operation::Conversion::create(
@@ -2518,10 +2518,9 @@ AuthorityFactory::createProjectedCRS(const std::string &code) const {
                     boundCRS->baseCRS().get());
                 if (projCRS) {
                     auto newBoundCRS = crs::BoundCRS::create(
-                        crs::ProjectedCRS::create(
-                            props, projCRS->baseCRS(),
-                            projCRS->derivingConversionRef(),
-                            projCRS->coordinateSystem()),
+                        crs::ProjectedCRS::create(props, projCRS->baseCRS(),
+                                                  projCRS->derivingConversion(),
+                                                  projCRS->coordinateSystem()),
                         boundCRS->hubCRS(), boundCRS->transformation());
                     return NN_NO_CHECK(
                         util::nn_dynamic_pointer_cast<crs::ProjectedCRS>(

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -9059,7 +9059,7 @@ PROJStringParser::createFromPROJString(const std::string &projString) {
                     auto projCRS = dynamic_cast<ProjectedCRS *>(crs);
                     if (projCRS) {
                         // Override with easting northing order
-                        const auto &conv = projCRS->derivingConversionRef();
+                        const auto conv = projCRS->derivingConversion();
                         if (conv->method()->getEPSGCode() !=
                             EPSG_CODE_METHOD_TRANSVERSE_MERCATOR_SOUTH_ORIENTATED) {
                             return ProjectedCRS::create(


### PR DESCRIPTION
Hopefully final cut at solving the same class of bug that the one
that affected QGIS in December.

This time, this hit GDAL in the situation of
https://lists.osgeo.org/pipermail/gdal-dev/2020-January/051500.html
The bug fix for that particular issue is in
PROJStringParser::createFromPROJString()

But grepping more in the code base, I could find other potential smelly
situations (might not be issues, but better be safe than sorry),
so let's fix them too.

Bottom line is:
derivingConversionRef() should *only* be used for consultation, and
never to create a new ProjectedCRS()
