### PR TITLE
Remove occurences of deprecated PROJ.4 syntax

### DIFF
--- a/docs/source/operations/projections/cass.rst
+++ b/docs/source/operations/projections/cass.rst
@@ -40,12 +40,12 @@ The Cassini-Soldner was also used for the detailed mapping of many German states
 
 Example using EPSG 30200 (Trinidad 1903, units in clarke's links)::
 
-    $ echo 0.17453293 -1.08210414 | proj +proj=cass +lat_0=10.44166666666667 +lon_0=-61.33333333333334 +x_0=86501.46392051999 +y_0=65379.0134283 +a=6378293.645208759 +b=6356617.987679838 +to_meter=0.201166195164 +no_defs
+    $ echo 0.17453293 -1.08210414 | proj +proj=cass +lat_0=10.44166666666667 +lon_0=-61.33333333333334 +x_0=86501.46392051999 +y_0=65379.0134283 +a=6378293.645208759 +b=6356617.987679838 +to_meter=0.201166195164
     66644.94	82536.22
 
 Example using EPSG 3068 (Soldner Berlin)::
 
-    $ echo 13.5 52.4 | proj +proj=cass +lat_0=52.41864827777778 +lon_0=13.62720366666667 +x_0=40000 +y_0=10000 +ellps=bessel +datum=potsdam +units=m +no_defs
+    $ echo 13.5 52.4 | proj +proj=cass +lat_0=52.41864827777778 +lon_0=13.62720366666667 +x_0=40000 +y_0=10000 +ellps=bessel +units=m
     31343.05	7932.76
 
 Options

--- a/docs/source/operations/projections/ccon.rst
+++ b/docs/source/operations/projections/ccon.rst
@@ -120,7 +120,7 @@ For ATPOL to WGS84 test, run the following script:
 ::
 
    #!/bin/bash
-   cat << EOF | src/cs2cs -v -f "%E" +proj=ccon +lat_1=52 +lat_0=52 +lon_0=19 +axis=esu +a=6390000 +x_0=330000 +y_0=-350000 +to +proj=longlat +datum=WGS84 +no_defs
+   cat << EOF | src/cs2cs -v -f "%E" +proj=ccon +lat_1=52 +lat_0=52 +lon_0=19 +axis=esu +a=6390000 +x_0=330000 +y_0=-350000 +to +proj=longlat
    0 0
    0 700000
    700000 0
@@ -142,7 +142,7 @@ Analogous script can be run for reverse test:
 
 ::
 
-   cat << EOF  | src/cs2cs -v -f "%E" +proj=longlat +datum=WGS84 +no_defs +to +proj=ccon +lat_1=52 +lat_0=52 +lon_0=19 +axis=esu +a=6390000 +x_0=330000 +y_0=-350000
+   cat << EOF  | src/cs2cs -v -f "%E" +proj=longlat +to +proj=ccon +lat_1=52 +lat_0=52 +lon_0=19 +axis=esu +a=6390000 +x_0=330000 +y_0=-350000
    24 55
    15 49
    24 49

--- a/docs/source/operations/projections/eqc.rst
+++ b/docs/source/operations/projections/eqc.rst
@@ -63,7 +63,7 @@ The following table gives special cases of the cylindrical equidistant projectio
 
 Example using EPSG 32662 (WGS84 Plate Carrée)::
 
-    $ echo 2 47 | proj +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+    $ echo 2 47 | proj +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m
     222638.98       5232016.07
 
 Example using Plate Carrée projection with true scale at latitude 30° and central meridian 90°W::

--- a/docs/source/operations/projections/gall.rst
+++ b/docs/source/operations/projections/gall.rst
@@ -45,12 +45,12 @@ Unlike the Mercator, the Gall shows the poles as lines running across the top an
 
 Example using Gall Stereographical  ::
 
-    $ echo 9 51 | proj +proj=gall +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+    $ echo 9 51 | proj +proj=gall +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m
     708432.90	5193386.36
 
 Example using Gall Stereographical (Central meridian 90°W) ::
 
-    $ echo 9 51 | proj +proj=gall +lon_0=90w +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+    $ echo 9 51 | proj +proj=gall +lon_0=90w +x_0=0 +y_0=0 +ellps=WGS84 +units=m
     7792761.91	5193386.36
 
 Parameters

--- a/docs/source/operations/projections/tmerc.rst
+++ b/docs/source/operations/projections/tmerc.rst
@@ -62,12 +62,12 @@ The following table gives special cases of the Transverse Mercator projection.
 
 Example using Gauss-Kruger on Germany area (aka EPSG:31467) ::
 
-    $ echo 9 51 | proj +proj=tmerc +lat_0=0 +lon_0=9 +k_0=1 +x_0=3500000 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs
+    $ echo 9 51 | proj +proj=tmerc +lat_0=0 +lon_0=9 +k_0=1 +x_0=3500000 +y_0=0 +ellps=bessel +units=m
     3500000.00	5651505.56
 
 Example using Gauss Boaga on Italy area (EPSG:3004) ::
 
-    $ echo 15 42 | proj +proj=tmerc +lat_0=0 +lon_0=15 +k_0=0.9996 +x_0=2520000 +y_0=0 +ellps=intl +units=m +no_defs
+    $ echo 15 42 | proj +proj=tmerc +lat_0=0 +lon_0=15 +k_0=0.9996 +x_0=2520000 +y_0=0 +ellps=intl +units=m
     2520000.00	4649858.60
 
 Parameters


### PR DESCRIPTION
+no_defs and +datum has no effect on the behaviour of proj, so can be
left out in these examples in the docs. +no_defs in rare occasions would
have had an effect in older PROJ versions but not from PROJ 6 and
onwards. +datum has ever only been honoured by cs2cs and pj_transform().

Fixes #2017