### PR TITLE
Add transformations for CHGeo2004, Swiss geoid model

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -85,6 +85,8 @@ VALUES
 -- ch_swisstopo - Swisstopo Federal Office of Topography
 ('CHENyx06a.gsb','ch_swisstopo_CHENyx06a.tif','CHENyx06a.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/ch_swisstopo_CHENyx06a.tif',1,1,NULL),
 ('CHENyx06_ETRS.gsb','ch_swisstopo_CHENyx06_ETRS.tif','CHENyx06_ETRS.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/ch_swisstopo_CHENyx06_ETRS.tif',1,1,NULL),
+('chgeo2004_ETRS.agr','ch_swisstopo_chgeo2004_ETRS89_LHN95.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/ch_swisstopo_chgeo2004_ETRS89_LHN95.tif',1,1,NULL),
+('chgeo2004_htrans_ETRS.agr','ch_swisstopo_chgeo2004_ETRS89_LN02.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/ch_swisstopo_chgeo2004_ETRS89_LN02.tif',1,1,NULL),
 
 -- de_adv - Arbeitsgemeinschaft der Vermessungsverwaltungender der Länder der Bundesrepublik Deutschland (AdV)
 ('BETA2007.gsb','de_adv_BETA2007.tif','BETA2007.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/de_adv_BETA2007.tif',1,1,NULL),

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -169,3 +169,45 @@ INSERT INTO "usage" VALUES(
     'EPSG','3263', -- area of use: Japan - onshore mainland
     'EPSG','1024'  -- unknown
 );
+
+-- Switzerland
+
+INSERT INTO "grid_transformation" VALUES(
+    'PROJ','EPSG_4937_TO_EPSG_5729','ETRS89 to LHN95 height',
+    NULL,
+    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
+    'EPSG','4937', -- source CRS (ETRS89)
+    'EPSG','5729', -- target CRS (LHN95 height)
+    NULL,
+    'EPSG','8666','Geoid (height correction) model file','chgeo2004_ETRS.agr',
+    NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
+
+INSERT INTO "usage" VALUES(
+    'PROJ',
+    'EPSG_4937_TO_EPSG_5729_USAGE',
+    'grid_transformation',
+    'PROJ',
+    'EPSG_4937_TO_EPSG_5729',
+    'EPSG','1286', -- area of use: Europe - Liechtenstein and Switzerland
+    'EPSG','1024'  -- unknown
+);
+
+INSERT INTO "grid_transformation" VALUES(
+    'PROJ','EPSG_4937_TO_EPSG_5728','ETRS89 to LN02 height',
+    NULL,
+    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
+    'EPSG','4937', -- source CRS (ETRS89)
+    'EPSG','5728', -- target CRS (LN02 height)
+    NULL,
+    'EPSG','8666','Geoid (height correction) model file','chgeo2004_htrans_ETRS.agr',
+    NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
+
+INSERT INTO "usage" VALUES(
+    'PROJ',
+    'EPSG_4937_TO_EPSG_5728_USAGE',
+    'grid_transformation',
+    'PROJ',
+    'EPSG_4937_TO_EPSG_5728',
+    'EPSG','1286', -- area of use: Europe - Liechtenstein and Switzerland
+    'EPSG','1024'  -- unknown
+);


### PR DESCRIPTION
- added entries in `grid_alternatives.sql` for `ch_swisstopo_chgeo2004_ETRS89_LHN95.tif` and `ch_swisstopo_chgeo2004_ETRS89_LN02.tif`, included in `PROJ-data`
- added entries in `grid_transformation_custom.sql` until EPSG is updated. This gives us more time to test the behaviour.

See related PR https://github.com/OSGeo/PROJ-data/pull/61