### PR TITLE
Fix configuration for sphinxcontrib-bibtex version 2 or later

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -48,6 +48,8 @@ jobs:
       run: |
           python3 --version
           sphinx-build --version
+          python3 -m pip list --not-required --format=columns
+
     - uses: actions/download-artifact@v2
       name: Images
       with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,9 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# BibTeX configuration
+bibtex_bibfiles = ['references.bib']
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']

--- a/docs/source/operations/projections/utm.rst
+++ b/docs/source/operations/projections/utm.rst
@@ -37,7 +37,7 @@ to which specific parameters, such as central meridians, have been applied.
 The Earth is divided into 60 zones each generally 6° wide in longitude.
 Bounding meridians are evenly divisible by 6°, and zones are
 numbered from 1 to 60 proceeding east from the 180th meridian from Greenwich
-with minor exceptions [Snyder1987]_.
+with minor exceptions :cite:`Snyder1987`.
 
 Usage
 #####

--- a/docs/source/operations/projections/webmerc.rst
+++ b/docs/source/operations/projections/webmerc.rst
@@ -64,7 +64,7 @@ Parameters
 Mathematical definition
 #######################
 
-The formulas describing the Mercator projection are all taken from G. Evenden's libproj manuals [Evenden2005]_.
+The formulas describing the Mercator projection are all taken from G. Evenden's libproj manuals :cite:`Evenden2005`.
 
 Forward projection
 ==================


### PR DESCRIPTION
To use sphinxcontrib-biblatex version 2.0 or later, some basic [configuration](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#configuration) is required. Furthermore, some references need to be fixed.

These changes are backwards compatible, so there is no need to update the osgeo/proj-docs container.

Also show a listing of installed pip packages.