### PR TITLE
Fix gcc 11 -Wnonnull warnings

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -4723,12 +4723,17 @@ AuthorityFactory::createBetweenGeodeticCRSWithDatumBasedIntermediates(
         sourceCRSCode == targetCRSCode) {
         return listTmp;
     }
+    const auto sourceGeodCRS =
+        dynamic_cast<crs::GeodeticCRS *>(sourceCRS.get());
+    const auto targetGeodCRS =
+        dynamic_cast<crs::GeodeticCRS *>(targetCRS.get());
+    if (!sourceGeodCRS || !targetGeodCRS) {
+        return listTmp;
+    }
 
     std::string minDate;
-    const auto &sourceDatum =
-        dynamic_cast<crs::GeodeticCRS *>(sourceCRS.get())->datum();
-    const auto &targetDatum =
-        dynamic_cast<crs::GeodeticCRS *>(targetCRS.get())->datum();
+    const auto &sourceDatum = sourceGeodCRS->datum();
+    const auto &targetDatum = targetGeodCRS->datum();
     if (sourceDatum && sourceDatum->publicationDate().has_value() &&
         targetDatum && targetDatum->publicationDate().has_value()) {
         const auto sourceDate(sourceDatum->publicationDate()->toString());

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -1856,14 +1856,14 @@ createBallparkGeographicOffset(const crs::CRSNNPtr &sourceCRS,
         accuracies.emplace_back(metadata::PositionalAccuracy::create("0"));
     }
 
-    if (dynamic_cast<const crs::SingleCRS *>(sourceCRS.get())
-                ->coordinateSystem()
-                ->axisList()
-                .size() == 3 ||
-        dynamic_cast<const crs::SingleCRS *>(targetCRS.get())
-                ->coordinateSystem()
-                ->axisList()
-                .size() == 3) {
+    const auto singleSourceCRS =
+        dynamic_cast<const crs::SingleCRS *>(sourceCRS.get());
+    const auto singleTargetCRS =
+        dynamic_cast<const crs::SingleCRS *>(targetCRS.get());
+    if ((singleSourceCRS &&
+         singleSourceCRS->coordinateSystem()->axisList().size() == 3) ||
+        (singleTargetCRS &&
+         singleTargetCRS->coordinateSystem()->axisList().size() == 3)) {
         return Transformation::createGeographic3DOffsets(
             map, sourceCRS, targetCRS, angle0, angle0, common::Length(0),
             accuracies);


### PR DESCRIPTION
```
/proj-8.0.0/src/iso19111/operation/coordinateoperationfactory.cpp: In function 'osgeo::proj::operation::TransformationNNPtr osgeo::proj::operation::createBallparkGeographicOffset(const CRSNNPtr&, const CRSNNPtr&, const DatabaseContextPtr&)':
/proj-8.0.0/src/iso19111/operation/coordinateoperationfactory.cpp:1860:36: warning: 'this' pointer is null [-Wnonnull]
 1860 |                 ->coordinateSystem()
      |                                    ^
In file included from /proj-8.0.0/src/iso19111/operation/coordinateoperationfactory.cpp:35:
/proj-8.0.0/include/proj/crs.hpp:196:47: note: in a call to non-static member function 'const CoordinateSystemNNPtr& osgeo::proj::crs::SingleCRS::coordinateSystem() const'
  196 |     PROJ_DLL const cs::CoordinateSystemNNPtr &coordinateSystem() PROJ_PURE_DECL;
      |                                               ^~~~~~~~~~~~~~~~
/proj-8.0.0/src/iso19111/operation/coordinateoperationfactory.cpp:1864:36: warning: 'this' pointer is null [-Wnonnull]
 1864 |                 ->coordinateSystem()
      |                                    ^
In file included from /proj-8.0.0/src/iso19111/operation/coordinateoperationfactory.cpp:35:
/proj-8.0.0/include/proj/crs.hpp:196:47: note: in a call to non-static member function 'const CoordinateSystemNNPtr& osgeo::proj::crs::SingleCRS::coordinateSystem() const'
  196 |     PROJ_DLL const cs::CoordinateSystemNNPtr &coordinateSystem() PROJ_PURE_DECL;
      |                                               ^~~~~~~~~~~~~~~~
/proj-8.0.0/src/iso19111/factory.cpp: In member function 'std::vector<dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::operation::CoordinateOperation> > > osgeo::proj::io::AuthorityFactory::createBetweenGeodeticCRSWithDatumBasedIntermediates(const CRSNNPtr&, const string&, const string&, const CRSNNPtr&, const string&, const string&, bool, bool, bool, bool, const std::vector<std::__cxx11::basic_string<char> >&, const ExtentPtr&, const ExtentPtr&) const':
/proj-8.0.0/src/iso19111/factory.cpp:4724:66: warning: 'this' pointer is null [-Wnonnull]
 4724 |         dynamic_cast<crs::GeodeticCRS *>(sourceCRS.get())->datum();
      |                                                                  ^
In file included from /proj-8.0.0/src/iso19111/factory.cpp:36:
/proj-8.0.0/include/proj/crs.hpp:254:54: note: in a call to non-static member function 'const GeodeticReferenceFramePtr& osgeo::proj::crs::GeodeticCRS::datum() const'
  254 |     PROJ_DLL const datum::GeodeticReferenceFramePtr &datum() PROJ_PURE_DECL;
      |                                                      ^~~~~
/proj-8.0.0/src/iso19111/factory.cpp:4726:66: warning: 'this' pointer is null [-Wnonnull]
 4726 |         dynamic_cast<crs::GeodeticCRS *>(targetCRS.get())->datum();
      |                                                                  ^
In file included from /proj-8.0.0/src/iso19111/factory.cpp:36:
/proj-8.0.0/include/proj/crs.hpp:254:54: note: in a call to non-static member function 'const GeodeticReferenceFramePtr& osgeo::proj::crs::GeodeticCRS::datum() const'
  254 |     PROJ_DLL const datum::GeodeticReferenceFramePtr &datum() PROJ_PURE_DECL;
      |                                                      ^~~~~
```
