### PR TITLE
Add api method to force +over on transformation operations and unit test.

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -204,6 +204,17 @@ paragraph for more details.
 .. doxygenfunction:: proj_normalize_for_visualization
    :project: doxygen_api
 
+.. c:function:: void proj_context_set_force_over(PJ_CONTEXT* ctx, int enable)
+
+   .. versionadded:: 8.0.0
+
+   Force the +over flag on transformations created with this threading-context.
+
+   :param ctx: Threading context.
+   :type ctx: :c:type:`PJ_CONTEXT` *
+   :param enable: Toggle the enabled flag.
+   :type enable: `int`
+
 .. c:function:: PJ* proj_destroy(PJ *P)
 
     Deallocate a :c:type:`PJ` transformation object.

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -797,6 +797,7 @@ proj_context_set_ca_bundle_path
 proj_context_set_database_path
 proj_context_set_enable_network
 proj_context_set_fileapi
+proj_context_set_force_over
 proj_context_set_file_finder
 proj_context_set_network_callbacks
 proj_context_set(PJconsts*, pj_ctx*)

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -955,6 +955,17 @@ int proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_legacy_code_
     return from_legacy_code_path;
 }
 
+/************************************************************************/
+/*                  proj_context_set_force_over()                       */
+/************************************************************************/
+
+void proj_context_set_force_over(PJ_CONTEXT* ctx, int enable) {
+    if (ctx == nullptr) {
+        ctx = pj_get_default_ctx();
+    }
+    ctx->forceOver = enable;
+}
+
 /** Adds a " +type=crs" suffix to a PROJ string (if it is a PROJ string) */
 std::string pj_add_type_crs_if_needed(const std::string& str)
 {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -590,6 +590,9 @@ pj_init_ctx_with_allow_init_epsg(PJ_CONTEXT *ctx, int argc, char **argv, int all
 
     /* Over-ranging flag */
     PIN->over = pj_param(ctx, start, "bover").i;
+    if (ctx->forceOver) {
+        PIN->over = ctx->forceOver;
+    }
 
     /* Vertical datum geoid grids */
     PIN->has_geoid_vgrids = pj_param(ctx, start, "tgeoidgrids").i;

--- a/src/proj.h
+++ b/src/proj.h
@@ -371,6 +371,7 @@ void PROJ_DLL proj_context_set_search_paths(PJ_CONTEXT *ctx, int count_paths, co
 void PROJ_DLL proj_context_set_ca_bundle_path(PJ_CONTEXT *ctx, const char *path);
 void PROJ_DLL proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable);
 int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_legacy_code_path);
+void PROJ_DLL proj_context_set_force_over(PJ_CONTEXT* ctx, int enable);
 
 /*! @endcond */
 

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -652,6 +652,7 @@ struct pj_ctx{
     void    *logger_app_data = nullptr;
     struct projCppContext* cpp_context = nullptr; /* internal context for C++ code */
     int     use_proj4_init_rules = -1; /* -1 = unknown, 0 = no, 1 = yes */
+    int     forceOver = 0; /* 0 = no, 1 = yes */
     int     epsg_file_exists = -1; /* -1 = unknown, 0 = no, 1 = yes */
     std::string ca_bundle_path{};
 

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -819,4 +819,60 @@ TEST(gie, proj_trans_generic) {
     proj_destroy(P);
 }
 
+TEST(gie, proj_create_crs_to_crs_force_over) {
+
+    PJ_CONTEXT* ctx;
+
+    ctx = proj_context_create();
+    ASSERT_TRUE(ctx != nullptr);
+    proj_context_set_force_over(ctx, 1);
+    ASSERT_TRUE(ctx->forceOver);
+
+    auto P = proj_create_crs_to_crs(ctx, "EPSG:4326", "EPSG:3857", nullptr);
+    ASSERT_TRUE(P != nullptr);
+    PJ_COORD input;
+    PJ_COORD input_over;
+
+    //Test a point along the equator. 
+    //The same point, but in two different representations.
+    input.xyz.x = 0; // Lat in deg
+    input.xyz.y = 140;  // Long in deg
+    input.xyz.z = 0;
+
+    input_over.xyz.x = 0; // Lat in deg
+    input_over.xyz.y = -220;  // Long in deg
+    input_over.xyz.z = 0;
+
+    auto output = proj_trans(P, PJ_FWD, input);
+    auto output_over = proj_trans(P, PJ_FWD, input_over);
+
+    auto input_inv = proj_trans(P, PJ_INV, output);
+    auto input_over_inv = proj_trans(P, PJ_INV, output_over);
+
+    //Web Mercator x's between 0 and 180 longitude come out positive.
+    //But when forcing the over flag, the -220 calculation makes it flip.
+    EXPECT_GT(output.xyz.x, 0);
+    EXPECT_LT(output_over.xyz.x, 0);
+
+    EXPECT_NEAR(output.xyz.x, 15584728.711058298, 1e-8);
+    EXPECT_NEAR(output_over.xyz.x, -24490287.974520184, 1e-8);
+
+    //The distance from 140 to 180 and -220 to -180 should be pretty much the same.
+    auto dx_o = fabs(output.xyz.x - 20037508.342789244);
+    auto dx_over = fabs(output_over.xyz.x + 20037508.342789244);
+    auto dx = fabs(dx_o - dx_over);
+
+    EXPECT_NEAR(dx, 0, 1e-8);
+
+    //Check the inverse operations get us back close to our original input values.
+    EXPECT_NEAR(input.xyz.x, input_inv.xyz.x, 1e-8);
+    EXPECT_NEAR(input.xyz.y, input_inv.xyz.y, 1e-8);
+    EXPECT_NEAR(input_over.xyz.x, input_over_inv.xyz.x, 1e-8);
+    EXPECT_NEAR(input_over.xyz.y, input_over_inv.xyz.y, 1e-8);
+
+    proj_destroy(P);
+
+    proj_context_destroy(ctx);
+}
+
 } // namespace


### PR DESCRIPTION
Code for issue #2512. Since the deadline for release is looming, I didn't bother with adding any command switches for the various applications (since I didn't end up going that route anyway in the end). I added an item to the functions.rst docs page, but let me know if the wording or location needs to be changed.

 - [x] Closes #2512 
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/functions.rst` for new API