### PR TITLE
Add methods to projCtx_t for safer interactions with cpp_context

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -113,6 +113,30 @@ projCtx_t projCtx_t::createDefault()
     return ctx;
 }
 
+/**************************************************************************/
+/*                           get_cpp_context()                            */
+/**************************************************************************/
+
+projCppContext* projCtx_t::get_cpp_context()
+{
+    if (cpp_context == nullptr) {
+        cpp_context = new projCppContext(this);
+    }
+    return cpp_context;
+}
+
+
+/**************************************************************************/
+/*                           safeAutoCloseDbIfNeeded()                      */
+/**************************************************************************/
+
+void projCtx_t::safeAutoCloseDbIfNeeded()
+{
+    if (cpp_context) {
+        cpp_context->autoCloseDbIfNeeded();
+    }
+}
+
 /************************************************************************/
 /*                           set_search_paths()                         */
 /************************************************************************/

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1627,10 +1627,7 @@ static void *pj_open_file_with_manager(projCtx ctx, const char *name,
 
 static NS_PROJ::io::DatabaseContextPtr getDBcontext(PJ_CONTEXT *ctx) {
     try {
-        if (ctx->cpp_context == nullptr) {
-            ctx->cpp_context = new projCppContext(ctx);
-        }
-        return ctx->cpp_context->getDatabaseContext().as_nullable();
+        return ctx->get_cpp_context()->getDatabaseContext().as_nullable();
     } catch (const std::exception &e) {
         pj_log(ctx, PJ_LOG_DEBUG, "%s", e.what());
         return nullptr;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -758,6 +758,8 @@ struct projCtx_t {
 
     projCtx_t& operator= (const projCtx_t&) = delete;
 
+    projCppContext* get_cpp_context();
+    void safeAutoCloseDbIfNeeded();
     void set_search_paths(const std::vector<std::string>& search_paths_in);
     void set_ca_bundle_path(const std::string& ca_bundle_path_in);
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Added clear title that can be used to generate release notes

Because the member `cpp_context` of `projCtx_t` can be null, methods to ensure safe interactions with `cpp_context` looked like they would be helpful.