### PR TITLE
[Backport 7.1] CMake build: Check "target_clones" before use

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -303,7 +303,18 @@ source_group("CMake Files" FILES CMakeLists.txt)
 # Embed PROJ_LIB data files location
 add_definitions(-DPROJ_LIB="${CMAKE_INSTALL_PREFIX}/${DATADIR}")
 
-add_definitions(-DTARGET_CLONES_FMA_ALLOWED)
+# The gcc "target_clones" function attribute relies on an extension
+# to the ELF standard. It must not be used on MinGW.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_QUIET TRUE)
+check_cxx_source_compiles([[
+  __attribute__((target_clones("fma","default")))
+  int clonable() { return 0; }
+  int main() { return clonable(); }
+]] TARGET_CLONES_FMA_ALLOWED)
+if(TARGET_CLONES_FMA_ALLOWED)
+  add_definitions(-DTARGET_CLONES_FMA_ALLOWED)
+endif()
 
 #################################################
 ## targets: libproj and proj_config.h

--- a/travis/osx/before_install.sh
+++ b/travis/osx/before_install.sh
@@ -4,19 +4,19 @@ set -e
 
 export PATH=$HOME/Library/Python/3.7/bin:$PATH
 
-brew unlink python@2
-brew update
+#brew unlink python@2
+#brew update
 brew install ccache
 #brew upgrade sqlite3
 #brew upgrade libtiff
-brew install doxygen graphviz
+#brew install doxygen graphviz
 #brew install md5sha1sum
 #brew reinstall python
-brew reinstall wget
+#brew reinstall wget
 
 ./travis/before_install_pip.sh
 
-pip3 install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
-which sphinx-build
+# pip3 install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
+# which sphinx-build
 
-(cd docs; make html)
+# (cd docs; make html)


### PR DESCRIPTION
gcc's "target_clones" and "ifunc" function attributes rely on
extensions to the ELF standard. Using them on MinGW causes "error:
the call requires 'ifunc', which is not supported by this target".
Amends 5396b72.

Backport of #2294