### PR TITLE
CMake: prefer to use use PROJ_SOURCE_DIR and PROJ_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,9 +225,9 @@ endif()
 # top of the build tree rather than in hard-to-find leaf
 # directories. This simplifies manual testing and the use of the build
 # tree rather than installed PROJ libraries.
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJ_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJ_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJ_BINARY_DIR}/bin)
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 ################################################################################

--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -41,7 +41,7 @@ set(PACKAGE_VERSION "${${PROJECT_NAME}_VERSION}")
 
 # check if a second proj_config.h exists (created by ./configure)
 # as this is within CMake's C_INCLUDES / CXX_INCLUDES
-set(AUTOCONF_PROJ_CONFIG_H "${CMAKE_SOURCE_DIR}/src/proj_config.h")
+set(AUTOCONF_PROJ_CONFIG_H "${PROJ_SOURCE_DIR}/src/proj_config.h")
 if(EXISTS ${AUTOCONF_PROJ_CONFIG_H})
   message(WARNING
     "Autoconf's ${AUTOCONF_PROJ_CONFIG_H} may interfere with this "

--- a/cmake/ProjTest.cmake
+++ b/cmake/ProjTest.cmake
@@ -3,8 +3,10 @@
 #
 
 function(proj_test_set_properties TESTNAME)
-    set_tests_properties( ${TESTNAME}
-        PROPERTIES ENVIRONMENT "PROJ_IGNORE_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  set_property(TEST ${TESTNAME}
+    PROPERTY ENVIRONMENT
+      "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES"
+      "PROJ_LIB=${PROJ_BINARY_DIR}/data/for_tests")
 endfunction()
 
 function(proj_add_test_script_sh SH_NAME BIN_USE)
@@ -12,8 +14,8 @@ function(proj_add_test_script_sh SH_NAME BIN_USE)
     get_filename_component(testname ${SH_NAME} NAME_WE)
 
     add_test(NAME "${testname}"
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/data
-      COMMAND bash ${PROJECT_SOURCE_DIR}/test/cli/${SH_NAME}
+      WORKING_DIRECTORY ${PROJ_SOURCE_DIR}/data
+      COMMAND bash ${PROJ_SOURCE_DIR}/test/cli/${SH_NAME}
       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${${BIN_USE}}
     )
     proj_test_set_properties(${testname})
@@ -25,9 +27,9 @@ endfunction()
 function(proj_add_gie_test TESTNAME TESTCASE)
 
     set(GIE_BIN $<TARGET_FILE_NAME:gie>)
-    set(TESTFILE ${CMAKE_SOURCE_DIR}/test/${TESTCASE})
+    set(TESTFILE ${PROJ_SOURCE_DIR}/test/${TESTCASE})
     add_test(NAME ${TESTNAME}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
+      WORKING_DIRECTORY ${PROJ_SOURCE_DIR}/test
       COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${GIE_BIN}
       ${TESTFILE}
     )

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -292,7 +292,7 @@ source_group("Source Files\\Transformations"
 source_group("Source Files\\ISO19111"
   FILES ${SRC_LIBPROJ_ISO19111})
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${PROJ_SOURCE_DIR}/include)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 source_group("CMake Files" FILES CMakeLists.txt)

--- a/test/googletest/CMakeLists.txt.in
+++ b/test/googletest/CMakeLists.txt.in
@@ -8,8 +8,8 @@ ExternalProject_Add(googletest
   URL https://github.com/google/googletest/archive/release-1.8.1.zip
   URL_HASH SHA1=7b41ea3682937069e3ce32cb06619fead505795e
   DOWNLOAD_NO_PROGRESS ON
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  SOURCE_DIR        "${PROJ_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${PROJ_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   TEST_COMMAND      ""

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -17,17 +17,17 @@ message(STATUS "Using internal GTest")
 # Source https://github.com/google/googletest/blob/master/googletest/README.md
 # Download and unpack googletest at configure time
 configure_file(
-  ${CMAKE_SOURCE_DIR}/test/googletest/CMakeLists.txt.in
-  ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
+  ${PROJ_SOURCE_DIR}/test/googletest/CMakeLists.txt.in
+  ${PROJ_BINARY_DIR}/googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+  WORKING_DIRECTORY ${PROJ_BINARY_DIR}/googletest-download)
 if(result)
   message(FATAL_ERROR "CMake step for googletest failed: ${result}")
 endif()
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+  WORKING_DIRECTORY ${PROJ_BINARY_DIR}/googletest-download)
 if(result)
   message(FATAL_ERROR "Build step for googletest failed: ${result}")
 endif()
@@ -38,8 +38,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # the gtest and gtest_main targets.
 option(INSTALL_GTEST "Enable installation of googletest" OFF)
 add_subdirectory(
-  ${CMAKE_BINARY_DIR}/googletest-src
-  ${CMAKE_BINARY_DIR}/googletest-build
+  ${PROJ_BINARY_DIR}/googletest-src
+  ${PROJ_BINARY_DIR}/googletest-build
   EXCLUDE_FROM_ALL)
 
 # Provide the same target name as find_package(GTest)
@@ -55,13 +55,19 @@ if(MSVC AND BUILD_SHARED_LIBS)
   add_definitions(-DPROJ_MSVC_DLL_IMPORT=1)
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${PROJ_SOURCE_DIR}/include)
 include_directories(${SQLITE3_INCLUDE_DIR})
 # Add the directory containing proj_config.h
-include_directories(${CMAKE_BINARY_DIR}/src)
+include_directories(${PROJ_BINARY_DIR}/src)
 
 # Apply to targets in the current directory and below
 add_compile_options(${PROJ_CXX_WARN_FLAGS})
+
+set(PROJ_TEST_ENVIRONMENT
+  "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES"
+  "PROJ_LIB=${PROJ_BINARY_DIR}/data/for_tests"
+  "PROJ_SOURCE_DATA=${PROJ_SOURCE_DIR}/data"
+)
 
 add_executable(proj_pj_transform_test
   main.cpp
@@ -71,7 +77,7 @@ target_link_libraries(proj_pj_transform_test
   ${PROJ_LIBRARIES})
 add_test(NAME proj_pj_transform_test COMMAND proj_pj_transform_test)
 set_property(TEST proj_pj_transform_test
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 
 add_executable(proj_errno_string_test
@@ -82,7 +88,7 @@ target_link_libraries(proj_errno_string_test
   ${PROJ_LIBRARIES})
 add_test(NAME proj_errno_string_test COMMAND proj_errno_string_test)
 set_property(TEST proj_errno_string_test
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 add_executable(proj_angular_io_test
   main.cpp
@@ -92,7 +98,7 @@ target_link_libraries(proj_angular_io_test
   ${PROJ_LIBRARIES})
 add_test(NAME proj_angular_io_test COMMAND proj_angular_io_test)
 set_property(TEST proj_angular_io_test
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 add_executable(proj_context_test
   main.cpp
@@ -102,7 +108,7 @@ target_link_libraries(proj_context_test
   ${PROJ_LIBRARIES})
 add_test(NAME proj_context_test COMMAND proj_context_test)
 set_property(TEST proj_context_test
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   # ph_phi2_test not compatible of a .dll build
@@ -115,7 +121,7 @@ else()
     ${PROJ_LIBRARIES})
   add_test(NAME pj_phi2_test COMMAND pj_phi2_test)
   set_property(TEST pj_phi2_test
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+    PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 endif()
 
 add_executable(proj_test_cpp_api
@@ -136,7 +142,7 @@ target_link_libraries(proj_test_cpp_api
   ${SQLITE3_LIBRARY})
 add_test(NAME proj_test_cpp_api COMMAND proj_test_cpp_api)
 set_property(TEST proj_test_cpp_api
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 
 add_executable(gie_self_tests
@@ -147,8 +153,7 @@ target_link_libraries(gie_self_tests
   ${PROJ_LIBRARIES})
 add_test(NAME gie_self_tests COMMAND gie_self_tests)
 set_property(TEST gie_self_tests
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests")
-
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
 
 add_executable(test_network
   main.cpp
@@ -164,4 +169,4 @@ target_link_libraries(test_network
   ${SQLITE3_LIBRARY})
 add_test(NAME test_network COMMAND test_network)
 set_property(TEST test_network
-        PROPERTY ENVIRONMENT "PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY=YES;PROJ_LIB=${PROJECT_BINARY_DIR}/data/for_tests;PROJ_SOURCE_DATA=${PROJECT_SOURCE_DIR}/data")
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})


### PR DESCRIPTION
PROJ_SOURCE_DIR and PROJ_BINARY_DIR are absolute paths to the source and binary build trees for PROJ, whereas CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR refer to the top-level CMakeLists.txt, which could be a different project. Similarly, PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR are relative to the most recent project() command. It's just more direct to make these consistently PROJ_SOURCE_DIR and PROJ_BINARY_DIR.

Other items covered here:
* Set properties with a list variable rather than a long line
* Correction to 'proj_test_set_properties' function, rename ENVIRONMENT:
  - PROJ_IGNORE_USER_WRITABLE_DIRECTORY     (ignored)
  - PROJ_SKIP_READ_USER_WRITABLE_DIRECTORY  (used by filemanager.cpp)

Closes #2094