### PR TITLE
Fix static linking (due to typo in pc)

### DIFF
--- a/proj.pc.in
+++ b/proj.pc.in
@@ -9,5 +9,5 @@ Description: Cartographic Projections Library.
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj
-Libs.Private: @SQLITE3_LIBS@ -lstdc++
+Libs.private: @SQLITE3_LIBS@ -lstdc++
 Cflags: -I${includedir}


### PR DESCRIPTION
This fixes: https://github.com/OSGeo/libgeotiff/issues/32

Before:

```sh
$ pkg-config --libs --static proj
# -LC:/rtools40/mingw64/lib -lproj
```

After:

```sh
$ pkg-config --libs --static proj
# -LC:/rtools40/mingw64/lib -lproj -lsqlite3 -lz -lstdc++
```