### PR TITLE
add PROJ transformation for ETRS89 (EPSG:4937) to Alicate height (EPSG:5782)

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -138,6 +138,7 @@ VALUES
 -- Spain
 ('100800401.gsb','es_cat_icgc_100800401.tif','100800401.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/es_cat_icgc_100800401.tif',1,1,NULL),
 ('SPED2ETV2.gsb','es_ign_SPED2ETV2.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/es_ign_SPED2ETV2.tif',1,1,NULL),
+('EGM08_REDNAP.asc','es_ign_egm08-rednap.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/es_ign_egm08-rednap.tif',1,1,NULL),
 -- Portugal
 ('DLx_ETRS89_geo.gsb','pt_dgt_DLx_ETRS89_geo.tif','DLx_ETRS89_geo.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/pt_dgt_DLx_ETRS89_geo.tif',1,1,NULL),
 ('D73_ETRS89_geo.gsb','pt_dgt_D73_ETRS89_geo.tif','D73_ETRS89_geo.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/pt_dgt_D73_ETRS89_geo.tif',1,1,NULL),

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -84,3 +84,15 @@ INSERT INTO "grid_transformation" VALUES(
     NULL,
     'EPSG','8666','Geoid (height correction) model file','Icegeoid_ISN2016.gtx',
     NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
+-- Spain
+
+INSERT INTO "grid_transformation" VALUES(
+    'PROJ','EPSG_4937_TO_EPSG_5782','ETRS89 to Alicante height',
+    NULL,NULL,
+    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
+    'EPSG','4937', -- source CRS (ETRS89 geographic 3D)
+    'EPSG','5782', -- target CRS (Alicante height)
+    'EPSG','2366', -- area of use: Spain - mainland onshore
+    NULL,
+    'EPSG','8666','Geoid (height correction) model file','EGM08_REDNAP.asc',
+    NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);


### PR DESCRIPTION
This PR adds the PROJ transformation to use the Spanish geoid, already included in PROJ-data, es_ign_egm08-rednap.tif: `PROJ:EPSG_4937_TO_EPSG_5782`

The inclusion of this transformation in `EPSG` is being processed by the IGN. Once it is finally approved, I will remove `PROJ:EPSG_4937_TO_EPSG_5782` and create the new one `EPSG:xxxx`.

Some control points provided by the IGN:
```
P LONG_ETRS89(º ' ")   LAT_ETRS89(º ' ")    N  
1  -3º 42' 00.00000"   40º 27' 00.00000"  51.113
2  -1º 55' 12.00000"   41º 25' 12.00000"  51.877
3  -4º 52' 36.00000"   39º 23' 45.00000"  54.144
4   1º 12' 22.00000"   42º 12' 12.00000"  51.603
5  -5º 22' 13.00000"   39º 42' 06.00000"  53.873
6  -2º 22' 00.00000"   38º 12' 00.00000"  52.853
```


 - [ ] Tests added
 - [x] Added clear title that can be used to generate release notes

Note: Alicante height (`EPSG:5782`) is only valid in the Spanish peninsula. Some other Vertical CRS are being created in `EPSG` for the different islands. Then I will create more transformations for them. The Balearic islands will use the same geoid file.
