### PR TITLE
Better grid_alternatives entries to include 'GDA94 to AHD (Tasmania) height' using 'au_ga_AUSGeoid98.tif'

### DIFF
--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -18,7 +18,7 @@ INSERT INTO grid_alternatives(original_grid_name,
            0,
            NULL,
            'https://cdn.proj.org/au_ga_AUSGeoid98.tif', 1, 1, NULL FROM grid_transformation WHERE
-                grid_name LIKE '%DAT.htm' AND name LIKE 'GDA94 to AHD height%';
+                grid_name LIKE '%DAT.htm' AND name LIKE 'GDA94 to AHD %height%';
 
 -- OGC CRS84, CRS27 and CRS83 longitude/latitude ordered CRS
 


### PR DESCRIPTION

 - [x] Added clear title that can be used to generate release notes (I am not sure)

The other transformations are named `GDA94 to AHD height (...)` for EPSG:5711. However in Tasmania, it is called `GDA94 to AHD (Tasmania) height (1)` for EPSG:5712.
The grid file for Tasmania is `SK55_DAT.htm`

I assume that `au_ga_AUSGeoid98.tif` includes Tasmania (SK55_DAT.htm), as many other S*_DAT.htm files. If it is not the case, close this PR.
