### PR TITLE
Enable linking against static cURL on Windows

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -409,7 +409,14 @@ endif()
 if(CURL_ENABLED)
   target_compile_definitions(${PROJ_CORE_TARGET} PRIVATE -DCURL_ENABLED)
   target_include_directories(${PROJ_CORE_TARGET} PRIVATE ${CURL_INCLUDE_DIR})
-  target_link_libraries(${PROJ_CORE_TARGET} PRIVATE ${CURL_LIBRARY})
+  target_link_libraries(${PROJ_CORE_TARGET}
+    PRIVATE
+      ${CURL_LIBRARY}
+      $<$<CXX_COMPILER_ID:MSVC>:ws2_32>
+      $<$<CXX_COMPILER_ID:MSVC>:wldap32>
+      $<$<CXX_COMPILER_ID:MSVC>:advapi32>
+      $<$<CXX_COMPILER_ID:MSVC>:crypt32>
+      $<$<CXX_COMPILER_ID:MSVC>:normaliz>)
 endif()
 
 if(MSVC AND BUILD_SHARED_LIBS)


### PR DESCRIPTION
This is preliminary fix to allow linking the library
as well as its dependants (e.g. PROJ apps) against cURL
built as static library on Windows with support of native
Windows TLS/SSL.

On Windows, such static cURL (and its dependants) requires linking
against Winsock, CryptoAPI and other networking libaries.

------

This patch is a minimal version confirm to work with cURL 7.75.0 built as SChannel mode (old name WinSSL, see https://github.com/curl/curl/pull/3504), that is MSVC outputs binaries into:

```
curl\builds\libcurl-vc14-x86-debug-static-ipv6-sspi-schannel\
curl\builds\libcurl-vc14-x86-release-static-ipv6-sspi-schannel\ 
```

### References

- Blocked by issue #2515