### PR TITLE
Don't print version when using PROJ4 from cmake

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -8,12 +8,6 @@
 #  @PROJECT_VARIANT_NAME@_BINARY_DIRS = /usr/local/bin
 #  @PROJECT_VARIANT_NAME@_VERSION = 4.9.1 (for example)
 
-message (STATUS "Reading ${CMAKE_CURRENT_LIST_FILE}")
-# @PROJECT_VARIANT_NAME@_VERSION is set by version file
-message (STATUS
-  "@PROJECT_VARIANT_NAME@ configuration, \
-version ${@PROJECT_VARIANT_NAME@_VERSION}")
-
 # Tell the user project where to find our headers and libraries
 get_filename_component (_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
 get_filename_component (_ROOT "${_DIR}/@PROJECT_ROOT_DIR@" ABSOLUTE)


### PR DESCRIPTION
This will declutter cmake output for PROJ4 users.

I use a few dozen libraries in my C++ project, and none of them print their version to stdout when I run cmake. I realise it may be useful when developing PROJ4 to have this message, but for users who may not even be depending on PROJ4 directly (e.g. indirectly via another library), it's a bit noisy.