### PR TITLE
Don't assume $HOME to be writable.

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1220,7 +1220,7 @@ std::string pj_context_get_user_writable_directory(PJ_CONTEXT *ctx,
             path = xdg_data_home;
         } else {
             const char *home = getenv("HOME");
-            if (home) {
+            if (home && access(home, W_OK) == 0) {
 #if defined(__MACH__) && defined(__APPLE__)
                 path = std::string(home) + "/Library/Application Support";
 #else


### PR DESCRIPTION
The read_grid_from_user_writable_directory test fails otherwise.

Fixes: #1933