### PR TITLE
Map ESRI Transverse_Mercator_Complex to Transverse Mercator

### DIFF
--- a/include/proj/internal/esri_projection_mappings.hpp
+++ b/include/proj/internal/esri_projection_mappings.hpp
@@ -114,6 +114,19 @@ static const ESRIParamMapping paramsESRI_Transverse_Mercator[] = {
      EPSG_CODE_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN, "0.0", false},
     {nullptr, nullptr, 0, "0.0", false}};
 
+static const ESRIParamMapping paramsESRI_Transverse_Mercator_Complex[] = {
+    {"False_Easting", EPSG_NAME_PARAMETER_FALSE_EASTING,
+     EPSG_CODE_PARAMETER_FALSE_EASTING, "0.0", false},
+    {"False_Northing", EPSG_NAME_PARAMETER_FALSE_NORTHING,
+     EPSG_CODE_PARAMETER_FALSE_NORTHING, "0.0", false},
+    {"Central_Meridian", EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN,
+     EPSG_CODE_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN, "0.0", false},
+    {"Scale_Factor", EPSG_NAME_PARAMETER_SCALE_FACTOR_AT_NATURAL_ORIGIN,
+     EPSG_CODE_PARAMETER_SCALE_FACTOR_AT_NATURAL_ORIGIN, "0.0", false},
+    {"Latitude_Of_Origin", EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN,
+     EPSG_CODE_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN, "0.0", false},
+    {nullptr, nullptr, 0, "0.0", false}};
+
 static const ESRIParamMapping paramsESRI_Albers[] = {
     {"False_Easting", EPSG_NAME_PARAMETER_EASTING_FALSE_ORIGIN,
      EPSG_CODE_PARAMETER_EASTING_FALSE_ORIGIN, "0.0", false},
@@ -901,6 +914,9 @@ static const ESRIMethodMapping esriMappings[] = {
      EPSG_CODE_METHOD_TRANSVERSE_MERCATOR, paramsESRI_Gauss_Kruger},
     {"Transverse_Mercator", EPSG_NAME_METHOD_TRANSVERSE_MERCATOR,
      EPSG_CODE_METHOD_TRANSVERSE_MERCATOR, paramsESRI_Transverse_Mercator},
+    {"Transverse_Mercator_Complex", EPSG_NAME_METHOD_TRANSVERSE_MERCATOR,
+     EPSG_CODE_METHOD_TRANSVERSE_MERCATOR,
+     paramsESRI_Transverse_Mercator_Complex},
     {"Albers", EPSG_NAME_METHOD_ALBERS_EQUAL_AREA,
      EPSG_CODE_METHOD_ALBERS_EQUAL_AREA, paramsESRI_Albers},
     {"Sinusoidal", PROJ_WKT2_NAME_METHOD_SINUSOIDAL, 0, paramsESRI_Sinusoidal},

--- a/scripts/build_esri_projection_mapping.py
+++ b/scripts/build_esri_projection_mapping.py
@@ -86,6 +86,15 @@ config_str = """
         - Scale_Factor: EPSG_NAME_PARAMETER_SCALE_FACTOR_AT_NATURAL_ORIGIN
         - Latitude_Of_Origin: EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN
 
+- Transverse_Mercator_Complex: # This is likely PROJ etmerc method
+    WKT2_name: EPSG_NAME_METHOD_TRANSVERSE_MERCATOR
+    Params:
+        - False_Easting: EPSG_NAME_PARAMETER_FALSE_EASTING
+        - False_Northing: EPSG_NAME_PARAMETER_FALSE_NORTHING
+        - Central_Meridian: EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN
+        - Scale_Factor: EPSG_NAME_PARAMETER_SCALE_FACTOR_AT_NATURAL_ORIGIN
+        - Latitude_Of_Origin: EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN
+
 - Albers:
     WKT2_name: EPSG_NAME_METHOD_ALBERS_EQUAL_AREA
     Params:
@@ -680,7 +689,6 @@ config_str = """
 # Fuller
 # Berghaus_Star
 # Cube
-# Transverse_Mercator_Complex
 # Robinson_ARC_INFO
 # Local
 # Equidistant_Cylindrical_Auxiliary_Sphere

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -4344,6 +4344,21 @@ static const struct {
          {"False northing", 2},
      }},
 
+    {"Transverse_Mercator_Complex",
+     {{"False_Easting", 1},
+      {"False_Northing", 2},
+      {"Central_Meridian", 3},
+      {"Scale_Factor", 4},
+      {"Latitude_Of_Origin", 5}},
+     "Transverse Mercator",
+     {
+         {"Latitude of natural origin", 5},
+         {"Longitude of natural origin", 3},
+         {"Scale factor at natural origin", 4},
+         {"False easting", 1},
+         {"False northing", 2},
+     }},
+
     {"Albers",
      {{"False_Easting", 1},
       {"False_Northing", 2},


### PR DESCRIPTION
According to https://gis.stackexchange.com/questions/226679/complex-utm-projection
it is highly likely that Transverse_Mercator_Complex corresponds to our
extended/enhanced/Poder-Engsager transverse mercator method (etmerc), or something
similarly precise. So we can map that to the standard Transverse Mercator
method, since etmerc is used for it.
