### PR TITLE
Create README from README.md when calling `make`.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ ACLOCAL_AMFLAGS =	-I m4
 check-local:
 	cd test; $(MAKE) check
 
+all-local: README
 
 README: README.md
 	fgrep -v "[![" $< > $@


### PR DESCRIPTION
The README file was only generated when calling `make README`.

Closes: #1927