### PR TITLE
Alternative grid for JTSK - JTSK03 transform (EPSG:8364)

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -2110,3 +2110,19 @@ INSERT INTO grid_alternatives(original_grid_name,
                               0,
                               'proj-datumgrid-oceania',
                               NULL, NULL, NULL, NULL);
+
+-- Slovakia
+INSERT INTO grid_alternatives(original_grid_name,
+                              proj_grid_name,
+                              proj_grid_format,
+                              proj_method,
+                              inverse_direction,
+                              package_name,
+                              url, direct_download, open_license, directory)
+                      VALUES ('Slovakia_JTSK03_to_JTSK.LAS',
+                              'Slovakia_JTSK03_to_JTSK.gsb',
+                              'NTv2',
+                              'hgridshift',
+                              0,
+                              NULL,
+                              NULL, NULL, NULL, NULL);

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -2112,6 +2112,12 @@ INSERT INTO grid_alternatives(original_grid_name,
                               NULL, NULL, NULL, NULL);
 
 -- Slovakia
+--
+-- The definition of EPSG:8364 (JTSK03 to JTSK) uses NADCON method which is not supported by PROJ.
+-- UGKK (Slovak Geodetic and Cartographic Institute) provides also NTv2 grid file in addition
+-- to NADCON .las/.los files, so we define the NTv2 file here as an alternative.
+-- The file is available at https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk_ntv2.zip
+-- but it does not have a confirmed license yet, so it is not available in proj-datumgrid-europe for now
 INSERT INTO grid_alternatives(original_grid_name,
                               proj_grid_name,
                               proj_grid_format,

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -2116,19 +2116,21 @@ INSERT INTO grid_alternatives(original_grid_name,
 -- The definition of EPSG:8364 (JTSK03 to JTSK) uses NADCON method which is not supported by PROJ.
 -- UGKK (Slovak Geodetic and Cartographic Institute) provides also NTv2 grid file in addition
 -- to NADCON .las/.los files, so we define the NTv2 file here as an alternative.
--- The file is available at https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk_ntv2.zip
--- but it does not have a confirmed license yet, so it is not available in proj-datumgrid-europe for now
+-- The file is available online but it does not have a confirmed open license yet,
+-- so it is not available in proj-datumgrid-europe for now
 INSERT INTO grid_alternatives(original_grid_name,
                               proj_grid_name,
                               proj_grid_format,
                               proj_method,
                               inverse_direction,
                               package_name,
-                              url, direct_download, open_license, directory)
+                              url,
+                              direct_download, open_license, directory)
                       VALUES ('Slovakia_JTSK03_to_JTSK.LAS',
                               'Slovakia_JTSK03_to_JTSK.gsb',
                               'NTv2',
                               'hgridshift',
                               0,
                               NULL,
-                              NULL, NULL, NULL, NULL);
+                              'https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk_ntv2.zip',
+                              0, 0, NULL);


### PR DESCRIPTION
The definition of EPSG:8364 uses NADCON method for horizontal grid (.las/.los files).
UGKK (Slovak Geodetic and Cartographic Institute) provides NADCON .las/.los files here:
https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk.zip

Additionally UGKK also provides the same grid file in NTv2 format:
https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk_ntv2.zip

Unfortunately PROJ cannot use the NADCON method files, so this pull request adds the NTv2 grid file to the grid_alternatives table so that PROJ can automatically pick it up...

Note: this addition does not specify any `package_name` for the grid because it is not included in the proj datumgrids package due to missing license. I have already contacted UGKK to resolve this issue so that the grid file may be included as well, but it may take them some time to sort it out.

Currently to get this transformation working with PROJ/QGIS, there is documentation which involves some fragile steps like patching proj.db and srs.db (qgis):
https://www.geoportal.sk/files/gz/s-jtsk_jtsk03_v_qgis.pdf (sorry only in Slovak)

Without this change:
```
$ projinfo --summary -s EPSG:5513 -t EPSG:8352
Candidate operations found: 4
Note: using '--spatial-test intersects' would bring more results (7)
unknown id, Inverse of Krovak (Greenwich) + S-JTSK to ETRS89 (3) + ETRS89 to S-JTSK [JTSK03] (1) + Krovak (Greenwich), 0.501 m, Slovakia
unknown id, Inverse of Krovak (Greenwich) + S-JTSK to ETRS89 (3) + Inverse of S-JTSK [JTSK03] to ETRS89 (1) + Krovak (Greenwich), 0.501 m, Slovakia
unknown id, Inverse of Krovak (Greenwich) + Ballpark geographic offset from S-JTSK to S-JTSK [JTSK03] + Krovak (Greenwich), unknown accuracy, World, has ballpark transformation
unknown id, Inverse of Krovak (Greenwich) + Inverse of S-JTSK [JTSK03] to S-JTSK (1) + Krovak (Greenwich), 0.05 m, Slovakia, at least one grid missing
```
(even when the .las/.los grid file is available, the last option will be unable to generate proj string)

With this change:
```
$ projinfo --summary -s EPSG:5513 -t EPSG:8352
Candidate operations found: 1
unknown id, Inverse of Krovak (Greenwich) + Inverse of S-JTSK [JTSK03] to S-JTSK (1) + Krovak (Greenwich), 0.05 m, Slovakia
```
