### PR TITLE
validateParameters(): fix false-positive warning on Equidistant Cylindrical

### DIFF
--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -2129,6 +2129,14 @@ std::list<std::string> SingleOperation::validateParameters() const {
         }
 
         if (!opv) {
+            if ((methodEPSGCode == EPSG_CODE_METHOD_EQUIDISTANT_CYLINDRICAL ||
+                 methodEPSGCode ==
+                     EPSG_CODE_METHOD_EQUIDISTANT_CYLINDRICAL_SPHERICAL) &&
+                paramMapping == &paramLatitudeNatOrigin) {
+                // extension of EPSG used by GDAL/PROJ, so we should not
+                // warn on its absence.
+                continue;
+            }
             std::string msg("Cannot find expected parameter ");
             msg += paramMapping->wkt2_name;
             res.emplace_back(msg);

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -2090,6 +2090,8 @@ TEST(operation, createEquidistantCylindrical) {
         "PARAMETER[\"central_meridian\",2],\n"
         "PARAMETER[\"false_easting\",3],\n"
         "PARAMETER[\"false_northing\",4]");
+
+    EXPECT_TRUE(conv->validateParameters().empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -2127,6 +2129,8 @@ TEST(operation, createEquidistantCylindricalSpherical) {
         "PARAMETER[\"central_meridian\",2],\n"
         "PARAMETER[\"false_easting\",3],\n"
         "PARAMETER[\"false_northing\",4]");
+
+    EXPECT_TRUE(conv->validateParameters().empty());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
We required the 'Latitude of natural origin' parameter to be present,
but it is only a GDAL/PROJ specific thing, not a EPSG one.
