### PR TITLE
Set CURL_ENABLED definition on projinfo build

### DIFF
--- a/src/bin_projinfo.cmake
+++ b/src/bin_projinfo.cmake
@@ -15,3 +15,7 @@ install(TARGETS binprojinfo
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(binprojinfo PRIVATE PROJ_MSVC_DLL_IMPORT=1)
 endif()
+
+if(CURL_ENABLED)
+  target_compile_definitions(binprojinfo PRIVATE -DCURL_ENABLED)
+endif()


### PR DESCRIPTION
Hi,

Currently "projinfo --remote-data" command does not check network settings, because CURL_ENABLED is not defined in projinfo build.

Regards,
Olli Räisä
