### PR TITLE
Set the container locale for spelling

### DIFF
--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -4,12 +4,16 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-dev python3-pip g++ doxygen dvipng latexmk \
     cmake libjpeg8-dev zlib1g-dev texlive-latex-base \
     texlive-latex-extra git latex-cjk-all texlive-lang-all \
-    graphviz python3-matplotlib wget unzip enchant
+    graphviz python3-matplotlib wget unzip enchant locales
 
 RUN python3 -m pip install Sphinx breathe \
     sphinx_bootstrap_theme awscli sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     sphinxcontrib-spelling
 
-# workaround for sphinxcontrib-spelling 7.1.0
-RUN sed -i '188s/except ImportError/except \(ImportError, UnicodeError\)/' /usr/local/lib/python3.6/dist-packages/sphinxcontrib/spelling/filters.py
+# Set the locale for spelling
+RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_GB.UTF-8
+
+ENV LANG en_GB.UTF-8


### PR DESCRIPTION
This should be the last container modification request for now. The primary issue [noted here](https://github.com/OSGeo/PROJ/pull/2573#issuecomment-797015308) was not a sphinxcontrib-spelling bug, but that the container did not have a locale set.

This PR removes the most recent hack, and sets the locale to `en_US.UTF-8` (which implies that we should be using American spelling throughout the docs?)

Dockerfile was checked locally to ensure `make spelling` succeeds.