### PR TITLE
appveyor: Use sqlite tool from vcpkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,16 +26,9 @@ build_script:
   - bootstrap-vcpkg.bat
   - set PATH=%CD%;%PATH%
   - cd ..
-  - vcpkg install sqlite3:"%platform%"-windows
+  - vcpkg install sqlite3[core,tool]:"%platform%"-windows
   - vcpkg install tiff:"%platform%"-windows
   - vcpkg install curl:"%platform%"-windows
-  - set SQLITE3_BIN=%APPVEYOR_BUILD_FOLDER%\sqlite3\bin
-  - mkdir %SQLITE3_BIN%
-  - ps: |
-        appveyor DownloadFile https://sqlite.org/2018/sqlite-tools-win32-x86-3250100.zip
-        7z x sqlite-tools-win32-x86-3250100.zip
-  - copy "%APPVEYOR_BUILD_FOLDER%"\sqlite-tools-win32-x86-3250100\sqlite3.exe %SQLITE3_BIN%
-  - set PATH=%SQLITE3_BIN%;%PATH%
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%platform%" == "x64" SET BUILD_LIBPROJ_SHARED=ON
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%


### PR DESCRIPTION
Potential fix for the failing appveyor builds. The problems seems to be the sqlite3 tool not being properly found. This installs it using vcpkg, as detailed in the build guide in the docs. No idea if this actually works...