### PR TITLE
Speed-up inverse merc (spherical and ellipsoidal formulations) for coordinates with same northing

### DIFF
--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -3233,10 +3233,12 @@ expect  -222638.981586547 -110579.965218249
 direction inverse
 accept  200 100
 expect  0.001796631 0.000904369
-accept  200 -100
-expect  0.001796631 -0.000904369
+# Make sure this test immediately follows the previous one so they use the same
+# northing, to test the related optimization
 accept  -200 100
 expect  -0.001796631 0.000904369
+accept  200 -100
+expect  0.001796631 -0.000904369
 accept  -200 -100
 expect  -0.001796631 -0.000904369
 
@@ -3256,10 +3258,12 @@ expect  -223402.144255274 -111706.743574944
 direction inverse
 accept  200 100
 expect  0.001790493 0.000895247
-accept  200 -100
-expect  0.001790493 -0.000895247
+# Make sure this test immediately follows the previous one so they use the same
+# northing, to test the related optimization
 accept  -200 100
 expect  -0.001790493 0.000895247
+accept  200 -100
+expect  0.001790493 -0.000895247
 accept  -200 -100
 expect  -0.001790493 -0.000895247
 


### PR DESCRIPTION
Same rationale as in https://github.com/OSGeo/PROJ/pull/2043
When converting by batch of coordinates of 2000 consecutive same northings,
the speed-up over master is 7 times for ellipsoidal formulation, and
about 40% for the spherical formulation (and thus webmerc)
On top of #2052, the speed-up for ellipsoidal would also be about 40%
