### PR TITLE
Enable commit notifications into dedicated 'proj-activity' IRC channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,14 @@ script:
 after_success: ./travis/${BUILD_NAME}/after_success.sh
 
 notifications:
+  irc:
+    channels:
+       - "irc.freenode.org#proj-activity"    
+#      - "irc.freenode.org#gdal"
+#      - "irc.freenode.org#proj"
+    use_notice: true
+    
 #  #email:
 #  #  recipients:
 #  #    - gdal-commits@lists.osgeo.org
-#
-  irc:
-    channels:
-#      - "irc.freenode.org#gdal"
-#      - "irc.freenode.org#proj"
-       - "irc.freenode.org#gdal-activity"
-    use_notice: true
+#    

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,13 +105,14 @@ script:
 
 after_success: ./travis/${BUILD_NAME}/after_success.sh
 
-#notifications:
+notifications:
 #  #email:
 #  #  recipients:
 #  #    - gdal-commits@lists.osgeo.org
 #
-#  irc:
-#    channels:
+  irc:
+    channels:
 #      - "irc.freenode.org#gdal"
 #      - "irc.freenode.org#proj"
-#    use_notice: true
+       - "irc.freenode.org#gdal-activity"
+    use_notice: true


### PR DESCRIPTION
 - enable commit notifications to dedicated IRC channel "proj-activity"
 - this follows how other projects handle this as QGIS, PostGIS (pushing commit notifications into dedicated <PROJECT>-activity channel, so packagers and developers get notices of changes, if they wish, and regular communications can still happen in the other #gdal or #proj channels).

@rouault has also been set as founder of the new activity channel.