### PR TITLE
Fix typos in resource_files.rst

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -151,7 +151,7 @@ proj-datumgrid
     series of packages are not maintained anymore and are only kept available for
     legacy purposes.
 
-For a functioning builds of PROJ prior to version 7, installation of the
+For a functioning build of PROJ prior to version 7, installation of the
 `proj-datumgrid <https://github.com/OSGeo/proj-datumgrid>`_ is needed. If you
 have installed PROJ from a package system chances are that this will already be
 done for you. The *proj-datumgrid* package provides transformation grids that
@@ -197,7 +197,7 @@ includes grids that have global extent, e.g. the global geoid model EGM08.
 
 All packages above come in different versions, e.g proj-datumgrid-1.8 or
 proj-datumgrid-europe-1.4. The `-latest` packages are symbolic links to the
-latest version of a given packages. That means that the link
+latest version of a given package. That means that the link
 https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.zip is
 equivalent to https://download.osgeo.org/proj/proj-datumgrid-north-america-1.2.zip
 (as of the time of writing this).
@@ -278,7 +278,7 @@ than one foot over the last two decades).
 Getting and building HTDP
 ................................................................................
 
-The HTDP modelling program is in written FORTRAN.  The source and documentation
+The HTDP modelling program is written in FORTRAN.  The source and documentation
 can be found on the HTDP page at http://www.ngs.noaa.gov/TOOLS/Htdp/Htdp.shtml
 
 On linux systems it will be necessary to install `gfortran` or some FORTRAN
@@ -322,10 +322,10 @@ Usage
             [-htdp <path_to_exe>] [-wrkdir <dirpath>] [-kwf]
             -o <output_grid_name>
 
- -griddef: by default the following values for roughly the continental USA
-           at a six minute step size are used:
-           -127 50 -66 25 251 611
- -kwf: keep working files in the working directory for review.
+     -griddef: by default the following values for roughly the continental USA
+               at a six minute step size are used:
+               -127 50 -66 25 251 611
+     -kwf: keep working files in the working directory for review.
 
 ::
 


### PR DESCRIPTION
Hi,

This PR fixes minor typos in `resource_files.rst`.

As a side-note, you may want to pin `sphinxcontrib-bibtex < 2.0.0` in [`docs/docbuild/Dockerfile`](https://github.com/OSGeo/PROJ/blob/1a84a71349c31740b4a525971cf56c899dda858e/docs/docbuild/Dockerfile#L10) as `sphinxcontrib` have released a major version on December 12th that introduced several breaking changes - especially one that requires a mandatory option `bibtex_bibfiles` and fails the build if the option is not present ([source](https://sphinxcontrib-bibtex.readthedocs.io/en/2.0.0/changes.html#december-2020)). If have seen that the `osgeo/proj-docs` Docker image is built and pushed manually so you will not face the problem immediately.