### PR TITLE
Add runtime checking that sqlite3 is >= 3.11

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -499,6 +499,15 @@ void DatabaseContext::Private::open(const std::string &databasePath,
     if (!ctx) {
         ctx = pj_get_default_ctx();
     }
+
+    const int sqlite3VersionNumber = sqlite3_libversion_number();
+    // Minimum version for correct performance: 3.11
+    if (sqlite3VersionNumber < 3 * 1000000 + 11 * 1000) {
+        pj_log(ctx, PJ_LOG_ERROR,
+               "SQLite3 version is %s, whereas at least 3.11 should be used",
+               sqlite3_libversion());
+    }
+
     setPjCtxt(ctx);
     std::string path(databasePath);
     if (path.empty()) {


### PR DESCRIPTION
```
$ LD_LIBRARY_PATH=$HOME/install-sqlite-3.8.2/lib PROJ_DEBUG=1 src/projinfo -s @in.wkt -t @out.wkt --spatial-test intersects >/dev/null
SQLite3 version is 3.8.2, whereas at least 3.11 should be used
```
