### PR TITLE
createObjectsFromName(): use alias as fallback only

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5214,9 +5214,9 @@ AuthorityFactory::createObjectsFromName(
     }
 
     std::string sql(
-        "SELECT table_name, auth_name, code, name, deprecated FROM ("
-        "SELECT table_name, auth_name, code, name, deprecated FROM object_view "
-        "WHERE ");
+        "SELECT table_name, auth_name, code, name, deprecated, is_alias FROM ("
+        "SELECT table_name, auth_name, code, name, deprecated, 0 as is_alias "
+        "FROM object_view WHERE ");
     if (deprecated) {
         sql += "deprecated = 1 AND ";
     }
@@ -5348,7 +5348,7 @@ AuthorityFactory::createObjectsFromName(
     sql += " UNION SELECT ov.table_name AS table_name, "
            "ov.auth_name AS auth_name, "
            "ov.code AS code, a.alt_name AS name, "
-           "ov.deprecated AS deprecated FROM object_view ov "
+           "ov.deprecated AS deprecated, 1 as is_alias FROM object_view ov "
            "JOIN alias_name a ON ov.table_name = a.table_name AND "
            "ov.auth_name = a.auth_name AND ov.code = a.code WHERE ";
     if (deprecated) {
@@ -5364,7 +5364,7 @@ AuthorityFactory::createObjectsFromName(
     }
     sql += getTableNameConstraint("ov.table_name");
 
-    sql += ") ORDER BY deprecated, length(name), name";
+    sql += ") ORDER BY deprecated, is_alias, length(name), name";
     if (limitResultCount > 0 &&
         limitResultCount <
             static_cast<size_t>(std::numeric_limits<int>::max()) &&

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2869,6 +2869,16 @@ TEST(factory, createObjectsFromName) {
         factory->createObjectsFromName("i_dont_exist", {type}, false, 1);
     }
     factory->createObjectsFromName("i_dont_exist", types, false, 1);
+
+    {
+        auto res = factoryEPSG->createObjectsFromName(
+            "ETRS89", {AuthorityFactory::ObjectType::GEOGRAPHIC_2D_CRS}, false,
+            1);
+        EXPECT_EQ(res.size(), 1U);
+        if (!res.empty()) {
+            EXPECT_EQ(res.front()->getEPSGCode(), 4258);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a regression of 6.3.0 found when creating with GDAL a TIFF with
a Geographic3D CRS. As TIFF must also encode the Geographic2D CRS,
the code of the Geographic2D CRS is searched from the name of the
Geographic3D CRS. When doing createObjectsFromName(
"ETRS89", {AuthorityFactory::ObjectType::GEOGRAPHIC_2D_CRS}, false, 1),
the result returned was not EPSG:4258 as expected, but EPSG:4173 IRENET95
which is registered as an alias of ETRS89. So sort results such
that non-alias results are returned first.
