### PR TITLE
Fix access violation in proj_context_get_database_metadata

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -348,6 +348,10 @@ const char *proj_context_get_database_metadata(PJ_CONTEXT *ctx,
         // temporary variable must be used as getDBcontext() might create
         // ctx->cpp_context
         auto osVal(getDBcontext(ctx)->getMetadata(key));
+        if (osVal == nullptr) {
+            ctx->cpp_context->autoCloseDbIfNeeded();
+            return nullptr;
+        }
         ctx->cpp_context->lastDbMetadataItem_ = osVal;
         ctx->cpp_context->autoCloseDbIfNeeded();
         return ctx->cpp_context->lastDbMetadataItem_.c_str();

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -2616,6 +2616,9 @@ TEST_F(CApi, proj_cs_get_axis_info) {
 TEST_F(CApi, proj_context_get_database_metadata) {
     EXPECT_TRUE(proj_context_get_database_metadata(m_ctxt, "IGNF.VERSION") !=
                 nullptr);
+
+    EXPECT_TRUE(proj_context_get_database_metadata(m_ctxt, "FOO") ==
+                nullptr);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

proj_context_get_database_metadata function crashes, if the requested key is not found. This pull request is an attempt to fix the bug. A simple test case is included.

Regards,
Olli Raisa
