### PR TITLE
Add limited support for non-conformant WKT1 LAS COMPD_CS[]

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -138,6 +138,8 @@ class PROJ_GCC_DLL CRS : public common::ObjectUsage,
 
     PROJ_INTERNAL CRSNNPtr normalizeForVisualization() const;
 
+    PROJ_INTERNAL CRSNNPtr allowNonConformantWKT1Export() const;
+
     //! @endcond
 
   protected:
@@ -891,6 +893,14 @@ class PROJ_GCC_DLL CompoundCRS final : public CRS,
     create(const util::PropertyMap &properties,
            const std::vector<CRSNNPtr>
                &components); // throw InvalidCompoundCRSException
+
+    //! @cond Doxygen_Suppress
+    PROJ_INTERNAL static CRSNNPtr
+    createLax(const util::PropertyMap &properties,
+              const std::vector<CRSNNPtr> &components,
+              const io::DatabaseContextPtr
+                  &dbContext); // throw InvalidCompoundCRSException
+                               //! @endcond
 
   protected:
     // relaxed: standard say SingleCRSNNPtr

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -479,8 +479,8 @@ static void outputObject(
                     std::cout << "WKT1:GDAL string:" << std::endl;
                 }
 
-                auto formatter =
-                    WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL);
+                auto formatter = WKTFormatter::create(
+                    WKTFormatter::Convention::WKT1_GDAL, dbContext);
                 if (outputOpt.singleLine) {
                     formatter->setMultiLine(false);
                 }


### PR DESCRIPTION
* Allow importing EPSG:{horizontal_code}+{geographic_code} and
  turn it into valid Geographic 3D or Projected 3D CRS internally
* Allow importing WKT1 COMPD_CS[] with above structure
* On an object imported that way, allow exporting to WKT1_GDAL,
  with this non-standard structure of a horizontal CRS + geographic CRS

CC @hobu