### PR TITLE
CMake: remove old configuration option aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,12 +252,6 @@ set(CMAKECONFIGDIR "${DEFAULT_CMAKEDIR}"
 ################################################################################
 include(CTest)
 
-# Support older option, to be removed by PROJ 8.0
-if(DEFINED PROJ_TESTS)
-  message(DEPRECATION "PROJ_TESTS has been replaced with BUILD_TESTING")
-  set(BUILD_TESTING ${PROJ_TESTS})
-endif()
-
 if(BUILD_TESTING)
   include(ProjTest)
 else()

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -4,13 +4,6 @@ message(STATUS "Configuring proj library:")
 ### SWITCH BETWEEN STATIC OR SHARED LIBRARY###
 ##############################################
 
-# Support older option, to be removed by PROJ 8.0
-if(DEFINED BUILD_LIBPROJ_SHARED)
-  message(DEPRECATION
-    "BUILD_LIBPROJ_SHARED has been replaced with BUILD_SHARED_LIBS")
-  set(BUILD_SHARED_LIBS ${BUILD_LIBPROJ_SHARED})
-endif()
-
 # default config is shared, except static on Windows
 set(BUILD_SHARED_LIBS_DEFAULT ON)
 if(WIN32)
@@ -32,12 +25,6 @@ elseif(USE_THREAD AND NOT Threads_FOUND)
   message(FATAL_ERROR
     "No thread library found and thread/mutex support is "
     "required by USE_THREAD option")
-endif()
-
-# Support older option, to be removed by PROJ 8.0
-if(DEFINED ENABLE_LTO)
-  message(DEPRECATION "ENABLE_LTO has been replaced with ENABLE_IPO")
-  set(ENABLE_IPO ${ENABLE_LTO})
 endif()
 
 option(ENABLE_IPO


### PR DESCRIPTION
These are CMake options that have been marked to remove by PROJ 8.0:
- [x] `PROJ_TESTS` replaced by CTest's `BUILD_TESTING`; xref #1870
- [x] `ENABLE_LTO` replaced by `ENABLE_IPO`; xref #1952
- [x] `BUILD_LIBPROJ_SHARED` replaced by CMake's `BUILD_SHARED_LIBS`; xref #1962

The older names should remain in the manual, particularly `BUILD_LIBPROJ_SHARED` which was used externally.

If anyone thinks there should be an extension to the above list of options, speak up now.

Closes #1877