### PR TITLE
Allow cct to instantiate operations via object codes or names

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -36,7 +36,7 @@ by :c:func:`proj_create`, provided it expresses a coordinate operation
     .. note::
 
         Before version 8.0.0 only proj-strings could be used to instantiate
-        operations in :prog:`cct`.
+        operations in :program:`cct`.
 
 
 

--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -15,6 +15,33 @@ Synopsis
 
     **cct** [**-cIostvz** [args]] *+opt[=arg]* ... file ...
 
+or
+
+    **cct** [**-cIostvz** [args]] {operation_reference} file ...
+
+Where {operation_reference} is one of the possibilities accepted
+by :c:func:`proj_create`, provided it expresses a coordinate operation
+
+- a proj-string,
+    - a WKT string,
+    - an object code (like "EPSG:1671" "urn:ogc:def:coordinateOperation:EPSG::1671"),
+    - an object name. e.g "ITRF2014 to ETRF2014 (1)". In that case as
+      uniqueness is not guaranteed, heuristics are applied to determine the appropriate best match.
+    - a OGC URN combining references for concatenated operations
+      (e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618")
+    - a PROJJSON string. The jsonschema is at https://proj.org/schemas/v0.2/projjson.schema.json
+
+    .. versionadded:: 8.0.0
+
+    .. note::
+
+        Before version 8.0.0 only proj-strings could be used to instantiate
+        operations in :prog:`cct`.
+
+
+
+
+
 Description
 ***********
 

--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -302,7 +302,8 @@ int main(int argc, char **argv) {
             P = proj_create_from_database(
                     nullptr, auth.c_str(), code.c_str(), PJ_CATEGORY_COORDINATE_OPERATION, 0, nullptr
             );
-        } else {
+        }
+        if( P == nullptr ) {
             /* if we didn't get a auth:code combo we try to see if the input matches */
             /* anything else */
             P = proj_create(nullptr, o->fargv[0]);

--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -195,7 +195,7 @@ static void print(PJ_LOG_LEVEL log_level, const char *fmt, ...) {
 }
 
 int main(int argc, char **argv) {
-    PJ *P;
+    PJ *P = nullptr;
     PJ_COORD point;
     PJ_PROJ_INFO info;
     OPTARGS *o;

--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
     if (o-> pargc == 0 && o->fargc > 0) {
         /* Assume we got a auth:code combination */
         std::string input(o->fargv[0]);
-        int n = input.find(":");
+        auto n = input.find(":");
         if (n > 0) {
             std::string auth = input.substr(0,n);
             std::string code = input.substr(n+1, input.length());

--- a/test/cli/testcct
+++ b/test/cli/testcct
@@ -32,6 +32,18 @@ echo "Testing cct -d 8 +proj=merc +R=1" >> ${OUT}
 echo "90 45" 0 | $EXE -d 8 +proj=merc +R=1 >>${OUT}
 echo "" >>${OUT}
 
+echo "Test cct with object code initialization" >> ${OUT}
+echo "3541657.3778 948984.2343 5201383.5231 2020.5" | $EXE EPSG:8366 >>${OUT}
+
+echo "Test cct with object name initialization" >> ${OUT}
+echo "3541657.3778 948984.2343 5201383.5231 2020.5" | $EXE "ITRF2014 to ETRF2014 (1)"  >>${OUT}
+
+echo "Test cct with object code initialization and file input" >> ${OUT}
+echo "3541657.3778 948984.2343 5201383.5231 2020.5" >> a
+echo "3541658.0000 948985.0000 5201384.0000 2020.5" >> b
+$EXE EPSG:8366 a b >>${OUT}
+/bin/rm a b
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testcct_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testcct_out.dist

--- a/test/cli/testcct_out.dist
+++ b/test/cli/testcct_out.dist
@@ -1,3 +1,10 @@
 Testing cct -d 8 +proj=merc +R=1
    1.57079633     0.88137359    0.00000000           inf
 
+Test cct with object code initialization
+ 3541657.9112    948983.7503  5201383.2482     2020.5000
+Test cct with object name initialization
+ 3541657.9112    948983.7503  5201383.2482     2020.5000
+Test cct with object code initialization and file input
+ 3541657.9112    948983.7503  5201383.2482     2020.5000
+ 3541658.5334    948984.5160  5201383.7251     2020.5000


### PR DESCRIPTION
Possible fix for #2418 

 - [x] Closes #2418
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API