### PR TITLE
Implement ellipsoidal formulation of +proj=ortho (fixes #397)

### DIFF
--- a/docs/source/operations/projections/ortho.rst
+++ b/docs/source/operations/projections/ortho.rst
@@ -10,7 +10,7 @@ around a given latitude and longitude.
 +---------------------+--------------------------------------------------------+
 | **Classification**  | Azimuthal                                              |
 +---------------------+--------------------------------------------------------+
-| **Available forms** | Forward and inverse, spherical projection              |
+| **Available forms** | Forward and inverse, spherical and ellipsoidal         |
 +---------------------+--------------------------------------------------------+
 | **Defined area**    | Global, although only one hemisphere can be seen at a  |
 |                     | time                                                   |
@@ -31,6 +31,12 @@ around a given latitude and longitude.
 
    proj-string: ``+proj=ortho``
 
+
+.. note:: Before PROJ 7.2, only the spherical formulation was implemented. If
+          wanting to replicate PROJ < 7.2 results with newer versions, the
+          ellipsoid must be forced to a sphere, for example by adding a ``+f=0``
+          parameter.
+
 Parameters
 ################################################################################
 
@@ -39,6 +45,8 @@ Parameters
 .. include:: ../options/lon_0.rst
 
 .. include:: ../options/lat_0.rst
+
+.. include:: ../options/ellps.rst
 
 .. include:: ../options/R.rst
 

--- a/include/proj/internal/coordinateoperation_constants.hpp
+++ b/include/proj/internal/coordinateoperation_constants.hpp
@@ -729,6 +729,9 @@ static const MethodMapping projectionMethodMappings[] = {
     {EPSG_NAME_METHOD_ORTHOGRAPHIC, EPSG_CODE_METHOD_ORTHOGRAPHIC,
      "Orthographic", "ortho", nullptr, paramsNatOrigin},
 
+    {PROJ_WKT2_NAME_ORTHOGRAPHIC_SPHERICAL, 0, "Orthographic", "ortho", "f=0",
+     paramsNatOrigin},
+
     {PROJ_WKT2_NAME_METHOD_PATTERSON, 0, "Patterson", "patterson", nullptr,
      paramsLonNatOrigin},
 

--- a/include/proj/internal/esri_projection_mappings.hpp
+++ b/include/proj/internal/esri_projection_mappings.hpp
@@ -600,6 +600,19 @@ static const ESRIParamMapping paramsESRI_Orthographic[] = {
      EPSG_CODE_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN, "0.0", false},
     {nullptr, nullptr, 0, "0.0", false}};
 
+static const ESRIParamMapping paramsESRI_Local[] = {
+    {"False_Easting", EPSG_NAME_PARAMETER_FALSE_EASTING,
+     EPSG_CODE_PARAMETER_FALSE_EASTING, "0.0", false},
+    {"False_Northing", EPSG_NAME_PARAMETER_FALSE_NORTHING,
+     EPSG_CODE_PARAMETER_FALSE_NORTHING, "0.0", false},
+    {"Scale_Factor", nullptr, 0, "1.0", false},
+    {"Azimuth", nullptr, 0, "0.0", false},
+    {"Longitude_Of_Center", EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN,
+     EPSG_CODE_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN, "0.0", false},
+    {"Latitude_Of_Center", EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN,
+     EPSG_CODE_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN, "0.0", false},
+    {nullptr, nullptr, 0, "0.0", false}};
+
 static const ESRIParamMapping paramsESRI_Winkel_Tripel[] = {
     {"False_Easting", EPSG_NAME_PARAMETER_FALSE_EASTING,
      EPSG_CODE_PARAMETER_FALSE_EASTING, "0.0", false},
@@ -1004,8 +1017,10 @@ static const ESRIMethodMapping esriMappings[] = {
      EPSG_CODE_METHOD_KROVAK_NORTH_ORIENTED, paramsESRI_Krovak_alt2},
     {"New_Zealand_Map_Grid", EPSG_NAME_METHOD_NZMG, EPSG_CODE_METHOD_NZMG,
      paramsESRI_New_Zealand_Map_Grid},
-    {"Orthographic", EPSG_NAME_METHOD_ORTHOGRAPHIC,
-     EPSG_CODE_METHOD_ORTHOGRAPHIC, paramsESRI_Orthographic},
+    {"Orthographic", PROJ_WKT2_NAME_ORTHOGRAPHIC_SPHERICAL, 0,
+     paramsESRI_Orthographic},
+    {"Local", EPSG_NAME_METHOD_ORTHOGRAPHIC, EPSG_CODE_METHOD_ORTHOGRAPHIC,
+     paramsESRI_Local},
     {"Winkel_Tripel", "Winkel Tripel", 0, paramsESRI_Winkel_Tripel},
     {"Aitoff", "Aitoff", 0, paramsESRI_Aitoff},
     {"Flat_Polar_Quartic", PROJ_WKT2_NAME_METHOD_FLAT_POLAR_QUARTIC, 0,

--- a/scripts/build_esri_projection_mapping.py
+++ b/scripts/build_esri_projection_mapping.py
@@ -436,11 +436,23 @@ config_str = """
         - Longitude_Of_Origin: EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN
         - Latitude_Of_Origin: EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN
 
+# ESRI's Orthographic is a spherical-only formulation. The ellipsoidal capable
+# name is Local. See below
 - Orthographic:
+    WKT2_name: PROJ_WKT2_NAME_ORTHOGRAPHIC_SPHERICAL
+    Params:
+        - False_Easting: EPSG_NAME_PARAMETER_FALSE_EASTING
+        - False_Northing: EPSG_NAME_PARAMETER_FALSE_NORTHING
+        - Longitude_Of_Center: EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN
+        - Latitude_Of_Center: EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN
+
+- Local:
     WKT2_name: EPSG_NAME_METHOD_ORTHOGRAPHIC
     Params:
         - False_Easting: EPSG_NAME_PARAMETER_FALSE_EASTING
         - False_Northing: EPSG_NAME_PARAMETER_FALSE_NORTHING
+        - Scale_Factor: 1.0
+        - Azimuth: 0.0
         - Longitude_Of_Center: EPSG_NAME_PARAMETER_LONGITUDE_OF_NATURAL_ORIGIN
         - Latitude_Of_Center: EPSG_NAME_PARAMETER_LATITUDE_OF_NATURAL_ORIGIN
 

--- a/src/iso19111/coordinateoperation.cpp
+++ b/src/iso19111/coordinateoperation.cpp
@@ -4251,7 +4251,7 @@ ConversionNNPtr Conversion::createObliqueStereographic(
  * This method is defined as [EPSG:9840]
  * (https://www.epsg-registry.org/export.htm?gml=urn:ogc:def:method:EPSG::9840)
  *
- * \note At the time of writing, PROJ only implements the spherical formulation
+ * \note Before PROJ 7.2, only the spherical formulation was implemented.
  *
  * @param properties See \ref general_properties of the conversion. If the name
  * is not provided, it is automatically set.

--- a/src/proj_constants.h
+++ b/src/proj_constants.h
@@ -183,6 +183,9 @@
 #define EPSG_NAME_METHOD_ORTHOGRAPHIC "Orthographic"
 #define EPSG_CODE_METHOD_ORTHOGRAPHIC 9840
 
+#define PROJ_WKT2_NAME_ORTHOGRAPHIC_SPHERICAL \
+    "Orthographic (Spherical)"
+
 #define PROJ_WKT2_NAME_METHOD_PATTERSON "Patterson"
 
 #define EPSG_NAME_METHOD_AMERICAN_POLYCONIC "American Polyconic"

--- a/src/projections/ortho.cpp
+++ b/src/projections/ortho.cpp
@@ -171,7 +171,7 @@ static PJ_LP ortho_e_inverse (PJ_XY xy, PJ *P) {           /* Ellipsoidal, inver
         // ==> lam = atan2(xy.x, -xy.y * sign(phi0))
         // ==> xy.x^2 + xy.y^2 = nu^2 * cosphi^2
         //                rh^2 = cosphi^2 / (1 - es * sinphi^2)
-        // ==>  sinphi^2 = (1 - rh^2) / (1 - es * rh^2)
+        // ==>  cosphi^2 = rh^2 * (1 - es) / (1 - es * rh^2)
 
         const double rh2 = SQ(xy.x) + SQ(xy.y);
         if (rh2 >= 1. - 1e-15) {
@@ -184,7 +184,7 @@ static PJ_LP ortho_e_inverse (PJ_XY xy, PJ *P) {           /* Ellipsoidal, inver
             lp.phi = 0;
         }
         else {
-            lp.phi = asin(sqrt((1 - rh2) / (1 - P->es * rh2))) * (Q->mode == N_POLE ? 1 : -1);
+            lp.phi = acos(sqrt(rh2 * P->one_es / (1 - P->es * rh2))) * (Q->mode == N_POLE ? 1 : -1);
         }
         lp.lam = atan2(xy.x, xy.y * (Q->mode == N_POLE ? -1 : 1));
         return lp;

--- a/src/projections/ortho.cpp
+++ b/src/projections/ortho.cpp
@@ -135,7 +135,7 @@ static PJ_XY ortho_e_forward (PJ_LP lp, PJ *P) {           /* Ellipsoidal, forwa
     PJ_XY xy;
     struct pj_opaque *Q = static_cast<struct pj_opaque*>(P->opaque);
 
-    // From EPSG guidance note 7.2
+    // From EPSG guidance note 7.2, March 2020, §3.3.5 Orthographic
     const double cosphi = cos(lp.phi);
     const double sinphi = sin(lp.phi);
     const double coslam = cos(lp.lam);
@@ -234,7 +234,7 @@ static PJ_LP ortho_e_inverse (PJ_XY xy, PJ *P) {           /* Ellipsoidal, inver
         return lp;
     }
 
-    // From EPSG guidance note 7.2
+    // From EPSG guidance note 7.2, March 2020, §3.3.5 Orthographic
 
     // It suggests as initial guess:
     // lp.lam = 0;

--- a/src/projections/ortho.cpp
+++ b/src/projections/ortho.cpp
@@ -50,6 +50,13 @@ static PJ_XY ortho_s_forward (PJ_LP lp, PJ *P) {           /* Spheroidal, forwar
         break;
     case OBLIQ:
         sinphi = sin(lp.phi);
+
+        // Is the point visible from the projection plane ?
+        // From https://lists.osgeo.org/pipermail/proj/2020-September/009831.html
+        // this is the dot product of the normal of the ellipsoid at the center of
+        // the projection and at the point considered for projection.
+        // [cos(phi)*cos(lambda), cos(phi)*sin(lambda), sin(phi)]
+        // Also from Snyder's Map Projection - A working manual, equation (5-3), page 149
         if (Q->sinph0 * sinphi + Q->cosph0 * cosphi * coslam < - EPS10)
             return forward_error(P, lp, xy);
         xy.y = Q->cosph0 * sinphi - Q->sinph0 * cosphi * coslam;
@@ -131,6 +138,14 @@ static PJ_XY ortho_e_forward (PJ_LP lp, PJ *P) {           /* Ellipsoidal, forwa
     const double sinphi = sin(lp.phi);
     const double coslam = cos(lp.lam);
     const double sinlam = sin(lp.lam);
+
+    // Is the point visible from the projection plane ?
+    // Same condition as in spherical case
+    if (Q->sinph0 * sinphi + Q->cosph0 * cosphi * coslam < - EPS10) {
+        xy.x = HUGE_VAL; xy.y = HUGE_VAL;
+        return forward_error(P, lp, xy);
+    }
+
     const double nu = 1.0 / sqrt(1.0 - P->es * sinphi * sinphi);
     xy.x = nu * cosphi * sinlam;
     xy.y = nu * (sinphi * Q->cosph0 - cosphi * Q->sinph0 * coslam) +

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -4266,7 +4266,7 @@ expect  -223374.577355253 -111701.072127637
 
 ===============================================================================
 # Orthographic
-# 	Azi, Sph.
+# 	Azi, Sph&Ell.
 ===============================================================================
 
 -------------------------------------------------------------------------------
@@ -4420,6 +4420,72 @@ expect      failure errno tolerance_condition
 # it should still results in a correct coordinate.
 accept      0.70710678118 0.7071067812
 expect      45  0
+
+
+-------------------------------------------------------------------------------
+# Test the ellipsoidal formulation
+
+# Test data from Guidance Note 7 part 2, March 2020,  p. 90
+-------------------------------------------------------------------------------
+operation   +proj=ortho +ellps=WGS84 +lat_0=55 +lon_0=5
+-------------------------------------------------------------------------------
+tolerance   1 mm
+accept      2.12955      53.80939444444444
+expect      -189011.711  -128640.567
+roundtrip   1
+
+# Equatorial
+operation   +proj=ortho +ellps=WGS84
+tolerance   0.1 mm
+accept      0               0
+expect      0               0
+roundtrip   1
+
+accept      0               89.99
+expect      0               6356752.2167
+roundtrip   1
+
+accept      0               -89.99
+expect      0               -6356752.2167
+roundtrip   1
+
+# Consistant with WGS84 semi-minor axis
+# The inverse transformation doesn't converge due to properties of the projection
+accept      0               90
+expect      0               6356752.3142
+
+# North pole tests
+operation   +proj=ortho +ellps=WGS84 +lat_0=90
+tolerance   0.1 mm
+accept      0               90
+expect      0               0
+roundtrip   1
+
+accept      1               89.999
+expect      1.9493         -111.6770
+roundtrip   1
+
+# Consistant with WGS84 semi-major axis
+# The inverse transformation doesn't converge due to properties of the projection
+accept      0               0
+expect      0               -6378137
+
+# South pole tests
+operation   +proj=ortho +ellps=WGS84 +lat_0=-90
+tolerance   0.1 mm
+accept      0               -90
+expect      0               0
+roundtrip   1
+
+accept      1               -89.999
+expect      1.9493          111.6770
+roundtrip   1
+
+# Consistant with WGS84 semi-major axis
+# The inverse transformation doesn't converge due to properties of the projection
+accept      0               0
+expect      0               6378137
+
 
 ===============================================================================
 # Perspective Conic

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -4434,11 +4434,21 @@ accept      2.12955      53.80939444444444
 expect      -189011.711  -128640.567
 roundtrip   1
 
+-------------------------------------------------------------------------------
 # Equatorial
+-------------------------------------------------------------------------------
 operation   +proj=ortho +ellps=WGS84
 tolerance   0.1 mm
 accept      0               0
 expect      0               0
+roundtrip   1
+
+accept      89.99           0
+expect      6378136.9029    0
+roundtrip   1
+
+accept      -89.99          0
+expect      -6378136.9029   0
 roundtrip   1
 
 accept      0               89.99
@@ -4449,12 +4459,33 @@ accept      0               -89.99
 expect      0               -6356752.2167
 roundtrip   1
 
+# Point not visible from the projection plane
+accept      90.00001        0
+expect      failure         errno tolerance_condition
+
+# Point not visible from the projection plane
+accept      -90.00001       0
+expect      failure         errno tolerance_condition
+
+# Consistant with WGS84 semi-major axis
+# The inverse transformation doesn't converge due to properties of the projection
+accept      90              0
+expect      6378137         0
+
+accept      -90             0
+expect      -6378137        0
+
 # Consistant with WGS84 semi-minor axis
 # The inverse transformation doesn't converge due to properties of the projection
 accept      0               90
 expect      0               6356752.3142
 
+accept      0               -90
+expect      0               -6356752.3142
+
+-------------------------------------------------------------------------------
 # North pole tests
+-------------------------------------------------------------------------------
 operation   +proj=ortho +ellps=WGS84 +lat_0=90
 tolerance   0.1 mm
 accept      0               90
@@ -4465,12 +4496,18 @@ accept      1               89.999
 expect      1.9493         -111.6770
 roundtrip   1
 
+# Point not visible from the projection plane
+accept      0               -0.0000001
+expect      failure         errno tolerance_condition
+
 # Consistant with WGS84 semi-major axis
 # The inverse transformation doesn't converge due to properties of the projection
 accept      0               0
 expect      0               -6378137
 
+-------------------------------------------------------------------------------
 # South pole tests
+-------------------------------------------------------------------------------
 operation   +proj=ortho +ellps=WGS84 +lat_0=-90
 tolerance   0.1 mm
 accept      0               -90
@@ -4480,6 +4517,10 @@ roundtrip   1
 accept      1               -89.999
 expect      1.9493          111.6770
 roundtrip   1
+
+# Point not visible from the projection plane
+accept      0               0.0000001
+expect      failure         errno tolerance_condition
 
 # Consistant with WGS84 semi-major axis
 # The inverse transformation doesn't converge due to properties of the projection

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -4270,7 +4270,7 @@ expect  -223374.577355253 -111701.072127637
 ===============================================================================
 
 -------------------------------------------------------------------------------
-# Test the equatorial aspect of the Orthopgraphic projection.
+# Test the equatorial aspect of the Orthographic projection.
 
 # Test data from Snyder (1987), table 22, p. 151.
 -------------------------------------------------------------------------------
@@ -4322,7 +4322,7 @@ expect      failure errno tolerance_condition
 
 
 -------------------------------------------------------------------------------
-# Test the oblique aspect of the Orthopgraphic projection.
+# Test the oblique aspect of the Orthographic projection.
 
 # Test data from Snyder (1987), table 23, pp. 152-153.
 -------------------------------------------------------------------------------
@@ -4356,7 +4356,7 @@ expect      failure errno tolerance_condition
 
 
 -------------------------------------------------------------------------------
-# Test the north polar aspect of the Orthopgraphic projection.
+# Test the north polar aspect of the Orthographic projection.
 -------------------------------------------------------------------------------
 operation   +proj=ortho +R=1 +lat_0=90 +lon_0=0
 -------------------------------------------------------------------------------
@@ -4386,7 +4386,7 @@ accept      2   2
 expect      failure errno tolerance_condition
 
 -------------------------------------------------------------------------------
-# Test the south polar aspect of the Orthopgraphic projection.
+# Test the south polar aspect of the Orthographic projection.
 -------------------------------------------------------------------------------
 operation   +proj=ortho +R=1 +lat_0=-90 +lon_0=0
 -------------------------------------------------------------------------------
@@ -4443,6 +4443,22 @@ accept      0               0
 expect      0               0
 roundtrip   1
 
+accept      1               1
+expect      111296.9991     110568.7748
+roundtrip   1
+
+accept      1               -1
+expect      111296.9991     -110568.7748
+roundtrip   1
+
+accept      -1              1
+expect      -111296.9991    110568.7748
+roundtrip   1
+
+accept      -1              -1
+expect      -111296.9991    -110568.7748
+roundtrip   1
+
 accept      89.99           0
 expect      6378136.9029    0
 roundtrip   1
@@ -4468,20 +4484,37 @@ accept      -90.00001       0
 expect      failure         errno tolerance_condition
 
 # Consistant with WGS84 semi-major axis
-# The inverse transformation doesn't converge due to properties of the projection
 accept      90              0
 expect      6378137         0
+roundtrip   1
 
 accept      -90             0
 expect      -6378137        0
+roundtrip   1
 
 # Consistant with WGS84 semi-minor axis
-# The inverse transformation doesn't converge due to properties of the projection
 accept      0               90
 expect      0               6356752.3142
+roundtrip   1
 
 accept      0               -90
 expect      0               -6356752.3142
+roundtrip   1
+
+# Point not visible from the projection plane
+direction   inverse
+accept      0               6356752.3143
+expect      failure         errno tolerance_condition
+
+# Point not visible from the projection plane
+direction   inverse
+accept      1000            6356752.314
+expect      failure         errno tolerance_condition
+
+# Point not visible from the projection plane
+direction   inverse
+accept      6378137.0001    0
+expect      failure         errno tolerance_condition
 
 -------------------------------------------------------------------------------
 # North pole tests
@@ -4501,9 +4534,14 @@ accept      0               -0.0000001
 expect      failure         errno tolerance_condition
 
 # Consistant with WGS84 semi-major axis
-# The inverse transformation doesn't converge due to properties of the projection
 accept      0               0
 expect      0               -6378137
+roundtrip   1
+
+# Point not visible from the projection plane
+direction   inverse
+accept      0               -6378137.1
+expect      failure         errno tolerance_condition
 
 -------------------------------------------------------------------------------
 # South pole tests
@@ -4523,9 +4561,14 @@ accept      0               0.0000001
 expect      failure         errno tolerance_condition
 
 # Consistant with WGS84 semi-major axis
-# The inverse transformation doesn't converge due to properties of the projection
 accept      0               0
 expect      0               6378137
+roundtrip   1
+
+# Point not visible from the projection plane
+direction   inverse
+accept      0               6378137.1
+expect      failure         errno tolerance_condition
 
 
 ===============================================================================

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -4435,6 +4435,46 @@ expect      -189011.711  -128640.567
 roundtrip   1
 
 -------------------------------------------------------------------------------
+# Oblique
+-------------------------------------------------------------------------------
+operation   +proj=ortho +ellps=WGS84 +lat_0=30
+
+# On boundary of visibility domain.
+direction   forward
+tolerance   0.1 mm
+accept      -90             0
+expect      -6378137        18504.1253
+
+# This test is fragile. Note the slighly important tolerance
+# direction   inverse
+# tolerance   100 mm
+# accept      -6378137        18504.125313223721605027
+# expect      -90             0
+
+# Slightly outside
+direction   inverse
+accept      -6378137.001    18504.1253
+expect      failure errno tolerance_condition
+
+# On boundary of visibility domain
+direction   forward
+tolerance   0.1 mm
+accept      0               -60
+expect      0               -6343601.0991
+
+# Just on it, but fails to converge. This test might be fragile
+direction   inverse
+accept      0               -6343601.099075031466782093
+expect      failure errno non_convergent
+
+# Slightly inside
+direction   inverse
+tolerance   0.1 mm
+accept      0               -6343600
+expect      0               -59.966377950099655436
+
+
+-------------------------------------------------------------------------------
 # Equatorial
 -------------------------------------------------------------------------------
 operation   +proj=ortho +ellps=WGS84

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -4565,8 +4565,12 @@ accept      0               90
 expect      0               0
 roundtrip   1
 
-accept      1               89.999
-expect      1.9493         -111.6770
+accept      30              45
+expect      2258795.4394   -3912348.4650
+roundtrip   1
+
+accept      135             89.999999873385
+expect      0.01            0.01
 roundtrip   1
 
 # Point not visible from the projection plane
@@ -4592,8 +4596,8 @@ accept      0               -90
 expect      0               0
 roundtrip   1
 
-accept      1               -89.999
-expect      1.9493          111.6770
+accept      135             -89.999999873385
+expect      0.01            -0.01
 roundtrip   1
 
 # Point not visible from the projection plane


### PR DESCRIPTION
- Map ESRI 'Local' to +proj=ortho when Scale_Factor = 1 and Azimuth = 0
- Map ESRI 'Orthographic' to a PROJ WKT2 'Orthographic (Spherical)'
  which maps to +proj=ortho +f=0 to froce spherical evaluation
