### PR TITLE
CMake build: Check "target_clones" before use

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -303,7 +303,18 @@ source_group("CMake Files" FILES CMakeLists.txt)
 # Embed PROJ_LIB data files location
 add_definitions(-DPROJ_LIB="${CMAKE_INSTALL_PREFIX}/${DATADIR}")
 
-add_definitions(-DTARGET_CLONES_FMA_ALLOWED)
+# The gcc "target_clones" function attribute relies on an extension
+# to the ELF standard. It must not be used on MinGW.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_QUIET TRUE)
+check_cxx_source_compiles([[
+  __attribute__((target_clones("fma","default")))
+  int clonable() { return 0; }
+  int main() { return clonable(); }
+]] TARGET_CLONES_FMA_ALLOWED)
+if(TARGET_CLONES_FMA_ALLOWED)
+  add_definitions(-DTARGET_CLONES_FMA_ALLOWED)
+endif()
 
 #################################################
 ## targets: libproj and proj_config.h


### PR DESCRIPTION
gcc's "target_clones" and "ifunc" function attributes rely on
extensions to the ELF standard. Using them on MinGW causes "error:
the call requires 'ifunc', which is not supported by this target".
Amends 5396b72.

 - [x] Added clear title that can be used to generate release notes
