### PR TITLE
add #proj IRC channel notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,4 +92,5 @@ notifications:
   irc:
     channels:
       - "irc.freenode.org#gdal"
+      - "irc.freenode.org#proj"
     use_notice: true


### PR DESCRIPTION
- #proj channel exists on IRC freenode (https://webchat.freenode.net/#proj)
- this change adds TRAVIS.CI notifications into the #proj IRC channel
  - (in addition to the notifications into the #gdal channel)

