### PR TITLE
Fix compiling warnings when using GCC 4.8.x

### DIFF
--- a/include/proj/datum.hpp
+++ b/include/proj/datum.hpp
@@ -541,7 +541,7 @@ class PROJ_GCC_DLL RealizationMethod : public util::CodeList {
     PROJ_FRIEND_OPTIONAL(RealizationMethod);
     PROJ_DLL explicit RealizationMethod(
         const std::string &nameIn = std::string());
-    PROJ_DLL RealizationMethod(const RealizationMethod &other);
+    PROJ_DLL RealizationMethod(const RealizationMethod &other) = default;
     PROJ_DLL RealizationMethod &operator=(const RealizationMethod &other);
 };
 

--- a/include/proj/util.hpp
+++ b/include/proj/util.hpp
@@ -692,7 +692,7 @@ class CodeList {
     //! @endcond
   protected:
     explicit CodeList(const std::string &nameIn) : name_(nameIn) {}
-    CodeList(const CodeList &other) = default;
+    CodeList(const CodeList &) = default;
     CodeList &operator=(const CodeList &other);
 
   private:

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1773,10 +1773,6 @@ RealizationMethod::RealizationMethod(const std::string &nameIn)
 
 // ---------------------------------------------------------------------------
 
-RealizationMethod::RealizationMethod(const RealizationMethod &) = default;
-
-// ---------------------------------------------------------------------------
-
 RealizationMethod &RealizationMethod::
 operator=(const RealizationMethod &other) {
     CodeList::operator=(other);


### PR DESCRIPTION
Without this, the original version gives the following warnings when compiling with GCC 4.8.5:

```
In file included from /home/saprykin/gemsim/src/3dparty/proj4/include/proj/io.hpp:41:0,
                 from /home/saprykin/gemsim/src/3dparty/proj4/include/proj/common.hpp:36,
                 from /home/saprykin/gemsim/src/3dparty/proj4/include/proj/datum.hpp:36,
                 from /home/saprykin/gemsim/src/3dparty/proj4/iso19111/datum.cpp:33:
/home/saprykin/gemsim/src/3dparty/proj4/include/proj/util.hpp:695:5: warning: unused parameter ‘other’ [-Wunused-parameter]
     CodeList(const CodeList &other) = default;
     ^
In file included from /home/saprykin/gemsim/src/3dparty/proj4/iso19111/datum.cpp:33:0:
/home/saprykin/gemsim/src/3dparty/proj4/include/proj/datum.hpp: In copy constructor ‘osgeo::proj::datum::RealizationMethod::RealizationMethod(const osgeo::proj::datum::RealizationMethod&)’:
/home/saprykin/gemsim/src/3dparty/proj4/include/proj/datum.hpp:534:20: note: synthesized method ‘osgeo::proj::util::CodeList::CodeList(const osgeo::proj::util::CodeList&)’ first required here 
 class PROJ_GCC_DLL RealizationMethod : public util::CodeList {
                    ^
/home/saprykin/gemsim/src/3dparty/proj4/iso19111/datum.cpp: At global scope:
/home/saprykin/gemsim/src/3dparty/proj4/iso19111/datum.cpp:1776:67: note: synthesized method ‘osgeo::proj::datum::RealizationMethod::RealizationMethod(const osgeo::proj::datum::RealizationMethod&)’ first required here 
 RealizationMethod::RealizationMethod(const RealizationMethod &) = default;
```