### PR TITLE
Remove legacy CMake target name "proj" addressing #802

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -39,9 +39,6 @@ install(FILES
 # Make information about the cmake targets (the library and the tools)
 # available.
 install(EXPORT targets
-  FILE ${PROJECT_NAME_LOWER}-targets.cmake
-  DESTINATION "${CMAKECONFIGDIR}")
-install(EXPORT targets
   NAMESPACE ${PROJECT_NAME}::
-  FILE ${PROJECT_NAME_LOWER}-namespace-targets.cmake
+  FILE ${PROJECT_NAME_LOWER}-targets.cmake
   DESTINATION "${CMAKECONFIGDIR}")

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -23,7 +23,6 @@ set (@PROJECT_NAME@_BINARY_DIRS "${_ROOT}/@BINDIR@")
 set (@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::proj)
 # Read in the exported definition of the library
 include ("${_DIR}/@PROJECT_NAME_LOWER@-targets.cmake")
-include ("${_DIR}/@PROJECT_NAME_LOWER@-namespace-targets.cmake")
 
 unset (_ROOT)
 unset (_DIR)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #802
 - [x] Added clear title that can be used to generate release notes

Next up: create issue for smooth transition from

    find_package(PROJ4)

to

    find_package(PROJ)