### PR TITLE
Avoid 2 warnings about missing database indices

### DIFF
--- a/data/sql/proj_db_table_defs.sql
+++ b/data/sql/proj_db_table_defs.sql
@@ -1340,6 +1340,8 @@ CREATE TABLE alias_name(
     source TEXT
 );
 
+CREATE INDEX idx_alias_name_code ON alias_name(code);
+
 CREATE TRIGGER alias_name_insert_trigger
 BEFORE INSERT ON alias_name
 FOR EACH ROW BEGIN

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5543,7 +5543,7 @@ AuthorityFactory::createObjectsFromName(
                 case ObjectType::GEOCENTRIC_CRS:
                     addToListStringWithOR(
                         otherConditions,
-                        "(" + colName + " = " GEOCENTRIC_SINGLE_QUOTED " AND "
+                        "(" + colName + " = 'geodetic_crs' AND "
                                         "type = " GEOCENTRIC_SINGLE_QUOTED ")");
                     break;
                 case ObjectType::GEOGRAPHIC_CRS:

--- a/src/sqlite3_utils.cpp
+++ b/src/sqlite3_utils.cpp
@@ -133,8 +133,25 @@ static int VFSCustomAccess(sqlite3_vfs *vfs, const char *zName, int flags,
 
 // ---------------------------------------------------------------------------
 
+// SQLite3 logging infrastructure
+static void projSqlite3LogCallback(void *, int iErrCode, const char *zMsg) {
+    fprintf(stderr, "SQLite3 message: (code %d) %s\n", iErrCode, zMsg);
+}
+
 std::unique_ptr<SQLite3VFS> SQLite3VFS::create(bool fakeSync, bool fakeLock,
                                                bool skipStatJournalAndWAL) {
+
+    // Install SQLite3 logger if PROJ_LOG_SQLITE3 env var is defined
+    struct InstallSqliteLogger {
+        InstallSqliteLogger() {
+            if (getenv("PROJ_LOG_SQLITE3") != nullptr) {
+                sqlite3_config(SQLITE_CONFIG_LOG, projSqlite3LogCallback,
+                               nullptr);
+            }
+        }
+    };
+    static InstallSqliteLogger installSqliteLogger;
+
     // Call to sqlite3_initialize() is normally not needed, except for
     // people building SQLite3 with -DSQLITE_OMIT_AUTOINIT
     sqlite3_initialize();

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2763,6 +2763,13 @@ TEST(factory, createObjectsFromName) {
                   .size(),
               3U);
 
+    EXPECT_EQ(
+        factory
+            ->createObjectsFromName(
+                "WGS 84", {AuthorityFactory::ObjectType::GEOCENTRIC_CRS}, false)
+            .size(),
+        1U);
+
     {
         auto res = factoryEPSG->createObjectsFromName(
             "WGS84", {AuthorityFactory::ObjectType::GEOGRAPHIC_2D_CRS}, true);


### PR DESCRIPTION
Fixes the 'automatic index on alias_name(code)' and 'automatic index on object_view(table_name)' warnings of #2221

Fixes #2221

Note: when running the whole test suite with PROJ_LOG_SQLITE3=YES, there are remaining warnings. I tried to address a few of the remaining ones, but wasn't successful