### PR TITLE
proj.h: add PROJ_COMPUTE_VERSION, PROJ_VERSION_NUMBER, PROJ_AT_LEAST_VERSION macros

### DIFF
--- a/docs/source/development/reference/index.rst
+++ b/docs/source/development/reference/index.rst
@@ -7,6 +7,7 @@ Reference
 .. toctree::
    :maxdepth: 1
 
+   macros
    datatypes
    functions
    cpp/index.rst

--- a/docs/source/development/reference/macros.rst
+++ b/docs/source/development/reference/macros.rst
@@ -1,0 +1,39 @@
+.. _macros:
+
+================================================================================
+Macros
+================================================================================
+
+.. c:macro:: PROJ_VERSION_MAJOR
+
+    Major version number, e.g 8 for PROJ 8.0.1
+
+.. c:macro:: PROJ_VERSION_MINOR
+
+    Minor version number, e.g 0 for PROJ 8.0.1
+
+.. c:macro:: PROJ_VERSION_PATCH
+
+    Patch version number, e.g 1 for PROJ 8.0.1
+
+.. c:macro:: PROJ_COMPUTE_VERSION(maj,min,patch)
+
+    .. versionadded:: 8.0.1
+
+    Compute the version number from the major, minor and patch numbers.
+
+.. c:macro:: PROJ_VERSION_NUMBER
+
+    .. versionadded:: 8.0.1
+
+    Total version number, equal to
+    ``PROJ_COMPUTE_VERSION(PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR, PROJ_VERSION_PATCH)``
+
+.. c:macro:: PROJ_AT_LEAST_VERSION(maj,min,patch)
+
+    .. versionadded:: 8.0.1
+
+    Macro that returns true if the current PROJ version is at least the version
+    specified by (maj,min,patch)
+
+    Equivalent to ``PROJ_VERSION_NUMBER >= PROJ_COMPUTE_VERSION(maj,min,patch)``

--- a/src/proj.h
+++ b/src/proj.h
@@ -174,6 +174,18 @@ extern "C" {
 #define PROJ_VERSION_MINOR 1
 #define PROJ_VERSION_PATCH 0
 
+/* Note: the following 3 defines have been introduced in PROJ 8.0.1 */
+/* Macro to compute a PROJ version number from its components */
+#define PROJ_COMPUTE_VERSION(maj,min,patch) ((maj)*10000+(min)*100+(patch))
+
+/* Current PROJ version from the above version numbers */
+#define PROJ_VERSION_NUMBER                 \
+    PROJ_COMPUTE_VERSION(PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR, PROJ_VERSION_PATCH)
+
+/* Macro that returns true if the current PROJ version is at least the version specified by (maj,min,patch) */
+#define PROJ_AT_LEAST_VERSION(maj,min,patch) \
+    (PROJ_VERSION_NUMBER >= PROJ_COMPUTE_VERSION(maj,min,patch))
+
 extern char const PROJ_DLL pj_release[]; /* global release id string */
 
 /* first forward declare everything needed */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -179,3 +179,13 @@ target_link_libraries(test_tinshift
 add_test(NAME test_tinshift COMMAND test_tinshift)
 set_property(TEST test_tinshift
   PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
+
+add_executable(test_misc
+  main.cpp
+  test_misc.cpp)
+target_link_libraries(test_misc
+  PRIVATE GTest::gtest
+  PRIVATE ${PROJ_LIBRARIES})
+add_test(NAME test_misc COMMAND test_misc)
+set_property(TEST test_misc
+  PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -19,7 +19,7 @@ noinst_PROGRAMS += include_proj_h_from_c
 noinst_PROGRAMS += test_network
 noinst_PROGRAMS += test_defmodel
 noinst_PROGRAMS += test_tinshift
-
+noinst_PROGRAMS += test_misc
 
 pj_phi2_test_SOURCES = pj_phi2_test.cpp main.cpp
 pj_phi2_test_LDADD = ../../src/libproj.la @GTEST_LIBS@
@@ -89,6 +89,13 @@ test_tinshift_LDADD = ../../src/libproj.la @GTEST_LIBS@
 test_tinshift-check: test_tinshift
 	PROJ_LIB=$(PROJ_LIB) ./test_tinshift
 
+test_misc_SOURCES = test_misc.cpp main.cpp
+test_misc_LDADD = ../../src/libproj.la @GTEST_LIBS@
+
+test_misc-check: test_misc
+	PROJ_LIB=$(PROJ_LIB) ./test_misc
+
 check-local: pj_phi2_test-check proj_errno_string_test-check \
 		proj_angular_io_test-check proj_context_test-check test_cpp_api-check \
-		gie_self_tests-check test_network-check test_defmodel-check test_tinshift-check
+		gie_self_tests-check test_network-check test_defmodel-check test_tinshift-check \
+		test_misc-check

--- a/test/unit/test_misc.cpp
+++ b/test/unit/test_misc.cpp
@@ -1,0 +1,48 @@
+/******************************************************************************
+ *
+ * Project:  PROJ
+ * Purpose:  Test
+ * Author:   Even Rouault <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2021, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gtest_include.h"
+
+#include "proj.h"
+
+namespace {
+
+TEST(misc, version) {
+    EXPECT_EQ(PROJ_COMPUTE_VERSION(2200, 98, 76), 22009876);
+    EXPECT_EQ(PROJ_VERSION_NUMBER, PROJ_VERSION_MAJOR * 10000 +
+                                       PROJ_VERSION_MINOR * 100 +
+                                       PROJ_VERSION_PATCH);
+    EXPECT_TRUE(PROJ_AT_LEAST_VERSION(PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR,
+                                      PROJ_VERSION_PATCH));
+    EXPECT_TRUE(PROJ_AT_LEAST_VERSION(PROJ_VERSION_MAJOR - 1,
+                                      PROJ_VERSION_MINOR, PROJ_VERSION_PATCH));
+    EXPECT_FALSE(PROJ_AT_LEAST_VERSION(PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR,
+                                       PROJ_VERSION_PATCH + 1));
+}
+
+} // namespace


### PR DESCRIPTION
Makes it easier for users to test if they build against a PROJ version
later than a given x.y.z version.

To be backported in 8.0 branch