### PR TITLE
CI: specify pip < 21.0; avoid using pip3 script

### DIFF
--- a/.github/workflows/clang_linux/start.sh
+++ b/.github/workflows/clang_linux/start.sh
@@ -7,7 +7,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo autoconf automake libtool clang++-10 python3-clang-10 make cmake ccache pkg-config tar zip \
     sqlite3 libsqlite3-dev libtiff-dev libcurl4-openssl-dev jq python3-pip
 
-pip3 install --user jsonschema
+python3 -m pip install --user jsonschema
 
 cd "$WORK_DIR"
 

--- a/.github/workflows/linux_gcc_32bit/start.sh
+++ b/.github/workflows/linux_gcc_32bit/start.sh
@@ -18,7 +18,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  -o AP
     libsqlite3-dev:$ARCH libtiff-dev:$ARCH libcurl4-openssl-dev:$ARCH \
     jq
 
-pip3 install --user jsonschema
+python3 -m pip install --user jsonschema
 export PATH=$HOME/.local/bin:$PATH
 
 export CXXFLAGS='-g -O2 -m32 -D_GLIBCXX_ASSERTIONS'

--- a/.github/workflows/linux_gcc_4_8/start.sh
+++ b/.github/workflows/linux_gcc_4_8/start.sh
@@ -15,11 +15,11 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libsqlite3-dev libtiff-dev libcurl4-openssl-dev \
     jq lcov
 
-pip3 install --user --upgrade pip
-echo `pip3 --version`
-pip3 config --user set global.progress_bar off
-pip3 install --user jsonschema
-pip3 install --user cmake==3.9.6
+python3 -m pip install --user --upgrade "pip < 21.0"
+echo `python3 -m pip --version`
+python3 -m pip config --user set global.progress_bar off
+python3 -m pip install --user jsonschema
+python3 -m pip install --user cmake==3.9.6
 
 export PATH=$HOME/.local/bin:$PATH
 

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     texlive-latex-extra git latex-cjk-all texlive-lang-all \
     graphviz python3-matplotlib wget unzip enchant
 
-RUN pip3 install Sphinx breathe \
+RUN python3 -m pip install Sphinx breathe \
     sphinx_bootstrap_theme awscli sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     sphinxcontrib-spelling

--- a/travis/before_install_pip.sh
+++ b/travis/before_install_pip.sh
@@ -4,7 +4,7 @@
 # "global" before_install script.
 
 # Configure Python pip
-pip3 install --user --upgrade pip
-echo `pip3 --version`
-pip3 config --user set global.progress_bar off
-pip3 install --user jsonschema
+python3 -m pip install --user --upgrade "pip < 21.0"
+echo `python3 -m pip --version`
+python3 -m pip config --user set global.progress_bar off
+python3 -m pip install --user jsonschema


### PR DESCRIPTION
Specify pip version less than 21.0 to avoid syntax error with Python 3.5 or older. This fixes CI errors since January 2021.

See [this answer](https://stackoverflow.com/a/65896996/) for details.

Furthermore, use safer `python3 -m pip` rather than `pip3`.