### PR TITLE
Fix spelling errors.

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -225,7 +225,7 @@ The following control parameters can appear in any order:
 
     .. versionadded:: 8.0
 
-    Allow to export a geographic or projected 3D CRS as a compound CRS whose
+    Allows exporting a geographic or projected 3D CRS as a compound CRS whose
     vertical CRS represents the ellipsoidal height.
 
     .. note:: only used for CRS, and with WKT1:GDAL output format

--- a/man/man1/projinfo.1
+++ b/man/man1/projinfo.1
@@ -331,7 +331,7 @@ only used for coordinate operation computation
 New in version 8.0.
 
 .sp
-Allow to export a geographic or projected 3D CRS as a compound CRS whose
+Allows exporting a geographic or projected 3D CRS as a compound CRS whose
 vertical CRS represents the ellipsoidal height.
 .sp
 \fBNOTE:\fP


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * Allow to <verb> -> Allows <verb>ing