### PR TITLE
 createOperations(): do not remove ballpark transformation if there are only grid based operations, even if they cover the whole area of use (fixes #2143)

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -1759,6 +1759,10 @@ class PROJ_GCC_DLL CoordinateOperationContext {
 
     PROJ_DLL void setDesiredAccuracy(double accuracy);
 
+    PROJ_DLL void setAllowBallparkTransformations(bool allow);
+
+    PROJ_DLL bool getAllowBallparkTransformations() const;
+
     /** Specify how source and target CRS extent should be used to restrict
      * candidate operations (only taken into account if no explicit area of
      * interest is specified. */

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -705,6 +705,7 @@ static void outputOperations(
         ctxt->setIntermediateCRS(pivots);
         ctxt->setUsePROJAlternativeGridNames(usePROJGridAlternatives);
         ctxt->setDiscardSuperseded(!showSuperseded);
+        ctxt->setAllowBallparkTransformations(outputOpt.ballparkAllowed);
         list = CoordinateOperationFactory::create()->createOperations(
             nnSourceCRS, nnTargetCRS, ctxt);
         if (!spatialCriterionExplicitlySpecified &&
@@ -725,15 +726,6 @@ static void outputOperations(
         std::cerr << "createOperations() failed with: " << e.what()
                   << std::endl;
         std::exit(1);
-    }
-    if (!outputOpt.ballparkAllowed) {
-        std::vector<CoordinateOperationNNPtr> listNew;
-        for (const auto &op : list) {
-            if (!op->hasBallparkTransformation()) {
-                listNew.emplace_back(op);
-            }
-        }
-        list = std::move(listNew);
     }
     if (outputOpt.quiet && !list.empty()) {
         outputObject(dbContext, list[0], allowUseIntermediateCRS, outputOpt);

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -7518,6 +7518,27 @@ void PROJ_DLL proj_operation_factory_context_set_discard_superseded(
 
 // ---------------------------------------------------------------------------
 
+/** \brief Set whether ballpark transformations are allowed.
+ *
+ * @param ctx PROJ context, or NULL for default context
+ * @param factory_ctx Operation factory context. must not be NULL
+ * @param allow set to TRUE to allow ballpark transformations.
+ * @since 7.1
+ */
+void PROJ_DLL proj_operation_factory_context_set_allow_ballpark_transformations(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx, int allow) {
+    SANITIZE_CTX(ctx);
+    assert(factory_ctx);
+    try {
+        factory_ctx->operationContext->setAllowBallparkTransformations(allow !=
+                                                                       0);
+    } catch (const std::exception &e) {
+        proj_log_error(ctx, __FUNCTION__, e.what());
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 //! @cond Doxygen_Suppress
 /** \brief Opaque object representing a set of operation results. */
 struct PJ_OPERATION_LIST : PJ_OBJ_LIST {

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -926,7 +926,8 @@ bool DatabaseContext::lookForGridAlternative(const std::string &officialName,
                                              bool &inverse) const {
     auto res = d->run(
         "SELECT proj_grid_name, proj_grid_format, inverse_direction FROM "
-        "grid_alternatives WHERE original_grid_name = ?",
+        "grid_alternatives WHERE original_grid_name = ? AND "
+        "proj_grid_name <> ''",
         {officialName});
     if (res.empty()) {
         return false;

--- a/src/proj.h
+++ b/src/proj.h
@@ -1202,6 +1202,11 @@ void PROJ_DLL proj_operation_factory_context_set_discard_superseded(
     PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
     int discard);
 
+void PROJ_DLL proj_operation_factory_context_set_allow_ballpark_transformations(
+    PJ_CONTEXT *ctx,
+    PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    int allow);
+
 /* ------------------------------------------------------------------------- */
 
 

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -1600,6 +1600,63 @@ TEST_F(CApi, proj_create_operations_with_pivot) {
 
 // ---------------------------------------------------------------------------
 
+TEST_F(CApi, proj_create_operations_allow_ballpark_transformations) {
+    auto ctxt = proj_create_operation_factory_context(m_ctxt, nullptr);
+    ASSERT_NE(ctxt, nullptr);
+    ContextKeeper keeper_ctxt(ctxt);
+
+    auto source_crs = proj_create_from_database(
+        m_ctxt, "EPSG", "4267", PJ_CATEGORY_CRS, false, nullptr); // NAD27
+    ASSERT_NE(source_crs, nullptr);
+    ObjectKeeper keeper_source_crs(source_crs);
+
+    auto target_crs = proj_create_from_database(
+        m_ctxt, "EPSG", "4258", PJ_CATEGORY_CRS, false, nullptr); // ETRS89
+    ASSERT_NE(target_crs, nullptr);
+    ObjectKeeper keeper_target_crs(target_crs);
+
+    proj_operation_factory_context_set_spatial_criterion(
+        m_ctxt, ctxt, PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION);
+
+    proj_operation_factory_context_set_grid_availability_use(
+        m_ctxt, ctxt, PROJ_GRID_AVAILABILITY_IGNORED);
+
+    // Default: allowed implictly
+    {
+        auto res = proj_create_operations(m_ctxt, source_crs, target_crs, ctxt);
+        ASSERT_NE(res, nullptr);
+        ObjListKeeper keeper_res(res);
+
+        EXPECT_EQ(proj_list_get_count(res), 1);
+    }
+
+    // Allow explictly
+    {
+        proj_operation_factory_context_set_allow_ballpark_transformations(
+            m_ctxt, ctxt, true);
+
+        auto res = proj_create_operations(m_ctxt, source_crs, target_crs, ctxt);
+        ASSERT_NE(res, nullptr);
+        ObjListKeeper keeper_res(res);
+
+        EXPECT_EQ(proj_list_get_count(res), 1);
+    }
+
+    // Disallow
+    {
+        proj_operation_factory_context_set_allow_ballpark_transformations(
+            m_ctxt, ctxt, false);
+
+        auto res = proj_create_operations(m_ctxt, source_crs, target_crs, ctxt);
+        ASSERT_NE(res, nullptr);
+        ObjListKeeper keeper_res(res);
+
+        EXPECT_EQ(proj_list_get_count(res), 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 TEST_F(CApi, proj_context_set_database_path_null) {
 
     EXPECT_TRUE(

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5109,7 +5109,7 @@ TEST(operation, geogCRS_to_geogCRS_init_IGNF_to_init_IGNF_context) {
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
     auto list = CoordinateOperationFactory::create()->createOperations(
         NN_CHECK_ASSERT(sourceCRS), NN_CHECK_ASSERT(targetCRS), ctxt);
-    ASSERT_EQ(list.size(), 1U);
+    ASSERT_EQ(list.size(), 2U);
 
     EXPECT_EQ(list[0]->nameStr(),
               "NOUVELLE TRIANGULATION DE LA FRANCE (NTF) vers RGF93 (ETRS89)");
@@ -6552,7 +6552,7 @@ TEST(operation, ETRS89_3D_to_proj_string_with_geoidgrids_nadgrids) {
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
     auto list = CoordinateOperationFactory::create()->createOperations(
         src, NN_NO_CHECK(dst), ctxt);
-    ASSERT_EQ(list.size(), 1U);
+    ASSERT_EQ(list.size(), 2U);
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=axisswap +order=2,1 "


### PR DESCRIPTION
I'll cherry-pick in 7.0 the first 2 commits