### PR TITLE
fix sql in method createCoordinateReferenceSystem  of factory.cpp

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2659,7 +2659,7 @@ AuthorityFactory::createCoordinateReferenceSystem(const std::string &code,
         return NN_NO_CHECK(crs);
     }
     auto res = d->runWithCodeParam(
-        "SELECT type FROM crs_view WHERE auth_name = ? AND code = ?", code);
+        "SELECT type FROM crs_view WHERE code = ?", code);
     if (res.empty()) {
         throw NoSuchAuthorityCodeException("crs not found", d->authority(),
                                            code);


### PR DESCRIPTION
obviously, data view "crs_view" have "auth_name" and "code" ,the two field value are not same;