### PR TITLE
[Backport 7.0] CMake: rename BUILD_LIBPROJ_SHARED to BUILD_SHARED_LIBS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,9 +30,9 @@ build_script:
   - vcpkg install tiff:"%platform%"-windows
   - vcpkg install curl:"%platform%"-windows
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
-  - if "%platform%" == "x64" SET BUILD_LIBPROJ_SHARED=ON
+  - if "%platform%" == "x64" SET BUILD_SHARED_LIBS=ON
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
-  - if "%platform%" == "x86" SET BUILD_LIBPROJ_SHARED=OFF
+  - if "%platform%" == "x86" SET BUILD_SHARED_LIBS=OFF
   - echo "%VS_FULL%"
 #
   - cd %APPVEYOR_BUILD_FOLDER%\data
@@ -42,7 +42,7 @@ build_script:
   - mkdir %PROJ_BUILD%
   - cd %PROJ_BUILD%
   - set PROJ_DIR=%APPVEYOR_BUILD_FOLDER%\proj_dir
-  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBPROJ_SHARED="%BUILD_LIBPROJ_SHARED%" -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DCMAKE_TOOLCHAIN_FILE=C:/projects/proj/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX="%PROJ_DIR%"
+  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS="%BUILD_SHARED_LIBS%" -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DCMAKE_TOOLCHAIN_FILE=C:/projects/proj/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX="%PROJ_DIR%"
   - cmake --build . --config Release --target install
   - copy c:\projects\proj\vcpkg\installed\"%platform%"-windows\bin\*.dll %PROJ_DIR%\bin
   - dir %PROJ_DIR%\bin

--- a/src/bin_cct.cmake
+++ b/src/bin_cct.cmake
@@ -14,6 +14,6 @@ target_compile_options(cct PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS cct
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(cct PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_cs2cs.cmake
+++ b/src/bin_cs2cs.cmake
@@ -13,6 +13,6 @@ target_compile_options(cs2cs PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS cs2cs
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(cs2cs PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_geod.cmake
+++ b/src/bin_geod.cmake
@@ -15,6 +15,6 @@ target_compile_options(geod PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS geod
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(geod PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_geodtest.cmake
+++ b/src/bin_geodtest.cmake
@@ -10,6 +10,6 @@ target_compile_options(geodtest PRIVATE ${PROJ_CXX_WARN_FLAGS})
 # Do not install, instead run as a test
 add_test(NAME geodesic-test COMMAND geodtest)
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(geodtest PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_gie.cmake
+++ b/src/bin_gie.cmake
@@ -14,6 +14,6 @@ target_compile_options(gie PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS gie
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(gie PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_proj.cmake
+++ b/src/bin_proj.cmake
@@ -16,6 +16,6 @@ target_compile_options(binproj PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS binproj
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(binproj PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_projinfo.cmake
+++ b/src/bin_projinfo.cmake
@@ -12,6 +12,6 @@ target_compile_options(binprojinfo PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS binprojinfo
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(binprojinfo PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/bin_projsync.cmake
+++ b/src/bin_projsync.cmake
@@ -11,6 +11,6 @@ target_compile_options(bin_projsync PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS bin_projsync
   RUNTIME DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(bin_projsync PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -4,21 +4,20 @@ message(STATUS "Configuring proj library:")
 ### SWITCH BETWEEN STATIC OR SHARED LIBRARY###
 ##############################################
 
-# default config, shared on unix and static on Windows
-if(UNIX)
-  set(BUILD_LIBPROJ_SHARED_DEFAULT ON)
-endif()
-if(WIN32)
-  set(BUILD_LIBPROJ_SHARED_DEFAULT OFF)
-endif()
-option(BUILD_LIBPROJ_SHARED
-  "Build libproj library shared." ${BUILD_LIBPROJ_SHARED_DEFAULT})
-if(BUILD_LIBPROJ_SHARED)
-  set(PROJ_LIBRARY_TYPE SHARED)
-else()
-  set(PROJ_LIBRARY_TYPE STATIC)
+# Support older option, to be removed by PROJ 8.0
+if(DEFINED BUILD_LIBPROJ_SHARED)
+  message(DEPRECATION
+    "BUILD_LIBPROJ_SHARED has been replaced with BUILD_SHARED_LIBS")
+  set(BUILD_SHARED_LIBS ${BUILD_LIBPROJ_SHARED})
 endif()
 
+# default config is shared, except static on Windows
+set(BUILD_SHARED_LIBS_DEFAULT ON)
+if(WIN32)
+  set(BUILD_SHARED_LIBS_DEFAULT OFF)
+endif()
+option(BUILD_SHARED_LIBS
+  "Build PROJ library shared." ${BUILD_SHARED_LIBS_DEFAULT})
 
 option(USE_THREAD "Build libproj with thread/mutex support " ON)
 if(NOT USE_THREAD)
@@ -321,7 +320,6 @@ proj_target_output_name(${PROJ_CORE_TARGET} PROJ_CORE_TARGET_OUTPUT_NAME)
 
 add_library(
   ${PROJ_CORE_TARGET}
-  ${PROJ_LIBRARY_TYPE}
   ${ALL_LIBPROJ_SOURCES}
   ${ALL_LIBPROJ_HEADERS}
   ${PROJ_RESOURCES}
@@ -416,7 +414,7 @@ if(CURL_FOUND)
   target_link_libraries(${PROJ_CORE_TARGET} ${CURL_LIBRARY})
 endif()
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(${PROJ_CORE_TARGET}
     PRIVATE PROJ_MSVC_DLL_EXPORT=1)
 endif()
@@ -441,5 +439,5 @@ endif()
 ##############################################
 print_variable(PROJ_CORE_TARGET)
 print_variable(PROJ_CORE_TARGET_OUTPUT_NAME)
-print_variable(PROJ_LIBRARY_TYPE)
+print_variable(BUILD_SHARED_LIBS)
 print_variable(PROJ_LIBRARIES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,6 @@ proj_add_gie_test("GIGS-5208" "gigs/5208.gie")
 #SET(TEST_MAIN_SRC test_main.cpp)
 #set(TEST_MAIN_LIBRARIES test_main)
 #add_library( ${TEST_MAIN_LIBRARIES}
-#                    ${PROJ_LIBRARY_TYPE}
 #                    ${TEST_MAIN_SRC}
 #                    ${CATCH2_INCLUDE}  )
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()  # USE_EXTERNAL_GTEST
 # Build PROJ unit tests
 #
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   add_definitions(-DPROJ_MSVC_DLL_IMPORT=1)
 endif()
 
@@ -104,7 +104,7 @@ add_test(NAME proj_context_test COMMAND proj_context_test)
 set_property(TEST proj_context_test
         PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
 
-if(MSVC AND BUILD_LIBPROJ_SHARED)
+if(MSVC AND BUILD_SHARED_LIBS)
   # ph_phi2_test not compatible of a .dll build
 else()
   add_executable(pj_phi2_test


### PR DESCRIPTION
Backport 2336ac77b53068b7a7d5618764a13a52c428a332 from #1962

(This was manually backported; "The backport to 7.0 failed: The process 'git' failed with exit code 128")