### PR TITLE
ENH: Add support for WKT/JSON parsing of PROJ-based conversion

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -1370,6 +1370,8 @@ class PROJ_GCC_DLL Conversion : public SingleOperation {
 
     PROJ_INTERNAL ConversionNNPtr shallowClone() const;
 
+    PROJ_INTERNAL ConversionNNPtr shallowCloneNoCRS() const;
+
     PROJ_INTERNAL ConversionNNPtr alterParametersLinearUnit(
         const common::UnitOfMeasure &unit, bool convertToNewUnit) const;
 

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -2502,6 +2502,15 @@ CoordinateOperationNNPtr Conversion::_shallowClone() const {
 // ---------------------------------------------------------------------------
 
 //! @cond Doxygen_Suppress
+ConversionNNPtr Conversion::shallowCloneNoCRS() const {
+    auto conv = Conversion::nn_make_shared<Conversion>(*this);
+    conv->assignSelf(conv);
+    return conv;
+}
+
+// ---------------------------------------------------------------------------
+
+//! @cond Doxygen_Suppress
 ConversionNNPtr
 Conversion::alterParametersLinearUnit(const common::UnitOfMeasure &unit,
                                       bool convertToNewUnit) const {

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -2967,7 +2967,8 @@ WKTParser::Private::buildConversion(const WKTNodeNNPtr &node,
         {
             if (geodeticCRS
                 && projString.find("+a=") == std::string::npos
-                && projString.find("+ellps=") == std::string::npos)
+                && projString.find("+ellps=") == std::string::npos
+                && projString.find("+R=") == std::string::npos)
             {
                 projString += " " + geodeticCRS->ellipsoid()->exportToPROJString(PROJStringFormatter::create().get());
             }
@@ -5253,7 +5254,8 @@ ConversionNNPtr JSONParser::buildConversion(const json &j, const GeodeticCRSPtr 
         {
             if (geodeticCRS
                 && projString.find("+a=") == std::string::npos
-                && projString.find("+ellps=") == std::string::npos)
+                && projString.find("+ellps=") == std::string::npos
+                && projString.find("+R=") == std::string::npos)
             {
                 projString += " " + geodeticCRS->ellipsoid()->exportToPROJString(PROJStringFormatter::create().get());
             }

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -4037,7 +4037,7 @@ WKTParser::Private::buildDerivedVerticalCRS(const WKTNodeNNPtr &node) {
     }
     auto derivingConversion = buildConversion(
         derivingConversionNode, UnitOfMeasure::NONE, UnitOfMeasure::NONE,
-        crs::GeodeticCRS::EPSG_4978);
+        nullptr);
 
     auto &csNode = nodeP->lookForChild(WKTConstants::CS_);
     if (isNull(csNode)) {
@@ -4190,7 +4190,7 @@ WKTParser::Private::buildDerivedTemporalCRS(const WKTNodeNNPtr &node) {
     return DerivedTemporalCRS::create(
         buildProperties(node), buildTemporalCRS(baseCRSNode),
         buildConversion(derivingConversionNode, UnitOfMeasure::NONE,
-                        UnitOfMeasure::NONE, crs::GeodeticCRS::EPSG_4978),
+                        UnitOfMeasure::NONE, nullptr),
         buildTemporalCS(node));
 }
 

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -2979,8 +2979,8 @@ WKTParser::Private::buildConversion(const WKTNodeNNPtr &node,
                     PROJStringParser().createFromPROJString(projString);
                 auto projObjCrs =
                     nn_dynamic_pointer_cast<ProjectedCRS>(projObj);
-                if (projObjCrs) {
-                    return projObjCrs->derivingConversion();
+                if (projObjCrs && projObjCrs->getExtensionProj4().empty()) {
+                    return projObjCrs->derivingConversion()->shallowCloneNoCRS();
                 }
             } catch (const io::ParsingException &) {
             }
@@ -5265,8 +5265,8 @@ ConversionNNPtr JSONParser::buildConversion(const json &j, const GeodeticCRSPtr 
                     PROJStringParser().createFromPROJString(projString);
                 auto projObjCrs =
                     nn_dynamic_pointer_cast<ProjectedCRS>(projObj);
-                if (projObjCrs) {
-                    return projObjCrs->derivingConversion();
+                if (projObjCrs && projObjCrs->getExtensionProj4().empty()) {
+                    return projObjCrs->derivingConversion()->shallowCloneNoCRS();
                 }
             } catch (const io::ParsingException &) {
             }
@@ -9471,8 +9471,8 @@ PROJStringParser::createFromPROJString(const std::string &projString) {
                     if (conversionStructure) {
                         auto projObjCrs =
                             nn_dynamic_pointer_cast<ProjectedCRS>(obj);
-                        if (projObjCrs) {
-                            return projObjCrs->derivingConversion();
+                        if (projObjCrs && projObjCrs->getExtensionProj4().empty()) {
+                            return projObjCrs->derivingConversion()->shallowCloneNoCRS();
                         }
                     }
                     else {

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -2964,6 +2964,7 @@ WKTParser::Private::buildConversion(const WKTNodeNNPtr &node,
         starts_with(methodName,  "PROJ-based operation method:")) {
         auto projString = methodName.substr(strlen("PROJ-based operation method: "));
         if (starts_with(projString, "+proj=")) {
+            projString += geodeticCRS->datum()->ellipsoid()->exportToPROJString(PROJStringFormatter::create().get());
             if (projString.find(" +type=crs") == std::string::npos) {
                 projString += " +type=crs";
             }
@@ -5243,6 +5244,7 @@ ConversionNNPtr JSONParser::buildConversion(const json &j, const GeodeticCRSNNPt
         starts_with(methodName,  "PROJ-based operation method:")) {
         auto projString = methodName.substr(strlen("PROJ-based operation method: "));
         if (starts_with(projString, "+proj=")) {
+            projString += geodeticCRS->datum()->ellipsoid()->exportToPROJString(PROJStringFormatter::create().get());
             if (projString.find(" +type=crs") == std::string::npos) {
                 projString += " +type=crs";
             }


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1890
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API

A lot of work to go on this one. It currently works, but not perfect:
```python
>>> from pyproj.crs.coordinate_operation import LambertCylindricalEqualAreaScaleConversion
>>> from pyproj.crs import ProjectedCRS
>>> pc = ProjectedCRS(conversion=LambertCylindricalEqualAreaScaleConversion(scale_factor_natural_origin=0.97))
>>> pc
<Projected CRS: {"$schema": "https://proj.org/schemas/v0.2/projjso ...>
Name: undefined
Axis Info [cartesian]:
- E[east]: Easting (metre)
- N[north]: Northing (metre)
Area of Use:
- undefined
Coordinate Operation:
- name: PROJ-based coordinate operation
- method: PROJ-based operation method: +proj=cea +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k_0=0.97
Datum: World Geodetic System 1984
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich

>>> pc.to_wkt()
'PROJCRS["undefined",BASEGEOGCRS["undefined",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ID["EPSG",6326]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8901]]],CONVERSION["PROJ-based coordinate operation",METHOD["PROJ-based operation method: +proj=cea +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k_0=0.97"]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]'
>>> from pyproj import CRS
>>> cc = CRS(pc.to_wkt())
>>> cc
<Projected CRS: PROJCRS["undefined",BASEGEOGCRS["undefined",DATUM[ ...>
Name: undefined
Axis Info [cartesian]:
- E[east]: Easting (metre)
- N[north]: Northing (metre)
Area of Use:
- undefined
Coordinate Operation:
- name: unknown
- method: Lambert Cylindrical Equal Area
Datum: World Geodetic System 1984
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich

>>> cc.to_wkt()
'PROJCRS["undefined",BASEGEOGCRS["undefined",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ID["EPSG",6326]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8901]]],CONVERSION["unknown",METHOD["Lambert Cylindrical Equal Area",ID["EPSG",9835]],PARAMETER["Latitude of 1st standard parallel",14.1153109848615,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]'

```

Progress will likely be slow as my c/c++ skills and knowledge of the PROJ codebase are at the beginner level. 

The functionality isn't exactly what I would like it to do. But, I am opening it up here in hopes of getting some tips/thoughts.

I have the function input modified to be:
```c++
ConversionNNPtr buildConversion(const json &j, const GeodeticCRSNNPtr &geodeticCRS);
```
As I would prefer to use this method (or something equivalent):
```c++
CRSNNPtr PROJStringParser::Private::buildProjectedCRS(
    int iStep, GeographicCRSNNPtr geogCRS, int iUnitConvert, int iAxisSwap)
```
Instead of:
```c++
PROJStringParser().createFromPROJString
```
As `GeographicCRSNNPtr` is used to determine the type of conversion selected in the PROJ string parsing. But, I don't completely understand how it works yet.

Thoughts? Other things I may be missing?