### PR TITLE
createOperation(): make sure no to discard deprecated operations...

### DIFF
--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -305,6 +305,11 @@ unset PROJ_AUX_DB
 rm -f tmp_projinfo_aux.db
 echo "" >>${OUT}
 
+echo 'Testing -s EPSG:23030 -t EPSG:25830 --bbox -6,40,-5,41 --grid-check known_available --hide-ballpark --summary' >> ${OUT}
+echo 'Checks that ED50 to ETRS89 (12) is in the output (superseded transformation, but replacements has unknown grid)' >> ${OUT}
+$EXE -s EPSG:23030 -t EPSG:25830 --bbox -6,40,-5,41 --grid-check known_available --hide-ballpark --summary >>${OUT} 2>&1
+echo "" >>${OUT}
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testprojinfo_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testprojinfo_out.dist

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1594,3 +1594,9 @@ GEOGCRS["WGS 84",
         BBOX[-90,-180,90,180]],
     ID["HOBU","XXXX"]]
 
+Testing -s EPSG:23030 -t EPSG:25830 --bbox -6,40,-5,41 --grid-check known_available --hide-ballpark --summary
+Checks that ED50 to ETRS89 (12) is in the output (superseded transformation, but replacements has unknown grid)
+Candidate operations found: 2
+unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (12) + UTM zone 30N, 0.2 m, Spain - mainland, Balearic Islands, Ceuta and Melila - onshore.
+unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (7) + UTM zone 30N, 1.5 m, Spain - onshore mainland except northwest (north of 41°30'N and west of 4°30'W).
+


### PR DESCRIPTION
if the replacement uses a grid unknown to us.

Fixes issue reported at https://lists.osgeo.org/pipermail/gdal-dev/2021-March/053771.html

The issue comes from the fact that EPSG has created 2 transformations
using grids BALR2009.gsb ad PENR2009.gsb that supersede the one which
uses the single grid SPED2ETV2 we have in PROJ-data.

More general fix than the hack of https://github.com/OSGeo/PROJ/pull/2619