### PR TITLE
Database: register geoid file for UK added in  OSGeo/PROJ-data#25

### DIFF
--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -123,6 +123,8 @@ INSERT INTO "geoid_model" SELECT 'GEOID12B', auth_name, code FROM grid_transform
 
 INSERT INTO "geoid_model" SELECT 'GEOID18', auth_name, code FROM grid_transformation WHERE auth_name = 'EPSG' AND grid_name LIKE 'g2018%' AND deprecated = 0;
 
+INSERT INTO "geoid_model" SELECT 'OSGM15', auth_name, code FROM grid_transformation WHERE auth_name = 'EPSG' AND grid_name LIKE '%OSGM15%' AND deprecated = 0;
+
 ---- PROJ historic +datum aliases -----
 
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','6326','WGS84','PROJ');

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -47,6 +47,8 @@ VALUES
 ('OSGM15_Malin.gri','uk_os_OSGM15_Malin.tif','OSGM15_Malin.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/uk_os_OSGM15_Malin.tif',1,1,NULL),
 -- Northern Ireland: OSGM15 height, Belfast height -> ETRS89 ellipsoidal heights
 ('OSGM15_Belfast.gri','uk_os_OSGM15_Belfast.tif','OSGM15_Belfast.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/uk_os_OSGM15_Belfast.tif',1,1,NULL),
+-- United Kingdom: OSGM15 height, ODN height -> ETRS89 ellipsoidal heights
+('OSTN15_OSGM15_GB.txt','uk_os_OSGM15_GB.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/uk_os_OSGM15_GB.tif',1,1,NULL),
 -- US GEOID99 height models. Not mapped: Alaska: g1999a01.gtx to g1999a04.gtx. Hawaii: g1999h01.gtx, Puerto Rico: g1999p01.gtx
 ('g1999u01.bin','us_noaa_g1999u01.tif','g1999u01.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/us_noaa_g1999u01.tif',1,1,NULL),
 ('g1999u02.bin','us_noaa_g1999u02.tif','g1999u02.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/us_noaa_g1999u02.tif',1,1,NULL),


### PR DESCRIPTION
Register geoid file for UK added in OSGeo/PROJ-data#25

There are already existing transformations `ETRS89 to ODN height (2)` with code `EPSG:7711`
 that use this grid `OSTN15_OSGM15_GB.txt`. So that's enough to add only `grid_alternatives` entry