### PR TITLE
Moved proj_context_get_url_endpoint & proj_context_get_user_writable_directory to proj.h

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -753,6 +753,12 @@ Network related functionality
 .. doxygenfunction:: proj_context_set_url_endpoint
    :project: doxygen_api
 
+.. doxygenfunction:: proj_context_get_url_endpoint
+   :project: doxygen_api
+
+.. doxygenfunction:: proj_context_get_user_writable_directory
+   :project: doxygen_api
+
 .. doxygenfunction:: proj_grid_cache_set_enable
    :project: doxygen_api
 

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -745,8 +745,8 @@ pj_cleanup_lock
 pj_clear_initcache
 pj_compare_datums
 pj_context_get_grid_cache_filename(projCtx_t*)
-pj_context_get_url_endpoint(projCtx_t*)
-pj_context_get_user_writable_directory(projCtx_t*, bool)
+proj_context_get_url_endpoint(projCtx_t*)
+proj_context_get_user_writable_directory(projCtx_t*, int)
 pj_context_set_user_writable_directory(projCtx_t*, std::string const&)
 pj_ctx_alloc
 pj_ctx_fclose

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -1074,7 +1074,7 @@ int main(int argc, char **argv) {
 #ifdef CURL_ENABLED
             if (proj_context_is_network_enabled(nullptr)) {
                 std::cout << "Status: enabled" << std::endl;
-                std::cout << "URL: " << std::string(proj_context_get_url_endpoint(nullptr))
+                std::cout << "URL: " << proj_context_get_url_endpoint(nullptr)
                           << std::endl;
             } else {
                 std::cout << "Status: disabled" << std::endl;

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -1074,7 +1074,7 @@ int main(int argc, char **argv) {
 #ifdef CURL_ENABLED
             if (proj_context_is_network_enabled(nullptr)) {
                 std::cout << "Status: enabled" << std::endl;
-                std::cout << "URL: " << pj_context_get_url_endpoint(nullptr)
+                std::cout << "URL: " << std::string(proj_context_get_url_endpoint(nullptr))
                           << std::endl;
             } else {
                 std::cout << "Status: disabled" << std::endl;

--- a/src/apps/projsync.cpp
+++ b/src/apps/projsync.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
     auto ctx = pj_get_default_ctx();
 
     std::string targetDir;
-    std::string endpoint(pj_context_get_url_endpoint(ctx));
+    std::string endpoint(proj_context_get_url_endpoint(ctx));
     const std::string geojsonFile("files.geojson");
     std::string queriedSourceId;
     std::string queriedAreaOfUse;
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (targetDir.empty()) {
-        targetDir = pj_context_get_user_writable_directory(ctx, true);
+        targetDir = std::string(proj_context_get_user_writable_directory(ctx, true));
     } else {
         if (targetDir.back() == '/') {
             targetDir.resize(targetDir.size() - 1);

--- a/src/apps/projsync.cpp
+++ b/src/apps/projsync.cpp
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (targetDir.empty()) {
-        targetDir = std::string(proj_context_get_user_writable_directory(ctx, true));
+        targetDir = proj_context_get_user_writable_directory(ctx, true);
     } else {
         if (targetDir.back() == '/') {
             targetDir.resize(targetDir.size() - 1);

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1186,7 +1186,7 @@ static void CreateDirectoryRecursively(PJ_CONTEXT *ctx,
 /** Get the PROJ user writable directory for datumgrid files.
  *
  * @param ctx PROJ context, or NULL
- * @param create Create the directory if it does not exist already.
+ * @param create If set to TRUE, create the directory if it does not exist already.
  * @return The path to the PROJ user writable directory.
  * @since 7.1
 */

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1774,7 +1774,7 @@ int pj_find_file(projCtx ctx, const char *short_filename,
 /** Get the URL endpoint to query for remote grids.
 *
 * @param ctx PROJ context, or NULL
-* @return Endpoint URL.
+* @return Endpoint URL. The returned pointer would be invalidated by a later call to proj_context_set_url_endpoint()
 * @since 7.1
 */
 const char* proj_context_get_url_endpoint(PJ_CONTEXT *ctx) {

--- a/src/networkfilemanager.cpp
+++ b/src/networkfilemanager.cpp
@@ -1947,7 +1947,7 @@ static bool is_rel_or_absolute_filename(const char *name) {
 static std::string build_url(PJ_CONTEXT *ctx, const char *name) {
     if (!is_tilde_slash(name) && !is_rel_or_absolute_filename(name) &&
         !starts_with(name, "http://") && !starts_with(name, "https://")) {
-        std::string remote_file(pj_context_get_url_endpoint(ctx));
+        std::string remote_file(proj_context_get_url_endpoint(ctx));
         if (!remote_file.empty()) {
             if (remote_file.back() != '/') {
                 remote_file += '/';
@@ -2213,7 +2213,7 @@ int proj_is_download_needed(PJ_CONTEXT *ctx, const char *url_or_filename,
     if (filename == nullptr)
         return false;
     const auto localFilename(
-        pj_context_get_user_writable_directory(ctx, false) + filename);
+        std::string(proj_context_get_user_writable_directory(ctx, false)) + filename);
 
     auto f = NS_PROJ::FileManager::open(ctx, localFilename.c_str(),
                                         NS_PROJ::FileAccess::READ_ONLY);
@@ -2351,7 +2351,7 @@ int proj_download_file(PJ_CONTEXT *ctx, const char *url_or_filename,
     const char *filename = strrchr(url.c_str(), '/');
     if (filename == nullptr)
         return false;
-    const auto localFilename(pj_context_get_user_writable_directory(ctx, true) +
+    const auto localFilename(std::string(proj_context_get_user_writable_directory(ctx, true)) +
                              filename);
 
 #ifdef _WIN32
@@ -2536,7 +2536,7 @@ std::string pj_context_get_grid_cache_filename(PJ_CONTEXT *ctx) {
     if (!ctx->gridChunkCache.filename.empty()) {
         return ctx->gridChunkCache.filename;
     }
-    const std::string path(pj_context_get_user_writable_directory(ctx, true));
+    const std::string path(proj_context_get_user_writable_directory(ctx, true));
     ctx->gridChunkCache.filename = path + "/cache.db";
     return ctx->gridChunkCache.filename;
 }

--- a/src/proj.h
+++ b/src/proj.h
@@ -512,6 +512,10 @@ int PROJ_DLL proj_context_is_network_enabled(PJ_CONTEXT* ctx);
 
 void PROJ_DLL proj_context_set_url_endpoint(PJ_CONTEXT* ctx, const char* url);
 
+const char PROJ_DLL *proj_context_get_url_endpoint(PJ_CONTEXT* ctx);
+
+const char PROJ_DLL *proj_context_get_user_writable_directory(PJ_CONTEXT *ctx, int create);
+
 void PROJ_DLL proj_grid_cache_set_enable(PJ_CONTEXT* ctx, int enabled);
 
 void PROJ_DLL proj_grid_cache_set_filename(PJ_CONTEXT* ctx, const char* fullname);

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -875,15 +875,12 @@ PJ *pj_create_internal (PJ_CONTEXT *ctx, const char *definition);
 PJ *pj_create_argv_internal (PJ_CONTEXT *ctx, int argc, char **argv);
 
 // For use by projinfo
-std::string PROJ_DLL pj_context_get_url_endpoint(PJ_CONTEXT* ctx);
-
 void pj_load_ini(PJ_CONTEXT* ctx);
 
 // Exported for testing purposes only
 std::string PROJ_DLL pj_context_get_grid_cache_filename(PJ_CONTEXT *ctx);
 
 // For use by projsync
-std::string PROJ_DLL pj_context_get_user_writable_directory(PJ_CONTEXT *ctx, bool create);
 void PROJ_DLL pj_context_set_user_writable_directory(PJ_CONTEXT* ctx, const std::string& path);
 std::string PROJ_DLL pj_get_relative_share_proj(PJ_CONTEXT *ctx);
 

--- a/test/unit/proj_context_test.cpp
+++ b/test/unit/proj_context_test.cpp
@@ -154,7 +154,7 @@ TEST(proj_context, proj_context_set_search_paths) {
 TEST(proj_context, read_grid_from_user_writable_directory) {
 
     auto ctx = proj_context_create();
-    auto path = pj_context_get_user_writable_directory(ctx, true);
+    auto path = std::string(proj_context_get_user_writable_directory(ctx, true));
     EXPECT_TRUE(!path.empty());
     auto filename = path + DIR_CHAR + "temp_proj_dic3";
     EXPECT_TRUE(createTmpFile(filename));


### PR DESCRIPTION
 - [x] Closes #2028
 - [x] Added clear title that can be used to generate release notes
 
After some thought, I decided that being consistent with what PROJ is using internally where possible will make things simpler.