### PR TITLE
Improved coordinate operation filtering

### DIFF
--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -13,7 +13,7 @@ Synopsis
 
     | **cs2cs** [**-eEfIlrstvwW** [args]]
     |           [[--area <name_or_code>] | [--bbox <west_long,south_lat,east_long,north_lat>]]
-    |           [--authority <name>]
+    |           [--authority <name>] [--no-ballpark] [--accuracy <accuracy>]
     |           ([*+opt[=arg]* ...] [+to *+opt[=arg]* ...] | {source_crs} {target_crs})
     |           file ...
 
@@ -165,6 +165,19 @@ The following control parameters can appear in any order:
     `west_long` and `east_long` should be in the [-180,180] range, and
     `south_lat` and `north_lat` in the [-90,90]. `west_long` is generally lower than
     `east_long`, except in the case where the area of interest crosses the antimeridian.
+
+.. option:: --no-ballpark
+
+    .. versionadded:: 8.0.0
+
+    Disallow any coordinate operation that is, or contains, a
+    :term:`Ballpark transformation`
+
+.. option:: --accuracy <accuracy>
+
+    .. versionadded:: 8.0.0
+
+    Sets the minimum desired accuracy for candidate coordinate operations.
 
 .. option:: --authority <name>
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -22,7 +22,7 @@ Synopsis
     |    [--crs-extent-use none|both|intersection|smallest]
     |    [--grid-check none|discard_missing|sort|known_available]
     |    [--pivot-crs always|if_no_direct_transformation|never|{auth:code[,auth:code]*}]
-    |    [--show-superseded] [--hide-ballpark]
+    |    [--show-superseded] [--hide-ballpark] [--accuracy {accuracy}]
     |    [--allow-ellipsoidal-height-as-vertical-crs]
     |    [--boundcrs-to-wgs84]
     |    [--main-db-path path] [--aux-db-path path]*
@@ -210,6 +210,14 @@ The following control parameters can appear in any order:
 
     Hides any coordinate operation that is, or contains, a
     :term:`Ballpark transformation`
+
+    .. note:: only used for coordinate operation computation
+
+.. option:: --accuracy {accuracy}
+
+    .. versionadded:: 8.0
+
+    Sets the minimum desired accuracy for returned coordinate operations.
 
     .. note:: only used for coordinate operation computation
 

--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -195,6 +195,11 @@ paragraph for more details.
       If authority is a non-empty string different of ``any``, then coordinate operations
       will be searched only in that authority namespace (e.g ``EPSG``).
 
+    - ACCURACY=value: to set the minimum desired accuracy (in metres) of the
+      candidate coordinate operations.
+
+    - ALLOW_BALLPARK=YES/NO: can be set to NO to disallow the use of
+      :term:`Ballpark transformation` in the candidate coordinate operations.
 
 .. doxygenfunction:: proj_normalize_for_visualization
    :project: doxygen_api

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1302,10 +1302,24 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     }
 
     const char* authority = nullptr;
+    double accuracy = -1;
+    bool allowBallparkTransformations = true;
     for (auto iter = options; iter && iter[0]; ++iter) {
         const char *value;
         if ((value = getOptionValue(*iter, "AUTHORITY="))) {
             authority = value;
+        } else if ((value = getOptionValue(*iter, "ACCURACY="))) {
+            accuracy = pj_atof(value);
+        } else if ((value = getOptionValue(*iter, "ALLOW_BALLPARK="))) {
+            if( ci_equal(value, "yes") )
+                allowBallparkTransformations = true;
+            else if( ci_equal(value, "no") )
+                allowBallparkTransformations = false;
+            else {
+                ctx->logger(ctx->logger_app_data, PJ_LOG_ERROR,
+                            "Invalid value for ALLOW_BALLPARK option.");
+                return nullptr;
+            }
         } else {
             std::string msg("Unknown option :");
             msg += *iter;
@@ -1317,6 +1331,14 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     auto operation_ctx = proj_create_operation_factory_context(ctx, authority);
     if( !operation_ctx ) {
         return nullptr;
+    }
+
+    proj_operation_factory_context_set_allow_ballpark_transformations(
+        ctx, operation_ctx, allowBallparkTransformations);
+
+    if( accuracy >= 0 ) {
+        proj_operation_factory_context_set_desired_accuracy(ctx, operation_ctx,
+                                                            accuracy);
     }
 
     if( area && area->bbox_set ) {

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -213,6 +213,10 @@ fi
 rm testprojinfo_out_remotedata.txt
 unset PROJ_NETWORK
 
+echo 'Testing --accuracy 0.05 -s EPSG:4326 -t EPSG:4258' >> ${OUT}
+$EXE --accuracy 0.05 -s EPSG:4326 -t EPSG:4258 >>${OUT} 2>&1
+echo "" >>${OUT}
+
 ######################
 # NZGD2000 -> ITRFxx #
 ######################

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1384,6 +1384,9 @@ DATUM["World Geodetic System 1984",
         LENGTHUNIT["metre",1]],
     ID["EPSG",6326]]
 
+Testing --accuracy 0.05 -s EPSG:4326 -t EPSG:4258
+Candidate operations found: 0
+
 Testing -s NZGD2000 -t ITRF96 -o PROJ -q
 +proj=pipeline
   +step +proj=unitconvert +xy_in=deg +xy_out=rad

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1021,6 +1021,18 @@ $EXE --authority EPSG -E +proj=latlong +datum=WGS84 +no_defs +to +init=epsg:6342
 -105 40
 EOF
 
+echo  "##############################################################" >> ${OUT}
+echo  "Test effect of --accuracy" >> ${OUT}
+$EXE -E --accuracy 0.05 EPSG:4326 EPSG:4258 >> ${OUT} <<EOF
+49 2
+EOF
+
+echo  "##############################################################" >> ${OUT}
+echo  "Test effect of --no-ballpark" >> ${OUT}
+$EXE -E --no-ballpark EPSG:4267 EPSG:4258 >> ${OUT} <<EOF
+49 2
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -492,3 +492,7 @@ The first result should use the 'WGS_1984_(ITRF08)_To_NAD_1983_2011' (ESRI:10836
 and the second one a no-op
 -105 40	500000.86	4427756.50 0.00
 -105 40	500000.00	4427757.22 0.00
+##############################################################
+Test effect of --accuracy
+##############################################################
+Test effect of --no-ballpark

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -4196,6 +4196,64 @@ TEST_F(CApi, proj_create_crs_to_crs_from_pj) {
 
 // ---------------------------------------------------------------------------
 
+TEST_F(CApi, proj_create_crs_to_crs_from_pj_accuracy_filter) {
+
+    auto src = proj_create(m_ctxt, "EPSG:4326"); // WGS 84
+    ObjectKeeper keeper_src(src);
+    ASSERT_NE(src, nullptr);
+
+    auto dst = proj_create(m_ctxt, "EPSG:4258"); // ETRS89
+    ObjectKeeper keeper_dst(dst);
+    ASSERT_NE(dst, nullptr);
+
+    // No options
+    {
+        auto P =
+            proj_create_crs_to_crs_from_pj(m_ctxt, src, dst, nullptr, nullptr);
+        ObjectKeeper keeper_P(P);
+        ASSERT_NE(P, nullptr);
+    }
+
+    {
+        const char *const options[] = {"ACCURACY=0.05", nullptr};
+        auto P =
+            proj_create_crs_to_crs_from_pj(m_ctxt, src, dst, nullptr, options);
+        ObjectKeeper keeper_P(P);
+        ASSERT_EQ(P, nullptr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_create_crs_to_crs_from_pj_ballpark_filter) {
+
+    auto src = proj_create(m_ctxt, "EPSG:4267"); // NAD 27
+    ObjectKeeper keeper_src(src);
+    ASSERT_NE(src, nullptr);
+
+    auto dst = proj_create(m_ctxt, "EPSG:4258"); // ETRS89
+    ObjectKeeper keeper_dst(dst);
+    ASSERT_NE(dst, nullptr);
+
+    // No options
+    {
+        auto P =
+            proj_create_crs_to_crs_from_pj(m_ctxt, src, dst, nullptr, nullptr);
+        ObjectKeeper keeper_P(P);
+        ASSERT_NE(P, nullptr);
+    }
+
+    {
+        const char *const options[] = {"ALLOW_BALLPARK=NO", nullptr};
+        auto P =
+            proj_create_crs_to_crs_from_pj(m_ctxt, src, dst, nullptr, options);
+        ObjectKeeper keeper_P(P);
+        ASSERT_EQ(P, nullptr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 static void
 check_axis_is_latitude(PJ_CONTEXT *ctx, PJ *cs, int axis_number,
                        const char *unit_name = "degree",


### PR DESCRIPTION
- projinfo: add a --accuracy option to define the minimum accuracy
- proj_create_crs_to_crs_from_pj(): add ACCURACY and ALLOW_BALLPARK options

