### PR TITLE
createFromCRSCodesWithIntermediates(): improve perf when no match

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -6081,6 +6081,22 @@ AuthorityFactory::createFromCRSCodesWithIntermediates(
         return listTmp;
     }
 
+    const auto CheckIfHasOperations = [=](const std::string &auth_name,
+                                          const std::string &code) {
+        return !(d->run("SELECT 1 FROM coordinate_operation_view WHERE "
+                        "(source_crs_auth_name = ? AND source_crs_code = ?) OR "
+                        "(target_crs_auth_name = ? AND target_crs_code = ?)",
+                        {auth_name, code, auth_name, code})
+                     .empty());
+    };
+
+    // If the source or target CRS are not the source or target of an operation,
+    // do not run the next costly requests.
+    if (!CheckIfHasOperations(sourceCRSAuthName, sourceCRSCode) ||
+        !CheckIfHasOperations(targetCRSAuthName, targetCRSCode)) {
+        return listTmp;
+    }
+
     const std::string sqlProlog(
         discardSuperseded
             ?


### PR DESCRIPTION
createFromCRSCodesWithIntermediates() runs a rather costly self-join.
Only run it if the source and target CRS are the source/target of a
coordinate operation. This helps for the performance of
proj_create_crs_to_crs() when run on projected CRS for example that are
extremely unlikely to be the source/target of an operation (except
currently the Finish ones). For the EPSG:26915 to EPSG:3857 case of
https://github.com/OSGeo/gdal/issues/3470, this helps decreasing the
time of proj_create_crs_to_crs() from 18 ms to 10 ms.
