### PR TITLE
Autotools/pkg-conf: Define datarootdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -360,7 +360,4 @@ fi
 
 AC_CONFIG_FILES([proj.pc])
 
-dnl Ignore WARNING:  'proj.pc.in' seems to ignore the --datarootdir setting
-AC_DEFUN([AC_DATAROOTDIR_CHECKED])
-
 AC_OUTPUT

--- a/proj.pc.in
+++ b/proj.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+datarootdir=@datarootdir@
 datadir=@datadir@/@PACKAGE@
 
 Name: PROJ


### PR DESCRIPTION
See more info [here](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Changed-Directory-Variables.html).

Closes #2064