### PR TITLE
cs2cs, cct, proj and geod: fflush(stdout) after each line to emit each result as …

### DIFF
--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -470,6 +470,8 @@ int main(int argc, char **argv) {
                    decimals_distances, point.xyzt.z,
                    point.xyzt.t, comment_delimiter, comment
             );
+        if( fout == stdout )
+            fflush(stdout);
     }
 
     proj_destroy(P);

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -217,6 +217,7 @@ static void process(FILE *fid)
             printf("%s", s);
         else
             printf("\n");
+        fflush(stdout);
     }
 }
 

--- a/src/apps/geod.cpp
+++ b/src/apps/geod.cpp
@@ -124,6 +124,7 @@ process(FILE *fid) {
 				(void)fputs(rtodms(pline, al21, 0, 0), stdout);
 		}
 		(void)fputs(s, stdout);
+                fflush(stdout);
 	}
 }
 

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -171,6 +171,7 @@ static void process(FILE *fid) {
                 (void)fputs("\t<* * * * * *>", stdout);
         }
         (void)fputs(bin_in ? "\n" : s, stdout);
+        fflush(stdout);
     }
 }
 
@@ -286,6 +287,8 @@ static void vprocess(FILE *fid) {
         (void)fputs(proj_rtodms(pline, facs.meridian_convergence, 0, 0), stdout);
         (void)printf(" [ %.8f ]\n", facs.meridian_convergence * RAD_TO_DEG);
         (void)printf("Max-min (Tissot axis a-b) scale error: %.5f %.5f\n\n", facs.tissot_semimajor, facs.tissot_semiminor);
+
+        fflush(stdout);
     }
 }
 


### PR DESCRIPTION
…soon as it is produced

This is needed when working with pipes, when stdout is not an interactive terminal,
and thus the behaviour is to have it buffered as a regular file, whereas with
an interactive terminal, each newline character causes an implicit flush.
