### PR TITLE
fix typo in Canary Islands

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@
 
   o Added various Brazillian grids to the database #2277
 
-  o Added geoid file for Canary Island to the database #2312
+  o Added geoid file for Canary Islands to the database #2312
 
   o Updated EPSG database to version 9.8.15 #2310
 


### PR DESCRIPTION
Name is plural, with `s`