### PR TITLE
hgridshift/vgridshift: defer grid opening when grid has already been opened

### DIFF
--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -264,4 +264,6 @@ void proj_cleanup() {
   pj_clear_initcache();
   pj_deallocate_grids();
   FileManager::clearMemoryCache();
+  pj_clear_hgridshift_knowngrids_cache();
+  pj_clear_vgridshift_knowngrids_cache();
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -890,6 +890,9 @@ int pj_get_suggested_operation(PJ_CONTEXT *ctx,
 const PJ_UNITS *pj_list_linear_units();
 const PJ_UNITS *pj_list_angular_units();
 
+void pj_clear_hgridshift_knowngrids_cache();
+void pj_clear_vgridshift_knowngrids_cache();
+
 /* classic public API */
 #include "proj_api.h"
 

--- a/test/unit/test_network.cpp
+++ b/test/unit/test_network.cpp
@@ -127,6 +127,8 @@ TEST(networking, basic) {
     ASSERT_EQ(P, nullptr);
     proj_context_destroy(ctx);
 
+    proj_cleanup();
+
 #ifdef CURL_ENABLED
     // enable through env variable
     ctx = proj_context_create();
@@ -141,6 +143,8 @@ TEST(networking, basic) {
     putenv(const_cast<char *>("PROJ_NETWORK="));
 #endif
 
+    proj_cleanup();
+
     // still disabled
     ctx = proj_context_create();
     proj_grid_cache_set_enable(ctx, false);
@@ -148,6 +152,8 @@ TEST(networking, basic) {
     P = proj_create(ctx, pipeline);
     ASSERT_EQ(P, nullptr);
     proj_context_destroy(ctx);
+
+    proj_cleanup();
 
     // enable through API
     ctx = proj_context_create();
@@ -174,6 +180,7 @@ TEST(networking, basic) {
     ASSERT_EQ(P, nullptr);
 #endif
     proj_context_destroy(ctx);
+    proj_cleanup();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Relates to #2115

With the fix of https://github.com/OSGeo/PROJ/pull/2128, transforming between
EPSG:4326+3855 and EPSG:4269+5703 leads to many operations with many grids,
and opening a file handle for each operation saturates the limit of 1024
file handles opened simunalteously. This fix defers grid opening when a
transformation has already been instanciated with the same grid.
