### PR TITLE
Add alternative grid for JTSK - JTSK03 transform (EPSG:8364)

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -176,6 +176,14 @@ VALUES
 ('Icegeoid_ISN2016.gtx','is_lmi_Icegeoid_ISN2016.tif','Icegeoid_ISN2016.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/is_lmi_Icegeoid_ISN2016.tif',1,1,NULL),
 -- New Zealand grid shift models.
 ('auckland-1946-to-nzvd2016-conversion.csv','nz_linz_auckht1946-nzvd2016.tif','auckht1946-nzvd2016.gtx','GTiff','vgridshift',0,NULL,'https://cdn.proj.org/nz_linz_auckht1946-nzvd2016.tif',1,1,NULL),
+-- Slovakia
+--
+-- The definition of EPSG:8364 (JTSK03 to JTSK) uses NADCON method which is not supported by PROJ.
+-- UGKK (Slovak Geodetic and Cartographic Institute) provides also NTv2 grid file in addition
+-- to NADCON .las/.los files, so we define the NTv2 file here as an alternative.
+-- The file is available online but it does not have a confirmed open license yet,
+-- so it is not available in proj-datumgrid-europe for now
+('Slovakia_JTSK03_to_JTSK.LAS', 'Slovakia_JTSK03_to_JTSK.gsb', 'Slovakia_JTSK03_to_JTSK.gsb', 'NTv2', 'hgridshift', 0, NULL, 'https://www.geoportal.sk/files/gz/slovakia_jtsk03_to_jtsk_ntv2.zip', 0, 0, NULL),
 -- Superseded entries
 ('bluff-1955-to-nzvd2016-conversion.csv','nz_linz_blufht1955-nzvd2016.tif','blufht1955-nzvd2016.gtx','GTiff','vgridshift',0,NULL,'https://cdn.proj.org/nz_linz_blufht1955-nzvd2016.tif',1,1,NULL),
 ('dunedin-1958-to-nzvd2016-conversion.csv','nz_linz_duneht1958-nzvd2016.tif','duneht1958-nzvd2016.gtx','GTiff','vgridshift',0,NULL,'https://cdn.proj.org/nz_linz_duneht1958-nzvd2016.tif',1,1,NULL),


### PR DESCRIPTION
This is port of #1941 to master.

I was wondering what to put to `proj_grid_name` column - according to the convention it should be `sk_ugkk_jtsk03-jtsk.tif`, but that would not work as PROJ would try to use that file name, and NULL was not allowed either, so I used the original `Slovakia_JTSK03_to_JTSK.gsb` file name - hopefully it's fine like that.

I see there is also 7.0 branch - should I port it there as well?