### PR TITLE
tests: force use of bash for proj_add_test_script_sh

### DIFF
--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -23,7 +23,7 @@ function(proj_add_test_script_sh SH_NAME BIN_USE)
     if(${TEST_OK})
       add_test(NAME "${testname}"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/data
-        COMMAND ${PROJECT_SOURCE_DIR}/test/cli/${SH_NAME}
+        COMMAND bash ${PROJECT_SOURCE_DIR}/test/cli/${SH_NAME}
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${${BIN_USE}}
       )
     set_tests_properties( ${testname}


### PR DESCRIPTION
I am trying to run the tests on an Alpine Linux system that uses ash shell by default. This causes all `proj_add_test_script_sh` tests to error with `system error -8 BAD COMMAND`. Installing bash is not a problem, but this commit is required to force it to use bash.