### PR TITLE
fix wrong capitalization of CHENyx06_ETRS.gsb

### DIFF
--- a/data/CH
+++ b/data/CH
@@ -18,6 +18,6 @@
 #
 <metadata> +origin=Swisstopo +lastupdate=2012-02-27
 # CH1903/LV03
-<1903_LV03>  +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +nadgrids=CHENYX06_etrs.gsb +no_defs
+<1903_LV03>  +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +units=m +nadgrids=CHENyx06_ETRS.gsb +no_defs
 # CH1903
-<1903> +proj=longlat +ellps=bessel +nadgrids=CHENYX06_etrs.gsb +no_defs  <>
+<1903> +proj=longlat +ellps=bessel +nadgrids=CHENyx06_ETRS.gsb +no_defs  <>


### PR DESCRIPTION
 - [x] Added clear title that can be used to generate release notes

The file `data/CH` containing the `+proj` string to use `CHENyx06_ETRS.gsb` was wrongly capitalized. It was not consistent with EPSG and therefore other entries in `proj.db`.

Entry in EPSG: https://epsg.org/transformation_7674/CH1903-to-ETRS89-2.html