### PR TITLE
Backport to 6.3 of the fix Add entries in grid_alternatives for Portugal grids coming from ESRI entries

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -1318,6 +1318,36 @@ INSERT INTO grid_alternatives(original_grid_name,
                               'proj-datumgrid-europe',
                               NULL, NULL, NULL, NULL);
 
+INSERT INTO grid_alternatives(original_grid_name,
+                              proj_grid_name,
+                              proj_grid_format,
+                              proj_method,
+                              inverse_direction,
+                              package_name,
+                              url, direct_download, open_license, directory)
+                      VALUES ('portugal/DLX_ETRS89_geo',
+                              'DLx_ETRS89_geo.gsb',
+                              'NTv2',
+                              'hgridshift',
+                              0,
+                              'proj-datumgrid-europe',
+                              NULL, NULL, NULL, NULL);
+
+INSERT INTO grid_alternatives(original_grid_name,
+                              proj_grid_name,
+                              proj_grid_format,
+                              proj_method,
+                              inverse_direction,
+                              package_name,
+                              url, direct_download, open_license, directory)
+                      VALUES ('portugal/D73_ETRS89_geo',
+                              'D73_ETRS89_geo.gsb',
+                              'NTv2',
+                              'hgridshift',
+                              0,
+                              'proj-datumgrid-europe',
+                              NULL, NULL, NULL, NULL);
+
 -- Canada provincial grids
 
 INSERT INTO grid_alternatives(original_grid_name,


### PR DESCRIPTION
Fixes wrong grids file name in esri.sql mapping the ESRI grid name to the PROJ one. Backport of https://github.com/OSGeo/PROJ/pull/2102

 - [x] Closes #2096