### PR TITLE
Increase CMake minimum version from 3.5 to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,14 @@
 ################################################################################
 # General settings
 ################################################################################
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 # For historic reasons, the CMake PROJECT-NAME is PROJ4
 project(PROJ4 LANGUAGES C CXX)
 set(PROJECT_INTERN_NAME PROJ)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.1)
-  cmake_policy(SET CMP0054 NEW)
-endif()
+# Only interpret if() arguments as variables or keywords when unquoted
+cmake_policy(SET CMP0054 NEW)
 
 # Set C++ version
 # Make CMAKE_CXX_STANDARD available as cache option overridable by user

--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -20,11 +20,6 @@ function(proj_add_test_script_sh SH_NAME BIN_USE)
       endif()
     endif()
 
-    if(CMAKE_VERSION VERSION_LESS 2.8.4)
-      set(TEST_OK 0)
-      message(STATUS "test with bash script need a cmake version >= 2.8.4")
-    endif()
-
     if(${TEST_OK})
       add_test(NAME "${testname}"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/data

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -143,7 +143,7 @@ Build requirements
 - SQLite3 >= 3.11 (headers, library and executable)
 - libtiff >= 4.0 (headers and library)
 - optional (but recommended): curl >= 7.29.0
-- GNU make for autotools build or CMake >= 3.5
+- GNU make for autotools build or CMake >= 3.9
 
 Autotools
 --------------------------------------------------------------------------------

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -376,10 +376,8 @@ if(ENABLE_LTO)
   endif()
 endif()
 
-if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-  target_include_directories(${PROJ_CORE_TARGET} INTERFACE
-    $<INSTALL_INTERFACE:${INCLUDEDIR}>)
-endif()
+target_include_directories(${PROJ_CORE_TARGET} INTERFACE
+  $<INSTALL_INTERFACE:${INCLUDEDIR}>)
 
 if(WIN32)
   set_target_properties(${PROJ_CORE_TARGET}


### PR DESCRIPTION
See discussion on [mail list](https://lists.osgeo.org/pipermail/proj/2020-January/009245.html), with [motion passed with PSC](https://lists.osgeo.org/pipermail/proj/2020-February/009324.html).

Also remove a few `if()`-blocks to support older CMake versions.

Supersedes #1542