### PR TITLE
[Backport 7.0] Fix support of WKT1_GDAL with netCDF rotated pole formulation (#2185)

### DIFF
--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -6344,10 +6344,9 @@ void Conversion::_exportToPROJString(
 
         auto derivedGeographicCRS =
             dynamic_cast<const crs::DerivedGeographicCRS *>(horiz);
-        if (derivedGeographicCRS) {
-            auto baseGeodCRS = derivedGeographicCRS->baseCRS();
+        if (!formatter->getCRSExport() && derivedGeographicCRS) {
             formatter->setOmitProjLongLatIfPossible(true);
-            baseGeodCRS->_exportToPROJString(formatter);
+            derivedGeographicCRS->addAngularUnitConvertAndAxisSwap(formatter);
             formatter->setOmitProjLongLatIfPossible(false);
         }
     }

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -4469,7 +4469,28 @@ CRSPtr WKTParser::Private::buildCRS(const WKTNodeNNPtr &node) {
     if (ci_equal(name, WKTConstants::PROJCS) ||
         ci_equal(name, WKTConstants::PROJCRS) ||
         ci_equal(name, WKTConstants::PROJECTEDCRS)) {
-        return util::nn_static_pointer_cast<CRS>(buildProjectedCRS(node));
+        auto projCRS =
+            util::nn_static_pointer_cast<CRS>(buildProjectedCRS(node));
+        auto projString = projCRS->getExtensionProj4();
+        if (starts_with(projString, "+proj=ob_tran +o_proj=longlat") ||
+            starts_with(projString, "+proj=ob_tran +o_proj=lonlat") ||
+            starts_with(projString, "+proj=ob_tran +o_proj=latlong") ||
+            starts_with(projString, "+proj=ob_tran +o_proj=latlon")) {
+            // Those are not a projected CRS, but a DerivedGeographic one...
+            if (projString.find(" +type=crs") == std::string::npos) {
+                projString += " +type=crs";
+            }
+            try {
+                auto projObj =
+                    PROJStringParser().createFromPROJString(projString);
+                auto crs = nn_dynamic_pointer_cast<CRS>(projObj);
+                if (crs) {
+                    return crs;
+                }
+            } catch (const io::ParsingException &) {
+            }
+        }
+        return projCRS.as_nullable();
     }
 
     if (ci_equal(name, WKTConstants::VERT_CS) ||


### PR DESCRIPTION
Contributes to fixing issue raised in
https://lists.osgeo.org/pipermail/gdal-dev/2020-April/052003.html

Backport of PR #2185