### PR TITLE
Fix bad copy&replace pattern on HEALPix and rHEALPix projection names

### DIFF
--- a/src/projections/healpix.cpp
+++ b/src/projections/healpix.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Project: PROJ.4
- * Purpose: Implementation of the HEAPJ_LPix and rHEAPJ_LPix projections.
+ * Purpose: Implementation of the HEALPix and rHEALPix projections.
  *          For background see <http://code.scenzgrid.org/index.php/p/scenzgrid-py/source/tree/master/docs/rhealpix_dggs.pdf>.
  * Authors: Alex Raichev (raichev@cs.auckland.ac.nz)
  *          Michael Speth (spethm@landcareresearch.co.nz)
@@ -36,8 +36,8 @@
 #include "proj.h"
 #include "proj_internal.h"
 
-PROJ_HEAD(healpix, "HEAPJ_LPix") "\n\tSph&Ell\n\trot_xy=";
-PROJ_HEAD(rhealpix, "rHEAPJ_LPix") "\n\tSph&Ell\n\tnorth_square= south_square=";
+PROJ_HEAD(healpix, "HEALPix") "\n\tSph&Ell\n\trot_xy=";
+PROJ_HEAD(rhealpix, "rHEALPix") "\n\tSph&Ell\n\tnorth_square= south_square=";
 
 /* Matrix for counterclockwise rotation by pi/2: */
 # define R1 {{ 0,-1},{ 1, 0}}
@@ -159,10 +159,10 @@ static int pnpoly(int nvert, double vert[][2], double testx, double testy) {
 
 /**
  * Return 1 if (x, y) lies in (the interior or boundary of) the image of the
- * HEAPJ_LPix projection (in case proj=0) or in the image the rHEAPJ_LPix projection
+ * HEALPix projection (in case proj=0) or in the image the rHEALPix projection
  * (in case proj=1), and return 0 otherwise.
- * @param north_square the position of the north polar square (rHEAPJ_LPix only)
- * @param south_square the position of the south polar square (rHEAPJ_LPix only)
+ * @param north_square the position of the north polar square (rHEALPix only)
+ * @param south_square the position of the south polar square (rHEALPix only)
  **/
 static int in_image(double x, double y, int proj, int north_square,
                     int south_square) {
@@ -243,7 +243,7 @@ static double auth_lat(PJ *P, double alpha, int inverse) {
 
 
 /**
- * Return the HEAPJ_LPix projection of the longitude-latitude point lp on
+ * Return the HEALPix projection of the longitude-latitude point lp on
  * the unit sphere.
 **/
 static PJ_XY healpix_sphere(PJ_LP lp) {
@@ -346,10 +346,10 @@ static void dot_product(const double a[2][2], const double b[2], double *ret) {
 /**
  * Return the number of the polar cap, the pole point coordinates, and
  * the region that (x, y) lies in.
- * If inverse=0, then assume (x,y) lies in the image of the HEAPJ_LPix
+ * If inverse=0, then assume (x,y) lies in the image of the HEALPix
  * projection of the unit sphere.
  * If inverse=1, then assume (x,y) lies in the image of the
- * (north_square, south_square)-rHEAPJ_LPix projection of the unit sphere.
+ * (north_square, south_square)-rHEALPix projection of the unit sphere.
  **/
 static CapMap get_cap(double x, double y, int north_square, int south_square,
                       int inverse) {
@@ -404,8 +404,8 @@ static CapMap get_cap(double x, double y, int north_square, int south_square,
             capmap.cn = 0;
             return capmap;
         }
-        /* Polar Region, find the HEAPJ_LPix polar cap number that
-           x, y moves to when rHEAPJ_LPix polar square is disassembled. */
+        /* Polar Region, find the HEALPix polar cap number that
+           x, y moves to when rHEALPix polar square is disassembled. */
         if (capmap.region == CapMap::north) {
             if (y >= -x - M_FORTPI - EPS && y < x + 5*M_FORTPI - EPS) {
                 capmap.cn = (north_square + 1) % 4;
@@ -433,7 +433,7 @@ static CapMap get_cap(double x, double y, int north_square, int south_square,
 
 
 /**
- * Rearrange point (x, y) in the HEAPJ_LPix projection by
+ * Rearrange point (x, y) in the HEALPix projection by
  * combining the polar caps into two polar squares.
  * Put the north polar square in position north_square and
  * the south polar square in position south_square.
@@ -519,7 +519,7 @@ static PJ_LP s_healpix_inverse(PJ_XY xy, PJ *P) { /* sphere */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     xy = rotate(xy, Q->rot_xy);
 
-    /* Check whether (x, y) lies in the HEAPJ_LPix image */
+    /* Check whether (x, y) lies in the HEALPix image */
     if (in_image(xy.x, xy.y, 0, 0, 0) == 0) {
         PJ_LP lp;
         lp.lam = HUGE_VAL;
@@ -536,7 +536,7 @@ static PJ_LP e_healpix_inverse(PJ_XY xy, PJ *P) { /* ellipsoid */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     xy = rotate(xy, Q->rot_xy);
 
-    /* Check whether (x, y) lies in the HEAPJ_LPix image. */
+    /* Check whether (x, y) lies in the HEALPix image. */
     if (in_image(xy.x, xy.y, 0, 0, 0) == 0) {
         lp.lam = HUGE_VAL;
         lp.phi = HUGE_VAL;
@@ -569,7 +569,7 @@ static PJ_XY e_rhealpix_forward(PJ_LP lp, PJ *P) { /* ellipsoid */
 static PJ_LP s_rhealpix_inverse(PJ_XY xy, PJ *P) { /* sphere */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
-    /* Check whether (x, y) lies in the rHEAPJ_LPix image. */
+    /* Check whether (x, y) lies in the rHEALPix image. */
     if (in_image(xy.x, xy.y, 1, Q->north_square, Q->south_square) == 0) {
         PJ_LP lp;
         lp.lam = HUGE_VAL;
@@ -586,7 +586,7 @@ static PJ_LP e_rhealpix_inverse(PJ_XY xy, PJ *P) { /* ellipsoid */
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
     PJ_LP lp = {0.0,0.0};
 
-    /* Check whether (x, y) lies in the rHEAPJ_LPix image. */
+    /* Check whether (x, y) lies in the rHEALPix image. */
     if (in_image(xy.x, xy.y, 1, Q->north_square, Q->south_square) == 0) {
         lp.lam = HUGE_VAL;
         lp.phi = HUGE_VAL;


### PR DESCRIPTION
Affects output of 'proj -l'
