### PR TITLE
[Backport 7.0] createOperations(): do not remove ballpark transformation if there are only grid based operations, even if they cover the whole area of use (fixes #2143)

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -1759,6 +1759,10 @@ class PROJ_GCC_DLL CoordinateOperationContext {
 
     PROJ_DLL void setDesiredAccuracy(double accuracy);
 
+    PROJ_DLL void setAllowBallparkTransformations(bool allow);
+
+    PROJ_DLL bool getAllowBallparkTransformations() const;
+
     /** Specify how source and target CRS extent should be used to restrict
      * candidate operations (only taken into account if no explicit area of
      * interest is specified. */

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -10462,6 +10462,7 @@ struct CoordinateOperationContext::Private {
     std::vector<std::pair<std::string, std::string>>
         intermediateCRSAuthCodes_{};
     bool discardSuperseded_ = true;
+    bool allowBallpark_ = true;
 };
 //! @endcond
 
@@ -10512,6 +10513,20 @@ double CoordinateOperationContext::getDesiredAccuracy() const {
 /** \brief Set the desired accuracy (in metre), or 0 */
 void CoordinateOperationContext::setDesiredAccuracy(double accuracy) {
     d->accuracy_ = accuracy;
+}
+
+// ---------------------------------------------------------------------------
+
+/** \brief Return whether ballpark transformations are allowed */
+bool CoordinateOperationContext::getAllowBallparkTransformations() const {
+    return d->allowBallpark_;
+}
+
+// ---------------------------------------------------------------------------
+
+/** \brief Set whether ballpark transformations are allowed */
+void CoordinateOperationContext::setAllowBallparkTransformations(bool allow) {
+    d->allowBallpark_ = allow;
 }
 
 // ---------------------------------------------------------------------------
@@ -11185,7 +11200,7 @@ struct FilterResults {
     const CoordinateOperationContext::SourceTargetCRSExtentUse
         sourceAndTargetCRSExtentUse;
 
-    bool hasOpThatContainsAreaOfInterest = false;
+    bool hasOpThatContainsAreaOfInterestAndNoGrid = false;
     std::vector<CoordinateOperationNNPtr> res{};
 
     // ----------------------------------------------------------------------
@@ -11231,12 +11246,16 @@ struct FilterResults {
                       STRICT_CONTAINMENT
                 : context->getSpatialCriterion();
         bool hasFoundOpWithExtent = false;
+        const bool allowBallpark = context->getAllowBallparkTransformations();
         for (const auto &op : sourceList) {
             if (desiredAccuracy != 0) {
                 const double accuracy = getAccuracy(op);
                 if (accuracy < 0 || accuracy > desiredAccuracy) {
                     continue;
                 }
+            }
+            if (!allowBallpark && op->hasBallparkTransformation()) {
+                continue;
             }
             if (areaOfInterest) {
                 bool emptyIntersection = false;
@@ -11246,9 +11265,11 @@ struct FilterResults {
                 hasFoundOpWithExtent = true;
                 bool extentContains =
                     extent->contains(NN_NO_CHECK(areaOfInterest));
-                if (extentContains) {
-                    if (!op->hasBallparkTransformation()) {
-                        hasOpThatContainsAreaOfInterest = true;
+                if (!hasOpThatContainsAreaOfInterestAndNoGrid &&
+                    extentContains) {
+                    if (!op->hasBallparkTransformation() &&
+                        op->gridsNeeded(nullptr, true).empty()) {
+                        hasOpThatContainsAreaOfInterestAndNoGrid = true;
                     }
                 }
                 if (spatialCriterion ==
@@ -11275,9 +11296,11 @@ struct FilterResults {
                     !extent1 || extent->contains(NN_NO_CHECK(extent1));
                 bool extentContainsExtent2 =
                     !extent2 || extent->contains(NN_NO_CHECK(extent2));
-                if (extentContainsExtent1 && extentContainsExtent2) {
-                    if (!op->hasBallparkTransformation()) {
-                        hasOpThatContainsAreaOfInterest = true;
+                if (!hasOpThatContainsAreaOfInterestAndNoGrid &&
+                    extentContainsExtent1 && extentContainsExtent2) {
+                    if (!op->hasBallparkTransformation() &&
+                        op->gridsNeeded(nullptr, true).empty()) {
+                        hasOpThatContainsAreaOfInterestAndNoGrid = true;
                     }
                 }
                 if (spatialCriterion ==
@@ -11310,6 +11333,9 @@ struct FilterResults {
                     if (accuracy < 0 || accuracy > desiredAccuracy) {
                         continue;
                     }
+                }
+                if (!allowBallpark && op->hasBallparkTransformation()) {
+                    continue;
                 }
                 res.emplace_back(op);
             }
@@ -11444,12 +11470,13 @@ struct FilterResults {
 
         // If we have more than one result, and than the last result is the
         // default "Ballpark geographic offset" or "Ballpark geocentric
-        // translation"
-        // operations we have synthetized, and that at least one operation
-        // has the desired area of interest, remove it as
-        // all previous results are necessarily better
-        if (hasOpThatContainsAreaOfInterest && res.size() > 1) {
-            const std::string &name = res.back()->nameStr();
+        // translation" operations we have synthetized, and that at least one
+        // operation has the desired area of interest and does not require the
+        // use of grids, remove it as all previous results are necessarily
+        // better
+        if (hasOpThatContainsAreaOfInterestAndNoGrid && res.size() > 1) {
+            const auto &opLast = res.back();
+            const std::string &name = opLast->nameStr();
             if (name.find(BALLPARK_GEOGRAPHIC_OFFSET) != std::string::npos ||
                 name.find(NULL_GEOGRAPHIC_OFFSET) != std::string::npos ||
                 name.find(NULL_GEOCENTRIC_TRANSLATION) != std::string::npos ||
@@ -14770,7 +14797,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
         }
     }
 
-    // If we didn't find a non-ballbark transformation between
+    // If we didn't find a non-ballpark transformation between
     // the 2 vertical CRS, then try through intermediate geographic CRS
     // For example
     // WGS 84 + EGM96 --> ETRS89 + Belfast height where

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -926,7 +926,8 @@ bool DatabaseContext::lookForGridAlternative(const std::string &officialName,
                                              bool &inverse) const {
     auto res = d->run(
         "SELECT proj_grid_name, proj_grid_format, inverse_direction FROM "
-        "grid_alternatives WHERE original_grid_name = ?",
+        "grid_alternatives WHERE original_grid_name = ? AND "
+        "proj_grid_name <> ''",
         {officialName});
     if (res.empty()) {
         return false;

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5109,7 +5109,7 @@ TEST(operation, geogCRS_to_geogCRS_init_IGNF_to_init_IGNF_context) {
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
     auto list = CoordinateOperationFactory::create()->createOperations(
         NN_CHECK_ASSERT(sourceCRS), NN_CHECK_ASSERT(targetCRS), ctxt);
-    ASSERT_EQ(list.size(), 1U);
+    ASSERT_EQ(list.size(), 2U);
 
     EXPECT_EQ(list[0]->nameStr(),
               "NOUVELLE TRIANGULATION DE LA FRANCE (NTF) vers RGF93 (ETRS89)");
@@ -6552,7 +6552,7 @@ TEST(operation, ETRS89_3D_to_proj_string_with_geoidgrids_nadgrids) {
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
     auto list = CoordinateOperationFactory::create()->createOperations(
         src, NN_NO_CHECK(dst), ctxt);
-    ASSERT_EQ(list.size(), 1U);
+    ASSERT_EQ(list.size(), 2U);
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=axisswap +order=2,1 "


### PR DESCRIPTION
Partial backport of PR #2155