### PR TITLE
promoteTo3D(): add a remark with the original CRS identifier (fixes #2368)

### DIFF
--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1021,7 +1021,8 @@ PROJCRS["WGS 84 / UTM zone 31N",
         AXIS["ellipsoidal height (h)",up,
             ORDER[3],
             LENGTHUNIT["metre",1,
-                ID["EPSG",9001]]]]
+                ID["EPSG",9001]]],
+    REMARK["Promoted to 3D from EPSG:32631"]]
 
 Testing -s EPSG:32631 -t EPSG:4326+3855 --summary
 Candidate operations found: 3


### PR DESCRIPTION
```
$ projinfo EPSG:32631 --3d

WKT2:2019 string:
PROJCRS["WGS 84 / UTM zone 31N",
[ ...snip ]
    REMARK["Promoted to 3D from EPSG:32631"]]
```
