### PR TITLE
Test GCC 4.8 and CMake 3.9; resolve a few shadowed declaration warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ matrix:
         - docker
       env:
         - BUILD_NAME=linux_gcc
-        - DETAILS="linux, gcc"
+        - DETAILS="linux, gcc-4.8"
+        - CC=gcc-4.8
+        - CXX=g++-4.8
+      addons:
+        apt:
+          packages:
+            - g++-4.8
 
     - os: linux
       dist: xenial

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -70,7 +70,7 @@ NS_PROJ_START
 
 // ---------------------------------------------------------------------------
 
-File::File(const std::string &name) : name_(name) {}
+File::File(const std::string &filename) : name_(filename) {}
 
 // ---------------------------------------------------------------------------
 
@@ -716,8 +716,8 @@ class FileStdio : public File {
     FileStdio &operator=(const FileStdio &) = delete;
 
   protected:
-    FileStdio(const std::string &name, PJ_CONTEXT *ctx, FILE *fp)
-        : File(name), m_ctx(ctx), m_fp(fp) {}
+    FileStdio(const std::string &filename, PJ_CONTEXT *ctx, FILE *fp)
+        : File(filename), m_ctx(ctx), m_fp(fp) {}
 
   public:
     ~FileStdio() override;
@@ -796,8 +796,8 @@ class FileLegacyAdapter : public File {
     FileLegacyAdapter &operator=(const FileLegacyAdapter &) = delete;
 
   protected:
-    FileLegacyAdapter(const std::string &name, PJ_CONTEXT *ctx, PAFile fp)
-        : File(name), m_ctx(ctx), m_fp(fp) {}
+    FileLegacyAdapter(const std::string &filename, PJ_CONTEXT *ctx, PAFile fp)
+        : File(filename), m_ctx(ctx), m_fp(fp) {}
 
   public:
     ~FileLegacyAdapter() override;
@@ -863,9 +863,9 @@ class FileApiAdapter : public File {
     FileApiAdapter &operator=(const FileApiAdapter &) = delete;
 
   protected:
-    FileApiAdapter(const std::string &name, PJ_CONTEXT *ctx,
+    FileApiAdapter(const std::string &filename, PJ_CONTEXT *ctx,
                    PROJ_FILE_HANDLE *fp)
-        : File(name), m_ctx(ctx), m_fp(fp) {}
+        : File(filename), m_ctx(ctx), m_fp(fp) {}
 
   public:
     ~FileApiAdapter() override;

--- a/src/filemanager.hpp
+++ b/src/filemanager.hpp
@@ -78,7 +78,7 @@ class File {
     std::string name_;
     std::string readLineBuffer_{};
     bool eofReadLine_ = false;
-    explicit File(const std::string &name);
+    explicit File(const std::string &filename);
 
   public:
     virtual PROJ_DLL ~File();

--- a/src/grids.cpp
+++ b/src/grids.cpp
@@ -96,9 +96,9 @@ bool ExtentAndRes::intersects(const ExtentAndRes &other) const {
 
 // ---------------------------------------------------------------------------
 
-Grid::Grid(const std::string &name, int widthIn, int heightIn,
+Grid::Grid(const std::string &nameIn, int widthIn, int heightIn,
            const ExtentAndRes &extentIn)
-    : m_name(name), m_width(widthIn), m_height(heightIn), m_extent(extentIn) {}
+    : m_name(nameIn), m_width(widthIn), m_height(heightIn), m_extent(extentIn) {}
 
 // ---------------------------------------------------------------------------
 
@@ -479,7 +479,7 @@ GTiffGrid::GTiffGrid(PJ_CONTEXT *ctx, TIFF *hTIFF, BlockCache &cache, File *fp,
             std::string value;
             value.append(endTag + 1, endValue - (endTag + 1));
 
-            std::string name;
+            std::string gridName;
             auto namePos = tag.find("name=\"");
             if (namePos == std::string::npos)
                 break;
@@ -488,7 +488,7 @@ GTiffGrid::GTiffGrid(PJ_CONTEXT *ctx, TIFF *hTIFF, BlockCache &cache, File *fp,
                 const auto endQuote = tag.find('"', namePos);
                 if (endQuote == std::string::npos)
                     break;
-                name = tag.substr(namePos, endQuote - namePos);
+                gridName = tag.substr(namePos, endQuote - namePos);
             }
 
             const auto samplePos = tag.find("sample=\"");
@@ -497,7 +497,7 @@ GTiffGrid::GTiffGrid(PJ_CONTEXT *ctx, TIFF *hTIFF, BlockCache &cache, File *fp,
                 sample = atoi(tag.c_str() + samplePos + strlen("sample=\""));
             }
 
-            m_metadata[std::pair<int, std::string>(sample, name)] = value;
+            m_metadata[std::pair<int, std::string>(sample, gridName)] = value;
 
             auto rolePos = tag.find("role=\"");
             if (rolePos != std::string::npos) {

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -203,10 +203,10 @@ void Datum::setAnchor(const util::optional<std::string> &anchor) {
 void Datum::setProperties(
     const util::PropertyMap &properties) // throw(InvalidValueTypeException)
 {
-    std::string publicationDate;
-    properties.getStringValue("PUBLICATION_DATE", publicationDate);
-    if (!publicationDate.empty()) {
-        d->publicationDate = common::DateTime::create(publicationDate);
+    std::string publicationDateResult;
+    properties.getStringValue("PUBLICATION_DATE", publicationDateResult);
+    if (!publicationDateResult.empty()) {
+        d->publicationDate = common::DateTime::create(publicationDateResult);
     }
     ObjectUsage::setProperties(properties);
 }
@@ -1376,13 +1376,13 @@ bool GeodeticReferenceFrame::hasEquivalentNameToUsingAlias(
     if (dbContext) {
         if (!identifiers().empty()) {
             const auto &id = identifiers().front();
-            auto aliases =
+            auto aliasesResult =
                 dbContext->getAliases(*(id->codeSpace()), id->code(), nameStr(),
                                       "geodetic_datum", std::string());
             const char *otherName = other->nameStr().c_str();
-            for (const auto &alias : aliases) {
+            for (const auto &aliasResult : aliasesResult) {
                 if (metadata::Identifier::isEquivalentName(otherName,
-                                                           alias.c_str())) {
+                                                           aliasResult.c_str())) {
                     return true;
                 }
             }
@@ -1395,13 +1395,13 @@ bool GeodeticReferenceFrame::hasEquivalentNameToUsingAlias(
             return false;
         }
 
-        auto aliases =
+        auto aliasesResult =
             dbContext->getAliases(std::string(), std::string(), nameStr(),
                                   "geodetic_datum", std::string());
         const char *otherName = other->nameStr().c_str();
-        for (const auto &alias : aliases) {
+        for (const auto &aliasResult : aliasesResult) {
             if (metadata::Identifier::isEquivalentName(otherName,
-                                                       alias.c_str())) {
+                                                       aliasResult.c_str())) {
                 return true;
             }
         }

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -103,6 +103,7 @@ if [ "$BUILD_NAME" != "linux_gcc8" ]; then
     # cmake build from generated tarball
     mkdir build_cmake
     cd build_cmake
+    cmake --version
     cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj_cmake_install
     VERBOSE=1 make
     make install

--- a/travis/linux_gcc/before_install.sh
+++ b/travis/linux_gcc/before_install.sh
@@ -17,5 +17,6 @@ scripts/doxygen.sh
 
 pip3 install --user sphinxcontrib-bibtex
 pip3 install --user cpp-coveralls
+pip3 install --user cmake==3.9.6
 
 ./travis/docker.sh

--- a/travis/linux_gcc/install.sh
+++ b/travis/linux_gcc/install.sh
@@ -5,4 +5,4 @@ set -e
 export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
-CC="ccache gcc" CXX="ccache g++" CFLAGS="-std=c99 -Werror" CXXFLAGS="-Werror" ./travis/install.sh
+CC="ccache $CC" CXX="ccache $CXX" CFLAGS="-std=c99 -Werror" CXXFLAGS="-Werror" ./travis/install.sh


### PR DESCRIPTION
There is a gap in the Travis CI testing for GCC 4.8 and/or the current minimum required version of CMake (3.9). This PR <s>adds yet another job to the matrix</s> modifies the existing `linux_gcc` job.

Testing with `g++-4.8` will avoid issues like #2062 and compatibility with building with [manylinux1](https://github.com/pypa/manylinux), for example see [pyproj#574](https://github.com/pyproj4/pyproj/issues/574).

A few shadowed declarations were resolved to pass tests with `-Werror`, but I'd appreciate a review of my C++ edits.