### PR TITLE
Add post-install checks for CMake and Autotools/pkg-config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
   # update vcpkg
   - cmd: |
       cd "C:\Tools\vcpkg"
-      git pull
+      git pull > nul
       .\bootstrap-vcpkg.bat
       cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sqlite3[core,tool]:"%platform%"-windows
@@ -52,6 +52,7 @@ test_script:
   - cd %PROJ_BUILD%
   - ctest -V -C Release
   - set PATH=%PROJ_DIR%\bin;%PATH%
+  - call %APPVEYOR_BUILD_FOLDER%\test\postinstall\test_cmake.bat %PROJ_DIR%
   - proj
 
 deploy: off

--- a/test/postinstall/test_cmake.bat
+++ b/test/postinstall/test_cmake.bat
@@ -1,0 +1,40 @@
+@echo off
+:: Post-install tests with CMake
+::
+:: First required argument is the installed prefix, which
+:: is used to set CMAKE_PREFIX_PATH
+
+echo Running post-install tests with CMake
+
+set CMAKE_PREFIX_PATH=%1
+if not defined CMAKE_PREFIX_PATH (
+    echo First positional argument CMAKE_PREFIX_PATH required
+    exit /B 1
+)
+
+echo CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%
+
+cd %~dp0
+
+cd testappprojinfo
+del /f /q build 2> nul
+
+:: Check CMake project name PROJ
+md build
+cd build
+cmake -G "%VS_FULL%" -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DUSE_PROJ_NAME=PROJ ..  || exit /B 2
+cmake --build . --config Release || exit /B 3
+ctest --build-config Release -VV || exit /B 4
+cd ..
+del /f /q build
+
+:: Check legacy CMake project name PROJ4
+md build
+cd build
+cmake -G "%VS_FULL%" -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DUSE_PROJ_NAME=PROJ4 .. || exit /B 2
+cmake --build . --config Release || exit /B 3
+ctest --build-config Release -VV || exit /B 4
+cd ..
+del /f /q build
+
+cd ..

--- a/test/postinstall/test_cmake.sh
+++ b/test/postinstall/test_cmake.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Post-install tests with CMake
+#
+# First required argument is the installed prefix, which
+# is used to set CMAKE_PREFIX_PATH
+
+set -e
+
+echo "Running post-install tests with CMake"
+
+CMAKE_PREFIX_PATH=$1
+if [ -z "$CMAKE_PREFIX_PATH" ]; then
+    echo "First positional argument CMAKE_PREFIX_PATH required"
+    exit 1
+fi
+
+echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH"
+
+cd $(dirname $0)
+
+cd testappprojinfo
+rm -rf build
+
+# Check CMake project name PROJ
+mkdir build
+cd build
+cmake -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DUSE_PROJ_NAME=PROJ -DCMAKE_VERBOSE_MAKEFILE=ON ..
+cmake --build .
+ctest -VV .
+cd ..
+rm -rf build
+
+# Check legacy CMake project name PROJ4
+mkdir build
+cd build
+cmake -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DUSE_PROJ_NAME=PROJ4 -DCMAKE_VERBOSE_MAKEFILE=ON ..
+cmake --build .
+ctest -VV .
+cd ..
+rm -rf build
+
+cd ..

--- a/test/postinstall/test_pkg-config.sh
+++ b/test/postinstall/test_pkg-config.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# Post-install tests with pkg-config
+#
+# First required argument is the installed prefix, which
+# is used to set PKG_CONFIG_PATH and LD_LIBRARY_PATH
+
+set -e
+
+echo "Running post-install tests with pkg-config"
+
+prefix=$1
+if [ -z "$prefix" ]; then
+    echo "First positional argument to the the installed prefix is required"
+    exit 1
+fi
+
+export PKG_CONFIG_PATH=$prefix/lib/pkgconfig
+export LD_LIBRARY_PATH=$prefix/lib
+
+echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
+
+PKG_CONFIG_MODVERSION=$(pkg-config proj --modversion)
+echo "pkg-config proj --modversion: $PKG_CONFIG_MODVERSION"
+PKG_CONFIG_DATADIR=$(pkg-config proj --variable=datadir)
+echo "pkg-config proj --variable=datadir: $PKG_CONFIG_DATADIR"
+
+UNAME=$(uname)
+case $UNAME in
+  Darwin*)
+    alias ldd="otool -L" ;;
+  Linux*)
+    ;;
+  *)
+    echo "no ldd equivalent found for UNAME=$UNAME"
+    exit 1 ;;
+esac
+
+cd $(dirname $0)
+
+PROGRAM=testappprojinfo
+cd $PROGRAM
+make
+
+# Run tests from shell, count any errors
+ERRORS=0
+
+LDD_OUTPUT=$(ldd ./$PROGRAM | grep proj)
+LDD_SUBSTR=$LD_LIBRARY_PATH/libproj.
+printf "Testing expected ldd output ... "
+case "$LDD_OUTPUT" in
+  *$LDD_SUBSTR*)
+    echo "passed" ;;
+  *)
+    ERRORS=$(($ERRORS + 1))
+    echo "failed: ldd output '$LDD_OUTPUT' does not contain '$LDD_SUBSTR'" ;;
+esac
+
+SEARCHPATH_OUTPUT=$(./$PROGRAM -s)
+printf "Testing expected searchpath/datadir ... "
+case "$SEARCHPATH_OUTPUT" in
+  *$PKG_CONFIG_DATADIR*)
+    echo "passed" ;;
+  *)
+    ERRORS=$(($ERRORS + 1))
+    echo "failed: searchpath '$SEARCHPATH_OUTPUT' does not contain '$PKG_CONFIG_DATADIR'" ;;
+esac
+
+VERSION_OUTPUT=$(./$PROGRAM -v)
+printf "Testing expected version ... "
+case "$VERSION_OUTPUT" in
+  $PKG_CONFIG_MODVERSION)
+    echo "passed" ;;
+  *)
+    ERRORS=$(($ERRORS + 1))
+    echo "failed: '$VERSION_OUTPUT' != '$PKG_CONFIG_MODVERSION'" ;;
+esac
+
+make clean
+
+cd ..
+
+exit $ERRORS

--- a/test/postinstall/testappprojinfo/CMakeLists.txt
+++ b/test/postinstall/testappprojinfo/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.5)
+project(testappprojinfo LANGUAGES C)
+
+set(USE_PROJ_NAME "PROJ"
+  CACHE STRING "Either PROJ (default) or PROJ4")
+
+find_package(${USE_PROJ_NAME})
+
+# Show some target properties
+get_cmake_property(_variableNames VARIABLES)
+list(SORT _variableNames)
+foreach(_variableName ${_variableNames})
+  string(REGEX MATCH "^${USE_PROJ_NAME}_" _matched ${_variableName})
+  if(NOT ${_matched} STREQUAL "")
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endif()
+endforeach()
+
+add_executable(testappprojinfo testappprojinfo.c)
+target_link_libraries(testappprojinfo ${${USE_PROJ_NAME}_LIBRARIES})
+
+include(CTest)
+
+if(APPLE)
+  set(LDD_CL "otool -L")
+  set(EXPECTED_LDD_CL_OUT "@rpath/libproj")
+elseif(UNIX)
+  set(LDD_CL "ldd")
+  set(EXPECTED_LDD_CL_OUT "${CMAKE_PREFIX_PATH}/lib/libproj")
+endif()
+
+if(LDD_CL)
+  add_test(NAME test_ldd
+    COMMAND sh -c "${LDD_CL} ${CMAKE_BINARY_DIR}/testappprojinfo | grep proj")
+  set_tests_properties(test_ldd PROPERTIES
+    PASS_REGULAR_EXPRESSION ${EXPECTED_LDD_CL_OUT}
+  )
+else()
+  add_test(NAME test_ldd COMMAND testappprojinfo)
+  set_tests_properties(test_ldd PROPERTIES SKIP_RETURN_CODE 1)
+endif()
+
+# data directory property not available, so recreate one
+get_filename_component(EXPECTED_DATADIR
+  "${${USE_PROJ_NAME}_DIR}/../../../share/proj" ABSOLUTE)
+if(WIN32)
+  # Match each '/' with either '\' or '/'
+  string(REPLACE "/" "[\\/]" EXPECTED_DATADIR ${EXPECTED_DATADIR})
+endif()
+add_test(NAME test_searchpath COMMAND testappprojinfo -s)
+set_tests_properties(test_searchpath PROPERTIES
+  PASS_REGULAR_EXPRESSION "${EXPECTED_DATADIR}"
+)
+
+add_test(NAME test_version COMMAND testappprojinfo -v)
+set_tests_properties(test_version PROPERTIES
+  PASS_REGULAR_EXPRESSION "${${USE_PROJ_NAME}_VERSION}"
+)

--- a/test/postinstall/testappprojinfo/Makefile
+++ b/test/postinstall/testappprojinfo/Makefile
@@ -1,0 +1,15 @@
+PROGRAM = testappprojinfo
+OBJECTS = $(addsuffix .o,$(PROGRAM))
+
+override CFLAGS += -g -Wall -Werror $(shell pkg-config proj --cflags)
+override LDFLAGS += $(shell pkg-config proj --libs)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(OBJECTS)
+	$(CC) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) $(PROGRAM) $(OBJECTS)
+
+.PHONY: clean

--- a/test/postinstall/testappprojinfo/testappprojinfo.c
+++ b/test/postinstall/testappprojinfo/testappprojinfo.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <proj.h>
+
+int main(int argc, char *argv[]) {
+    PJ_INFO info;
+    info = proj_info();
+    if(argc == 2 && argv[1][0] == '-') {
+        switch(argv[1][1]) {
+            case 's':
+                printf("%s\n", info.searchpath);
+                return(0);
+            case 'v':
+                printf("%d.%d.%d\n", info.major, info.minor, info.patch);
+                return(0);
+        }
+    }
+    printf("Use option -v or -s\n");
+    return(1);
+}


### PR DESCRIPTION
This PR is to ensure that PROJ can be used to build applications using CMake and Autotools/pkg-config. This idea was briefly discussed in #1910, and I could expect this to be extended further.

The tests use a simple C program 'testappversion' that includes proj.h and links to libproj.

CMake's `find_package(PROJ)` and `find_package(PROJ4)` are used and the program's linked libraries and output is tested. This hopefully prevents any unexpected changes to documented behavior.

Similarly, pkg-config is used within a simple Makefile, and the program is tested. This should also hopefully prevent issues like #2064 / #2070 .

Other changes in this PR (not exactly related, but are in the same edited files) are:
* Use `export MAKEFLAGS="-j ${NPROC}"` for various `make` calls
* Replace `$TOP_DIR` with `$TRAVIS_BUILD_DIR` (same thing)
