### PR TITLE
Doc: add specific explanations for lat_ts for +proj=stere, also mentions +lat_0 and +k_0

### DIFF
--- a/docs/source/operations/projections/stere.rst
+++ b/docs/source/operations/projections/stere.rst
@@ -33,7 +33,17 @@ Parameters
 
 .. note:: All parameters are optional for the projection.
 
-.. include:: ../options/lat_ts.rst
+.. include:: ../options/lat_0.rst
+
+.. option:: +lat_ts=<value>
+
+    Defines the latitude where scale is not distorted. It is only taken into
+    account for Polar Stereographic formulations (``+lat_0`` = +/- 90 ), and
+    then defaults to the ``+lat_0`` value.
+    If set to a value different from +/- 90, it takes precedence over ``+k_0``
+    if both options are used together.
+
+.. include:: ../options/k_0.rst
 
 .. include:: ../options/lon_0.rst
 


### PR DESCRIPTION
Refs #2254
