### PR TITLE
Move doc building (without deployment) to github action

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -1,0 +1,21 @@
+name: Doc building
+
+on: [push, pull_request]
+
+jobs:
+
+  doc_building:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Requirements
+        run: |
+          sudo apt update
+          sudo apt install -y python3-pip python3-setuptools python3-dev python3-wheel doxygen gcc
+          sudo pip3 install sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
+
+      - name: Build doc
+        run: |
+            (cd docs; make html)

--- a/travis/osx/before_install.sh
+++ b/travis/osx/before_install.sh
@@ -4,19 +4,19 @@ set -e
 
 export PATH=$HOME/Library/Python/3.7/bin:$PATH
 
-brew unlink python@2
-brew update
+#brew unlink python@2
+#brew update
 brew install ccache
 #brew upgrade sqlite3
 #brew upgrade libtiff
-brew install doxygen graphviz
+#brew install doxygen graphviz
 #brew install md5sha1sum
 #brew reinstall python
-brew reinstall wget
+#brew reinstall wget
 
 ./travis/before_install_pip.sh
 
-pip3 install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
-which sphinx-build
+# pip3 install --user sphinx sphinx-rtd-theme sphinxcontrib-bibtex breathe
+# which sphinx-build
 
-(cd docs; make html)
+# (cd docs; make html)


### PR DESCRIPTION
- Remove the 'make html' from the Travis OSX. Relying on Homebrew is too unstable
- Move it to a github action. Uses latest versions of Sphinx / Breathe from pip
- Regular building for deployment remains with the Docker method in the Travis linux_gcc config