### PR TITLE
.travis.yml: give-up with i386 builds on linux_gcc8 (refs #2175)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,19 @@ matrix:
         - docker
       env:
         - BUILD_NAME=linux_gcc8
-        - DETAILS="linux, gcc8, i386"
-        - ARCH=i386
+        - DETAILS="linux, gcc8"
+        - ARCH=amd64
+#        - DETAILS="linux, gcc8, i386"
+#        - ARCH=i386
         - CC=gcc-8
         - CXX=g++-8
-        - CXXFLAGS='-g -O2 -m32 -D_GLIBCXX_ASSERTIONS'
-        - CFLAGS='-g -O2 -m32'
-        - TIFF_CFLAGS=-I/usr/include/i386-linux-gnu
-        - TIFF_LIBS="-L/usr/lib/i386-linux-gnu -ltiff"
-        - SQLITE3_CFLAGS=-I/usr/include/i386-linux-gnu
-        - SQLITE3_LIBS="-L/usr/lib/i386-linux-gnu -lsqlite3"
+        - CXXFLAGS='-g -O2 -D_GLIBCXX_ASSERTIONS'
+#        - CXXFLAGS='-g -O2 -m32 -D_GLIBCXX_ASSERTIONS'
+#        - CFLAGS='-g -O2 -m32'
+#        - TIFF_CFLAGS=-I/usr/include/i386-linux-gnu
+#        - TIFF_LIBS="-L/usr/lib/i386-linux-gnu -ltiff"
+#        - SQLITE3_CFLAGS=-I/usr/include/i386-linux-gnu
+#        - SQLITE3_LIBS="-L/usr/lib/i386-linux-gnu -lsqlite3"
       addons:
         apt:
           sources:


### PR DESCRIPTION
My conclusion after numerous frustrating trial and error is that
there's something that has changed in the ppa:ubuntu-toolchain-r/test
that conflicts with the i386 packages.
