### PR TITLE
Improve the documentation for the Mercator projection

### DIFF
--- a/docs/source/operations/projections/merc.rst
+++ b/docs/source/operations/projections/merc.rst
@@ -6,9 +6,10 @@ Mercator
 
 The Mercator projection is a cylindrical map projection that origins from the 15th
 century. It is widely recognized as the first regularly used map projection.
-The projection has the property that a rhumb line, a course of constant
-heading, projects to a straight line.  This makes it suitable for
-navigational purposes.
+It is a conformal projection in which the equator projects to a straight
+line at constant scale.  The projection has the property that a rhumb
+line, a course of constant heading, projects to a straight line.  This
+makes it suitable for navigational purposes.
 
 
 +---------------------+----------------------------------------------------------+
@@ -99,7 +100,7 @@ Forward projection
 
 .. math::
 
-    \psi &= \log \tan \biggl(\frac{\pi}{4} + \frac{\phi}{2} \biggr)\\
+    \psi &= \ln \tan \biggl(\frac{\pi}{4} + \frac{\phi}{2} \biggr)\\
          &= \sinh^{-1}\tan\phi
 
 The quantity :math:`\psi` is the isometric latitude.
@@ -143,9 +144,9 @@ Forward projection
 
 .. math::
 
-    \psi &= \log\tan\biggl(\frac\pi4 + \frac{\phi}2\biggr)
+    \psi &= \ln\tan\biggl(\frac\pi4 + \frac{\phi}2\biggr)
             -\frac12 e
-            \log \biggl(\frac{1 + e \sin\phi}{1 - e \sin\phi}\biggr)\\
+            \ln \biggl(\frac{1 + e \sin\phi}{1 - e \sin\phi}\biggr)\\
          &= \sinh^{-1}\tan\phi - e \tanh^{-1}(e \sin\phi)
 
 

--- a/docs/source/operations/projections/merc.rst
+++ b/docs/source/operations/projections/merc.rst
@@ -4,12 +4,12 @@
 Mercator
 ********************************************************************************
 
-The Mercator projection is a cylindrical map projection that origins from the 15th
-century. It is widely recognized as the first regularly used map projection.
-It is a conformal projection in which the equator projects to a straight
-line at constant scale.  The projection has the property that a rhumb
-line, a course of constant heading, projects to a straight line.  This
-makes it suitable for navigational purposes.
+The Mercator projection is a cylindrical map projection that origins
+from the 16th century. It is widely recognized as the first regularly
+used map projection.  It is a conformal projection in which the equator
+projects to a straight line at constant scale.  The projection has the
+property that a rhumb line, a course of constant heading, projects to a
+straight line.  This makes it suitable for navigational purposes.
 
 
 +---------------------+----------------------------------------------------------+

--- a/docs/source/operations/projections/merc.rst
+++ b/docs/source/operations/projections/merc.rst
@@ -6,7 +6,9 @@ Mercator
 
 The Mercator projection is a cylindrical map projection that origins from the 15th
 century. It is widely recognized as the first regularly used map projection.
-The projection is conformal which makes it suitable for navigational purposes.
+The projection has the property that a rhumb line, a course of constant
+heading, projects to a straight line.  This makes it suitable for
+navigational purposes.
 
 
 +---------------------+----------------------------------------------------------+
@@ -38,8 +40,10 @@ Usage
 Applications should be limited to equatorial regions, but is frequently
 used for navigational charts with latitude of true scale (:option:`+lat_ts`) specified within
 or near chart's boundaries.
-Often inappropriately used for world maps since the regions near the poles
-cannot be shown :cite:`Evenden1995`.
+It is considered to be inappropriate for world maps because of the gross
+distortions in area; for example the projected area of Greenland is
+larger than that of South America, despite the fact that Greenland's
+area is :math:`\frac18` that of South America :cite:`Snyder1987`.
 
 
 Example using latitude of true scale::
@@ -78,8 +82,6 @@ Parameters
 Mathematical definition
 #######################
 
-The formulas describing the Mercator projection are all taken from G. Evenden's libproj manuals :cite:`Evenden2005`.
-
 Spherical form
 **************
 For the spherical form of the projection we introduce the scaling factor:
@@ -93,11 +95,14 @@ Forward projection
 
 .. math::
 
-    x = k_0 \lambda
+    x = k_0R \lambda; \qquad y = k_0R \psi
 
 .. math::
 
-    y = k_0 \ln \left[ \tan \left(\frac{\pi}{4} + \frac{\phi}{2} \right) \right]
+    \psi &= \log \tan \biggl(\frac{\pi}{4} + \frac{\phi}{2} \biggr)\\
+         &= \sinh^{-1}\tan\phi
+
+The quantity :math:`\psi` is the isometric latitude.
 
 
 Inverse projection
@@ -105,38 +110,43 @@ Inverse projection
 
 .. math::
 
-    \lambda = \frac{x}{k_0}
+    \lambda = \frac{x}{k_0R}; \qquad \psi = \frac{y}{k_0R}
 
 .. math::
 
-    \phi = \frac{\pi}{2} - 2 \arctan \left[ e^{-y/k_0} \right]
+    \phi &= \frac{\pi}{2} - 2 \tan^{-1} \exp(-\psi)\\
+         &= \tan^{-1}\sinh\psi
 
 
-Ellisoidal form
-***************
+Ellipsoidal form
+****************
 
 For the ellipsoidal form of the projection we introduce the scaling factor:
 
 .. math::
 
-    k_0 = m\left( \phi_{ts} \right)
+    k_0 = m( \phi_{ts} )
 
-where :math:`m\left(\phi\right)` is the parallel radius at latitude :math:`\phi`.
+where
 
-We also use the Isometric Latitude kernel function :math:`t()`.
+.. math::
 
-.. note::
-    m() and t() should be described properly on a separate page about the theory of projections on the ellipsoid.
+   m(\phi) = \frac{\cos\phi}{\sqrt{1 - e^2\sin^2\phi}}
+
+:math:`a\,m(\phi)` is the radius of the circle of latitude :math:`\phi`.
 
 Forward projection
 ==================
 .. math::
 
-    x = k_0 \lambda
+    x = k_0 a \lambda; \qquad y = k_0 a \psi
 
 .. math::
 
-    y = k_0 \ln t \left( \phi \right)
+    \psi &= \log\tan\biggl(\frac\pi4 + \frac{\phi}2\biggr)
+            -\frac12 e
+            \log \biggl(\frac{1 + e \sin\phi}{1 - e \sin\phi}\biggr)\\
+         &= \sinh^{-1}\tan\phi - e \tanh^{-1}(e \sin\phi)
 
 
 Inverse projection
@@ -144,11 +154,10 @@ Inverse projection
 
 .. math::
 
-    \lambda = \frac{x}{k_0}
+    \lambda = \frac{x}{k_0 a}; \quad \psi = \frac{y}{k_0 a}
 
-.. math::
-
-    \phi = t^{-1}\left[ e^{ -y/k_0 } \right]
+The latitude :math:`\phi` is found by inverting the equation for
+:math:`\psi` iteratively.
 
 Further reading
 ###############

--- a/docs/source/operations/projections/tmerc.rst
+++ b/docs/source/operations/projections/tmerc.rst
@@ -5,6 +5,8 @@ Transverse Mercator
 ********************************************************************************
 
 The transverse Mercator projection in its various forms is the most widely used projected coordinate system for world topographical and offshore mapping.
+It is a conformal projection in which a chosen meridian projects to a
+straight line at constant scale.
 
 +---------------------+----------------------------------------------------------+
 | **Classification**  | Transverse and oblique cylindrical                       |


### PR DESCRIPTION
This addresses item 1 in issue #2387

Things to note:

* I made "editorial" changes to the text.  The virtues and vices of
  Mercator are a hot topic.  So check these out.  (I judged that the
  text I replaced to be pretty misleading.)

* I include the radius of the sphere/ellipsoid in the formulas (and I
  did this also for my mods for tmerc documentation).  Surely this is
  better than leaving the reader to figure out how this is introduced.

* I include the "old-style" (ca 18th century) formulas and the newer
  ones in terms of hyperbolic functions.  The former may be the familiar
  ones, but the latter are better for computation (more succinct, more
  accurate, faster, preserve parity).

* For the inverse ellipsoidal transformation, I just say that the
  formula for psi is inverted iteratively.  This is probably sufficient,
  but it could be expanded later.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Partially closes #2387
 - [x] Added clear title that can be used to generate release notes
