### PR TITLE
Add build time option to make PROJ_LIB env var tested last (fixes #2399)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,13 @@ if(ENABLE_CURL)
 endif()
 
 ################################################################################
+
+option(PROJ_LIB_ENV_VAR_TRIED_LAST "Whether the PROJ_LIB environment variable should be tried after the hardcoded location" OFF)
+if(PROJ_LIB_ENV_VAR_TRIED_LAST)
+    add_definitions(-DPROJ_LIB_ENV_VAR_TRIED_LAST)
+endif()
+
+################################################################################
 # threading configuration
 ################################################################################
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)

--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,19 @@ AC_SUBST(CURL_LIBS,$CURL_LIBS)
 AC_SUBST(CURL_ENABLED_FLAGS,$CURL_ENABLED_FLAGS)
 AM_CONDITIONAL(HAVE_CURL, [test "x$FOUND_CURL" = "xyes"])
 
+
+dnl ---------------------------------------------------------------------------
+dnl proj-lib-env-var-tried-last
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_ENABLE(proj-lib-env-var-tried-last,
+              AS_HELP_STRING([--enable-proj-lib-env-var-tried-last],
+                    [Whether the PROJ_LIB environment variable should be tried after the hardcoded location [default=no]]))
+
+if test "x$enable_proj_lib_env_var_tried_last" = "xyes"; then
+    AC_SUBST(PROJ_LIB_ENV_VAR_TRIED_LAST_FLAGS,-DPROJ_LIB_ENV_VAR_TRIED_LAST)
+fi
+
 dnl ---------------------------------------------------------------------------
 dnl Check for external Google Test
 dnl ---------------------------------------------------------------------------

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -60,6 +60,11 @@ The following paths are checked in order:
   that since this is a hard-wired path setting, it only works if the whole
   PROJ installation is not moved somewhere else.
 
+  .. note:: if PROJ is built with the PROJ_LIB_ENV_VAR_TRIED_LAST CMake option /
+            --enable-proj-lib-env-var-tried-last configure switch, then this
+            hard-wired path will be tried before looking at the environment
+            variable :envvar:`PROJ_LIB`.
+
 - The current directory
 
 When networking capabilities are enabled, either by API with the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ TESTS = geodtest
 check_PROGRAMS = geodtest
 
 AM_CPPFLAGS =	-DPROJ_LIB=\"$(pkgdatadir)\" \
-		-DMUTEX_@MUTEX_SETTING@ -I$(top_srcdir)/include @SQLITE3_CFLAGS@ @TIFF_CFLAGS@ @TIFF_ENABLED_FLAGS@ @CURL_CFLAGS@ @CURL_ENABLED_FLAGS@
+		-DMUTEX_@MUTEX_SETTING@ -I$(top_srcdir)/include @SQLITE3_CFLAGS@ @TIFF_CFLAGS@ @TIFF_ENABLED_FLAGS@ @CURL_CFLAGS@ @CURL_ENABLED_FLAGS@ @PROJ_LIB_ENV_VAR_TRIED_LAST_FLAGS@
 AM_CXXFLAGS =    @CXX_WFLAGS@ @FLTO_FLAG@
 
 include_HEADERS = proj.h proj_experimental.h proj_constants.h geodesic.h \


### PR DESCRIPTION
If PROJ is built with the PROJ_LIB_ENV_VAR_TRIED_LAST CMake option /
--enable-proj-lib-env-var-tried-last configure switch, then the
hard-wired path ($prefix/share/proj) will be tried before looking at the
environment PROJ_LIB.
