### PR TITLE
Add Conda package GitHub Action

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,43 @@
+name: Conda
+
+on:
+  push:
+    branches: '*'
+
+jobs:
+  build:
+    name: Conda ${{ matrix.platform }}
+
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: ['ubuntu-latest','windows-latest','macos-latest']
+
+    env:
+      PLATFORM: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: goanpeca/setup-miniconda@v1
+      with:
+        channels: conda-forge
+        auto-update-conda: true
+
+    - name: Setup
+      shell: bash -l {0}
+      run: |
+          source ./scripts/ci/conda/setup.sh
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+          source ../scripts/ci/conda/compile.sh
+      working-directory: ./pdal-feedstock
+
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.platform }}-conda-package
+        path: ./pdal-feedstock/packages/

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -34,10 +34,10 @@ jobs:
       shell: bash -l {0}
       run: |
           source ../scripts/ci/conda/compile.sh
-      working-directory: ./pdal-feedstock
+      working-directory: ./proj.4-feedstock
 
 
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.platform }}-conda-package
-        path: ./pdal-feedstock/packages/
+        path: ./proj.4-feedstock/packages/

--- a/scripts/ci/conda/compile.sh
+++ b/scripts/ci/conda/compile.sh
@@ -5,4 +5,4 @@ mkdir packages
 conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages
 conda install -c ./packages proj
 
-projinfo -s NAD27 -t EPSG:4269 --area "USA - Missouri"
+#projinfo -s NAD27 -t EPSG:4269 --area "USA - Missouri"

--- a/scripts/ci/conda/compile.sh
+++ b/scripts/ci/conda/compile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir packages
+
+conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages
+conda install -c ./packages proj
+
+projinfo -s NAD27 -t EPSG:4269 --area "USA - Missouri"

--- a/scripts/ci/conda/setup.sh
+++ b/scripts/ci/conda/setup.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 
 conda update -n base -c defaults conda -y
-
-if [ "$PLATFORM" == "ubuntu-latest" ]; then
-    conda install conda-build ninja compilers automake libtool -y
-    ./autogen.sh
-else
-    conda install conda-build ninja compilers -y
-fi
-
+conda install conda-build ninja compilers -y
 
 pwd
 ls
-git clone https://github.com/conda-forge/proj.4-feedstock.git
+git clone https://github.com/hobu/proj.4-feedstock.git
 
 cd proj.4-feedstock
 cat > recipe/recipe_clobber.yaml <<EOL

--- a/scripts/ci/conda/setup.sh
+++ b/scripts/ci/conda/setup.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
 conda update -n base -c defaults conda -y
-conda install conda-build ninja compilers automake libtool -y
 
-./autogen.sh
+if [ "$PLATFORM" == "ubuntu-latest" ]; then
+    conda install conda-build ninja compilers automake libtool -y
+    ./autogen.sh
+else
+    conda install conda-build ninja compilers -y
+fi
+
 
 pwd
 ls

--- a/scripts/ci/conda/setup.sh
+++ b/scripts/ci/conda/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+conda update -n base -c defaults conda
+conda install conda-build ninja compilers -y
+pwd
+ls
+git clone https://github.com/conda-forge/proj.4-feedstock.git
+
+cd proj.4-feedstock
+cat > recipe/recipe_clobber.yaml <<EOL
+source:
+  git_url: https://github.com/hobu/PROJ.git
+  git_rev: ${GITHUB_SHA}
+  url:
+  sha256:
+
+build:
+  number: 2112
+EOL
+
+ls recipe

--- a/scripts/ci/conda/setup.sh
+++ b/scripts/ci/conda/setup.sh
@@ -5,12 +5,12 @@ conda install conda-build ninja compilers -y
 
 pwd
 ls
-git clone https://github.com/hobu/proj.4-feedstock.git
+git clone https://github.com/conda-forge/proj.4-feedstock.git
 
 cd proj.4-feedstock
 cat > recipe/recipe_clobber.yaml <<EOL
 source:
-  git_url: https://github.com/hobu/PROJ.git
+  git_url: https://github.com/OSGeo/PROJ.git
   git_rev: ${GITHUB_SHA}
   url:
   sha256:

--- a/scripts/ci/conda/setup.sh
+++ b/scripts/ci/conda/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-conda update -n base -c defaults conda
-conda install conda-build ninja compilers -y
+conda update -n base -c defaults conda -y
+conda install conda-build ninja compilers automake libtool -y
+
+./autogen.sh
+
 pwd
 ls
 git clone https://github.com/conda-forge/proj.4-feedstock.git


### PR DESCRIPTION
This PR adds a GitHub Action that builds the @conda-forge OSX, Windows, and Linux packages for every commit. In addition to testing a build on all three platforms, it makes the packages available as artifacts for individual download.