### PR TITLE
Add/update description for pkg-config and CMake, ignore proj.pc.in warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@
 ################################################################################
 cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
-project(PROJ LANGUAGES C CXX)
+project(PROJ
+  DESCRIPTION "PROJ coordinate transformation software library"
+  LANGUAGES C CXX
+)
 
 # Only interpret if() arguments as variables or keywords when unquoted
 cmake_policy(SET CMP0054 NEW)

--- a/configure.ac
+++ b/configure.ac
@@ -362,4 +362,7 @@ fi
 
 AC_CONFIG_FILES([proj.pc])
 
+dnl Ignore WARNING:  'proj.pc.in' seems to ignore the --datarootdir setting
+AC_DEFUN([AC_DATAROOTDIR_CHECKED])
+
 AC_OUTPUT

--- a/proj.pc.in
+++ b/proj.pc.in
@@ -4,8 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 datadir=@datadir@/@PACKAGE@
 
-Name: proj
-Description: Cartographic Projections Library.
+Name: PROJ
+Description: Coordinate transformation software library
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj


### PR DESCRIPTION
This PR adds or updates the description string based on the title in `CITATION`.

The [`PROJECT_DESCRIPTION` variable](https://cmake.org/cmake/help/v3.9/variable/PROJECT_DESCRIPTION.html) is new since CMake 3.9.

Also, clear up an annoyance with `./configure`, based on [autoconf's docs](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Changed-Directory-Variables.html), ignore:
> WARNING:  'proj.pc.in' seems to ignore the --datarootdir setting