### PR TITLE
Install null grid file if available.

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CONFIG_FILES
 )
 
 set(PROJ_DICTIONARY
+  null
   world
   other.extra
   nad27

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -93,7 +93,7 @@ EXTRA_DIST = proj.ini GL27 nad.lst nad27 nad83 \
 install-data-local:
 	$(mkinstalldirs) $(DESTDIR)$(pkgdatadir)
 	@for gridfile in $(DATAPATH)/*.gsb $(DATAPATH)/*.gtx $(DATAPATH)/ntv1_can.dat dummy \
-	                 $(DATAPATH)/alaska $(DATAPATH)/conus $(DATAPATH)/hawaii \
+	                 $(DATAPATH)/alaska $(DATAPATH)/conus $(DATAPATH)/hawaii $(DATAPATH)/null \
 	                 $(DATAPATH)/prvi $(DATAPATH)/stgeorge $(DATAPATH)/stlrnc $(DATAPATH)/stpaul \
 	                 $(DATAPATH)/FL $(DATAPATH)/MD $(DATAPATH)/TN $(DATAPATH)/WI $(DATAPATH)/WO; do \
 	  if test "$$gridfile" != "dummy" -a -f "$$gridfile" ; then \


### PR DESCRIPTION
It is one of the files included in proj-datumgrid.

It was added to the proj source tree in 6.3.0, and removed in 7.0.0.

When the content of proj-datumgrid in unpacked in the data directory the null grid should be installed along with the others grids like alaska, conus, etc.