### PR TITLE
Fix bounding box calculations around the 180 degrees longitude.

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -988,17 +988,35 @@ static void reproject_bbox(PJ* pjGeogToCrs,
     if( !(west_lon == -180.0 && east_lon == 180.0 &&
           south_lat == -90.0 && north_lat == 90.0) )
     {
+        double east_step;
+
         minx = -minx;
         miny = -miny;
         maxx = -maxx;
         maxy = -maxy;
 
+        if (east_lon >= west_lon)
+        {
+            east_step = (east_lon - west_lon) / 20;
+        }
+        else
+        {
+            east_step = (east_lon - west_lon + 360.0) / 20;
+        }
+
         std::vector<double> x(21 * 4), y(21 * 4);
         for( int j = 0; j <= 20; j++ )
         {
-            x[j] = west_lon + j * (east_lon - west_lon) / 20;
+            double lon_step = west_lon + j * east_step;
+
+            if (lon_step > 180.0)
+            {
+                lon_step -= 360.0;
+            }
+
+            x[j] = lon_step;
             y[j] = south_lat;
-            x[21+j] = west_lon + j * (east_lon - west_lon) / 20;
+            x[21+j] = lon_step;
             y[21+j] = north_lat;
             x[21*2+j] = west_lon;
             y[21*2+j] = south_lat + j * (north_lat - south_lat) / 20;


### PR DESCRIPTION
The bounding box calculations in 4D_api.cpp (which are used to calculate the 'best transform') are not capable of wrapping properly around at +/- 180 degrees.

This fixes the issue I originally misreported as issue #2615.

For EPSG 3851 this fixes the bounding box calculations from:
![image](https://user-images.githubusercontent.com/2271549/112747891-8d299880-8fb8-11eb-8e18-e0947b7bd6ea.png)

to
![image](https://user-images.githubusercontent.com/2271549/112748296-1a6dec80-8fbb-11eb-9cd3-355f60eca9ac.png)

Or in text:
The bounding box used to be calculated as

* Unexpected
X: -4432415 - 8601774
Y: -5984083 - 12006385

* Expected
X: 5228059 - 8692628
Y: 1722484 - 4624385


I don't have an example where PROJ makes a bad decision based on this, but others might re-use the code like I did in SharpProj.