### PR TITLE
International ellipsoid designation correction

### DIFF
--- a/src/ellps.cpp
+++ b/src/ellps.cpp
@@ -38,7 +38,7 @@ pj_ellps[] = {
 {"fschr68",	"a=6378150.",		"rf=298.3",		"Fischer 1968"},
 {"helmert",	"a=6378200.",		"rf=298.3",		"Helmert 1906"},
 {"hough",	"a=6378270.0",		"rf=297.",		"Hough"},
-{"intl",	"a=6378388.0",		"rf=297.",		"International 1909 (Hayford)"},
+{"intl",	"a=6378388.0",		"rf=297.",		"International 1924 (Hayford 1909, 1910)"},
 {"krass",	"a=6378245.0",		"rf=298.3",		"Krassovsky, 1942"},
 {"kaula",	"a=6378163.",		"rf=298.24",		"Kaula 1961"},
 {"lerch",	"a=6378139.",		"rf=298.257",		"Lerch 1979"},


### PR DESCRIPTION
The "International 1909 (Hayford)" designation is an unfortunate mix of different aspects of the same ellipsoid.

The Hayford ellipsoid was based on investigations in 1909, published in 1910 as J.F. Hayford: *Supplementary Investigation in 1909 of the Figure of the Earth and Isostasy*, Coast and Geodetic Survey, 80pp. (freely accessible through Google Books).

In 1924 Hayford's ellipsoid was adopted by the IUGG as "the International Ellipsoid".

Hence either of 

- Hayford, 1909 (for the year the work was done),
- Hayford, 1910 (for the year of publication), or
- International, 1924

are reasonable names, in common use, but the "International, 1909" really is a peculiar mix of concepts.

Resolves #2534

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2534
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API