### PR TITLE
Revert compiler generated Fused Multiply Addition optimized routines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,27 +128,6 @@ fi
 AC_LANG_POP([C++])
 
 dnl ---------------------------------------------------------------------------
-dnl Check if __attribute__((target_clones("fma","default"))) works
-dnl This is needed for example on Alpine Linux where for some reason, building
-dnl such tagged functions fails with 'error: the call requires 'ifunc', which is not supported by this target'
-dnl ---------------------------------------------------------------------------
-
-TARGET_CLONES_FMA_FLAGS=""
-AC_MSG_CHECKING([if target_clones_fma works])
-SAVED_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -Werror"
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[
-__attribute__((target_clones("fma","default"))) void foo() {}
-]])],
-[AC_MSG_RESULT([yes])]
-[TARGET_CLONES_FMA_FLAGS="-DTARGET_CLONES_FMA_ALLOWED"],
-[AC_MSG_RESULT([no])])
-CFLAGS="$SAVED_CFLAGS"
-AC_SUBST(TARGET_CLONES_FMA_FLAGS,$TARGET_CLONES_FMA_FLAGS)
-
-
-dnl ---------------------------------------------------------------------------
 dnl Check for --enable-lto
 dnl ---------------------------------------------------------------------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ check_PROGRAMS = geodtest
 
 AM_CPPFLAGS =	-DPROJ_LIB=\"$(pkgdatadir)\" \
 		-DMUTEX_@MUTEX_SETTING@ -I$(top_srcdir)/include @SQLITE3_CFLAGS@ @TIFF_CFLAGS@ @TIFF_ENABLED_FLAGS@ @CURL_CFLAGS@ @CURL_ENABLED_FLAGS@
-AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@ @TARGET_CLONES_FMA_FLAGS@
+AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@
 
 include_HEADERS = proj.h proj_experimental.h proj_constants.h proj_api.h geodesic.h \
 	 proj_symbol_rename.h

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -303,19 +303,6 @@ source_group("CMake Files" FILES CMakeLists.txt)
 # Embed PROJ_LIB data files location
 add_definitions(-DPROJ_LIB="${CMAKE_INSTALL_PREFIX}/${DATADIR}")
 
-# The gcc "target_clones" function attribute relies on an extension
-# to the ELF standard. It must not be used on MinGW.
-include(CheckCXXSourceCompiles)
-set(CMAKE_REQUIRED_QUIET TRUE)
-check_cxx_source_compiles([[
-  __attribute__((target_clones("fma","default")))
-  int clonable() { return 0; }
-  int main() { return clonable(); }
-]] TARGET_CLONES_FMA_ALLOWED)
-if(TARGET_CLONES_FMA_ALLOWED)
-  add_definitions(-DTARGET_CLONES_FMA_ALLOWED)
-endif()
-
 #################################################
 ## targets: libproj and proj_config.h
 #################################################

--- a/src/projections/tmerc.cpp
+++ b/src/projections/tmerc.cpp
@@ -66,15 +66,6 @@ struct tmerc_data {
 /* Constant for "exact" transverse mercator */
 #define PROJ_ETMERC_ORDER 6
 
-// Determine if we should try to provide optimized versions for the Fused Multiply Addition
-// Intel instruction set. We use GCC 6 __attribute__((target_clones("fma","default")))
-// mechanism for that, where the compiler builds a default version, and one that
-// uses FMA. And at runtimes it figures out automatically which version can be used
-// by the current CPU. This allows to create general purpose binaries.
-#if defined(TARGET_CLONES_FMA_ALLOWED) && defined(__GNUC__) && __GNUC__ >= 6 && defined(__x86_64__) && !defined(__FMA__)
-#define BUILD_FMA_OPTIMIZED_VERSION
-#endif
-
 /*****************************************************************************/
 //
 //                  Approximate Transverse Mercator functions
@@ -82,10 +73,7 @@ struct tmerc_data {
 /*****************************************************************************/
 
 
-#ifdef BUILD_FMA_OPTIMIZED_VERSION
-__attribute__((target_clones("fma","default")))
-#endif
-inline static PJ_XY approx_e_fwd_internal (PJ_LP lp, PJ *P)
+static PJ_XY approx_e_fwd (PJ_LP lp, PJ *P)
 {
     PJ_XY xy = {0.0, 0.0};
     const auto *Q = &(static_cast<struct tmerc_data*>(P->opaque)->approx);
@@ -125,11 +113,6 @@ inline static PJ_XY approx_e_fwd_internal (PJ_LP lp, PJ *P)
         + FC8 * als * (1385. + t * ( t * (543. - t) - 3111.) )
         ))));
     return (xy);
-}
-
-static PJ_XY approx_e_fwd (PJ_LP lp, PJ *P)
-{
-    return approx_e_fwd_internal(lp, P);
 }
 
 static PJ_XY approx_s_fwd (PJ_LP lp, PJ *P) {
@@ -177,10 +160,7 @@ static PJ_XY approx_s_fwd (PJ_LP lp, PJ *P) {
     return xy;
 }
 
-#ifdef BUILD_FMA_OPTIMIZED_VERSION
-__attribute__((target_clones("fma","default")))
-#endif
-inline static PJ_LP approx_e_inv_internal (PJ_XY xy, PJ *P) {
+static PJ_LP approx_e_inv (PJ_XY xy, PJ *P) {
     PJ_LP lp = {0.0,0.0};
     const auto *Q = &(static_cast<struct tmerc_data*>(P->opaque)->approx);
 
@@ -210,10 +190,6 @@ inline static PJ_LP approx_e_inv_internal (PJ_XY xy, PJ *P) {
         ))) / cosphi;
     }
     return lp;
-}
-
-static PJ_LP approx_e_inv (PJ_XY xy, PJ *P) {
-    return approx_e_inv_internal(xy, P);
 }
 
 static PJ_LP approx_s_inv (PJ_XY xy, PJ *P) {


### PR DESCRIPTION
Fixes #2326

Partially reverts commit b84c9d0cb61f3bd561da6092e15e294ae7e410e0 to
remove the use of the gcc 6 mechanism of generated multiple versions of
functions with different optimization flags, which was found to causes
crashes when dlopen'ing PROJ on CentOS 7.8 with gcc 8.3.1
