### PR TITLE
GitHub Action to build both the 'proj' and 'proj-docs' container 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,67 @@
+name: Docker
+
+on: [push, pull_request, workflow_dispatch]
+
+# adapted from https://raw.githubusercontent.com/stefanprodan/podinfo/master/.github/workflows/release.yml
+#
+jobs:
+  containers:
+    runs-on: ubuntu-latest
+    env:
+      PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint
+        id: lint
+        run: |
+          echo "are we pushing packages" ${{ env.PUSH_PACKAGES }}
+          echo "event_name" ${{ github.event_name }}
+          echo "ref" ${{ github.ref }}
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - if: ${{ env.PUSH_PACKAGES == 'true' }}
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - if: ${{ env.PUSH_PACKAGES == 'true' }}
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=sha-${GITHUB_SHA::8}
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ env.PUSH_PACKAGES == 'true' }}
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          tags: |
+            docker.io/osgeo/proj:${{ steps.prep.outputs.VERSION }}
+            docker.io/osgeo/proj:latest
+            ghcr.io/osgeo/proj:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/osgeo/proj:latest
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,20 @@ on: [push, pull_request, workflow_dispatch]
 #
 jobs:
   containers:
+    name: ${{ matrix.container }} Container
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: ["proj","proj-docs"]
+        dockerfile: ["./Dockerfile", "./docs/docbuild/Dockerfile"]
+        exclude:
+          - container: "proj"
+            dockerfile: "./docs/docbuild/Dockerfile"
+          - container: "proj-docs"
+            dockerfile: "./Dockerfile"
     env:
       PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' }}
+      CONTAINER: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2
       - name: Lint
@@ -50,13 +61,13 @@ jobs:
           push: ${{ env.PUSH_PACKAGES == 'true' }}
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          file: ./Dockerfile
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
           tags: |
-            docker.io/osgeo/proj:${{ steps.prep.outputs.VERSION }}
-            docker.io/osgeo/proj:latest
-            ghcr.io/osgeo/proj:${{ steps.prep.outputs.VERSION }}
-            ghcr.io/osgeo/proj:latest
+            docker.io/osgeo/${{ matrix.container }}:${{ steps.prep.outputs.VERSION }}
+            docker.io/osgeo/${{ matrix.container }}:latest
+            ghcr.io/osgeo/${{ matrix.container }}:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/osgeo/${{ matrix.container }}:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
           - container: "proj-docs"
             dockerfile: "./Dockerfile"
     env:
-      PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' }}
+      PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
       CONTAINER: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* Build both the 'proj' and the 'proj-docs' container
* Push the containers to both dockerhub and ghcr.io only if we are a commit in the OSGeo/PROJ repository
* Label both containers with the SHA or tag (if the commit is a tag)
* Label both with ``latest``. I think this might need some consideration. We use this code for PDAL, but we only ever push containers out of the ``master`` branch. PROJ could adopt that posture, or it could adjust how it labels the ``latest`` to follow only when a push to a maintenance branch happened.