### PR TITLE
isEquivalentName(): fix for GDAL test failure

### DIFF
--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1124,7 +1124,7 @@ void Identifier::_exportToJSON(JSONFormatter *formatter) const {
 //! @cond Doxygen_Suppress
 static bool isIgnoredChar(char ch) {
     return ch == ' ' || ch == '_' || ch == '-' || ch == '/' || ch == '(' ||
-           ch == ')' || ch == '.' || ch == '&';
+           ch == ')' || ch == '.' || ch == '&' || ch == ',';
 }
 //! @endcond
 

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -391,4 +391,8 @@ TEST(metadata, Identifier_isEquivalentName) {
     EXPECT_TRUE(Identifier::isEquivalentName("a", "\xc3\xa1"));
 
     EXPECT_TRUE(Identifier::isEquivalentName("\xc3\xa4", "\xc3\xa1"));
+
+    EXPECT_TRUE(Identifier::isEquivalentName(
+        "Unknown based on International 1924 (Hayford 1909, 1910) ellipsoid",
+        "Unknown_based_on_International_1924_Hayford_1909_1910_ellipsoid"));
 }


### PR DESCRIPTION
https://github.com/OSGeo/PROJ/pull/2536 changed the name of the
ellps=intl to "International 1924 (Hayford 1909, 1910)"
When writing a GeoTIFF file from GDAL using a SRS built from a
PROJ string, GDAL massages the datum name to
"Unknown_based_on_International_1924_Hayford_1909_1910_ellipsoid"
Before this fix, this wasn't considered as equivaleent to the non-massaged
datum name "Unknown based on International 1924 (Hayford 1909, 1910) ellipsoid"
