### PR TITLE
cs2cs: don't require +to for '{source_crs} {target_crs} filename...' syntax (fixes #2012)

### DIFF
--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -15,19 +15,16 @@ Synopsis
 
 or
 
-    **cs2cs** [**-eEfIlrstvwW** [args]] {source_crs} +to {target_crs} file ...
+    **cs2cs** [**-eEfIlrstvwW** [args]] {source_crs} {target_crs} file ...
 
     where {source_crs} or {target_crs} is a PROJ string, a WKT string or a AUTHORITY:CODE
     (where AUTHORITY is the name of a CRS authority and CODE the code of a CRS
     found in the proj.db database), expressing a coordinate reference system.
 
-.. versionadded:: 6.0.0
+    .. versionadded:: 6.0.0
 
-or
-
-    **cs2cs** [**-eEfIlrstvwW** [args]] {source_crs} {target_crs}
-
-.. versionadded:: 6.0.0
+    .. note:: before 7.0.1, it was needed to add +to between {source_crs} and {target_crs}
+              when adding a filename
 
 Description
 ***********

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -349,23 +349,14 @@ int main(int argc, char **argv) {
         exit(0);
     }
 
-    // First pass to check if we have "cs2cs [-bla]* <SRC> <DEST>" syntax
-    int countNonOptionArg = 0;
+    // First pass to check if we have "cs2cs [-bla]* <SRC> <DEST> [<filename>]" syntax
+    bool isProj4StyleSyntax = false;
     for (int i = 1; i < argc; i++) {
-        if (argv[i][0] == '-') {
-            if (argv[i][1] == 'f' || argv[i][1] == 'e' || argv[i][1] == 'd' ||
-                argv[i][1] == 'D' ) {
-                i++;
-            }
-        } else {
-            if (strcmp(argv[i], "+to") == 0) {
-                countNonOptionArg = -1;
-                break;
-            }
-            countNonOptionArg++;
+        if (argv[i][0] == '+') {
+            isProj4StyleSyntax = true;
+            break;
         }
     }
-    const bool isSrcDestSyntax = (countNonOptionArg == 2);
 
     /* process run line arguments */
     while (--argc > 0) { /* collect run line arguments */
@@ -492,11 +483,15 @@ int main(int argc, char **argv) {
                 }
                 break;
             }
-        } else if (isSrcDestSyntax) {
+        } else if (!isProj4StyleSyntax) {
             if (fromStr.empty())
                 fromStr = *argv;
-            else
+            else if( toStr.empty() )
                 toStr = *argv;
+            else {
+                 /* assumed to be input file name(s) */
+                eargv[eargc++] = *argv;
+            }
         } else if (strcmp(*argv, "+to") == 0) {
             have_to_flag = 1;
 

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -997,6 +997,11 @@ $EXE -f %.7f +proj=longlat +over +datum=WGS84 +to proj=merc +a=6378137 +b=637813
 -181 49
 EOF
 
+echo  "##############################################################" >> ${OUT}
+echo  "Test EPSG:xxxx EPSG:yyyy filename" >> ${OUT}
+echo "2 49" > tmp.txt
+$EXE EPSG:4326 EPSG:4326 tmp.txt -E >> ${OUT}
+rm tmp.txt
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -479,3 +479,6 @@ Check +init=epsg:4326 +over +to +init=epsg:3857 +over
 ##############################################################
 Check +proj=longlat +over +datum=WGS84 +to proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +over
 -181 49	-20148827.8335825	6274861.3940066 0.0000000
+##############################################################
+Test EPSG:xxxx EPSG:yyyy filename
+2 49	2dN	49dE 0.000


### PR DESCRIPTION
fixes #2012