### PR TITLE
isea.cpp: Use R instead of Rprime for G and H calculation as per Snyder (1992)

### DIFF
--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -290,8 +290,6 @@ static struct isea_pt isea_triangle_xy(int triangle)
         /* should be impossible */
         exit(EXIT_FAILURE);
     };
-    c.x *= Rprime;
-    c.y *= Rprime;
 
     return c;
 }

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -265,7 +265,6 @@ static double az_adjustment(int triangle)
 static struct isea_pt isea_triangle_xy(int triangle)
 {
     struct isea_pt  c;
-    const double Rprime = 0.91038328153090290025;
 
     triangle = (triangle - 1) % 20;
 


### PR DESCRIPTION
According to the original paper (Snyder, 1992), G and H should use R rather than R' (`Rprime`).

![image](https://user-images.githubusercontent.com/7456117/101089144-c611ad80-3582-11eb-990c-4f808455673a.png)

Snyder, J. P., 1992. An Equal-Area Map Projection for Polyhedral Globes. Cartographica 29 (1), 10-21.