### PR TITLE
CI: workaround for sphinxcontrib-spelling 7.1.0 on Python 3.6.9

### DIFF
--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -11,4 +11,5 @@ RUN python3 -m pip install Sphinx breathe \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     sphinxcontrib-spelling
 
-
+# workaround for sphinxcontrib-spelling 7.1.0
+RUN sed -i '188s/except ImportError/except \(ImportError, UnicodeError\)/' /usr/local/lib/python3.6/dist-packages/sphinxcontrib/spelling/filters.py


### PR DESCRIPTION
Trade one hack for another?

From https://github.com/OSGeo/PROJ/pull/2573#issuecomment-797015308 the container osgeo/proj-docs was updated, which unfortunately broke `make spelling`. This "fix" is really a workaround, which will need to come upstream (see https://github.com/sphinx-contrib/spelling/issues/121).