### PR TITLE
CRS::promoteTo3D(): propagate the extent from the 2D CRS (fixes #2587)

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1002,6 +1002,24 @@ CRSNNPtr CRS::promoteTo3D(const std::string &newName,
         auto props =
             util::PropertyMap().set(common::IdentifiedObject::NAME_KEY,
                                     !newName.empty() ? newName : nameStr());
+        const auto &l_domains = domains();
+        if (!l_domains.empty()) {
+            auto array = util::ArrayOfBaseObject::create();
+            for (const auto &domain : l_domains) {
+                auto extent = domain->domainOfValidity();
+                if (extent) {
+                    // Propagate only the extent, not the scope, as it might
+                    // imply more that we can guarantee with the promotion to
+                    // 3D.
+                    auto newDomain = common::ObjectDomain::create(
+                        util::optional<std::string>(), extent);
+                    array->add(newDomain);
+                }
+            }
+            if (!array->empty()) {
+                props.set(common::ObjectUsage::OBJECT_DOMAIN_KEY, array);
+            }
+        }
         const auto &l_identifiers = identifiers();
         if (l_identifiers.size() == 1) {
             std::string remarks("Promoted to 3D from ");

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1220,6 +1220,10 @@ PROJCRS["WGS 84 / UTM zone 31N",
             ORDER[3],
             LENGTHUNIT["metre",1,
                 ID["EPSG",9001]]],
+    USAGE[
+        SCOPE["unknown"],
+        AREA["Between 0°E and 6°E, northern hemisphere between equator and 84°N, onshore and offshore. Algeria. Andorra. Belgium. Benin. Burkina Faso. Denmark - North Sea. France. Germany - North Sea. Ghana. Luxembourg. Mali. Netherlands. Niger. Nigeria. Norway. Spain. Togo. United Kingdom (UK) - North Sea."],
+        BBOX[0,0,84,6]],
     REMARK["Promoted to 3D from EPSG:32631"]]
 
 Testing -s EPSG:32631 -t EPSG:4326+3855 --summary


### PR DESCRIPTION
This will help getting more consistent results between the 2D and 3D
cases, as identified in
https://github.com/OSGeo/PROJ/issues/2587#issue-836061171