### PR TITLE
test: add datum shift related tests for transformations crossing antimeridian

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -346,6 +346,8 @@ similarly, but prefers the 2D resp. 3D interfaces if available.
                         if (proj_log_level(P->ctx, PJ_LOG_TELL) >= PJ_LOG_DEBUG) {
                             std::string msg("Using coordinate operation ");
                             msg += alt.name;
+                            msg += " as a fallback due to lack of more "
+                                   "appropriate operations";
                             pj_log(P->ctx, PJ_LOG_DEBUG, msg.c_str());
                         }
                         P->iCurCoordOp = i;

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1033,6 +1033,20 @@ $EXE -E --no-ballpark EPSG:4267 EPSG:4258 >> ${OUT} <<EOF
 49 2
 EOF
 
+echo  "##############################################################" >> ${OUT}
+echo  "Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))" >> ${OUT}
+$EXE -E "Pulkovo 1942" "WGS 84" >> ${OUT} <<EOF
+50 179.999999999
+50 -179.999999999
+EOF
+
+echo  "##############################################################" >> ${OUT}
+echo  "Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))" >> ${OUT}
+$EXE -E EPSG:2636 "WGS 84" >> ${OUT} <<EOF
+5540944.47  499999.999
+5540944.47  500000.001
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -496,3 +496,11 @@ and the second one a no-op
 Test effect of --accuracy
 ##############################################################
 Test effect of --no-ballpark
+##############################################################
+Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))
+50 179.999999999	49d59'59.36"N	179d59'52.133"W 0.000
+50 -179.999999999	49d59'59.36"N	179d59'52.133"W 0.000
+##############################################################
+Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))
+5540944.47  499999.999	49d59'59.36"N	179d59'52.133"W 0.000
+5540944.47  500000.001	49d59'59.36"N	179d59'52.133"W 0.000


### PR DESCRIPTION
If using the proposed patch in PR #2616 refreshed as,

```
diff --git a/src/4D_api.cpp b/src/4D_api.cpp
index c7725d3a..3bd58a97 100644
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -998,7 +998,7 @@ static void reproject_bbox(PJ* pjGeogToCrs,
         constexpr int XY_SIZE = N_STEPS_P1 * 4;
         std::vector<double> x(XY_SIZE);
         std::vector<double> y(XY_SIZE);
-        const double step_lon = (east_lon - west_lon) / N_STEPS;
+        const double step_lon = (((east_lon >= west_lon) ? east_lon : east_lon + 360) - west_lon) / N_STEPS;
         const double step_lat = (north_lat - south_lat) / N_STEPS;
         for( int j = 0; j <= N_STEPS; j++ )
         {
@@ -1244,7 +1244,7 @@ std::vector<PJCoordOperation> pj_create_prepared_operations(PJ_CONTEXT *ctx,
             {
                 const bool isOffshore =
                     areaName && strstr(areaName, "- offshore");
-                if( west_lon <= east_lon )
+                if( true || west_lon <= east_lon )
                 {
                     op = add_coord_op_to_list(i, op,
                         west_lon, south_lat, east_lon, north_lat,
```

we'd get an incorrect result on one point, using the 'Pulkovo 1942 to WGS 84 (16)' less accurate transformation
due to mis-computation of bounding boxes.
```
--- ../test/cli/tv_out.dist	2021-04-07 22:29:02.706095239 +0200
+++ test/cli/tv_out	2021-04-07 22:29:35.809579495 +0200
@@ -499,7 +499,7 @@
 ##############################################################
 Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))
 50 179.999999999	49d59'59.36"N	179d59'52.133"W 0.000
-50 -179.999999999	49d59'59.36"N	179d59'52.133"W 0.000
+50 -179.999999999	49d59'59.422"N	179d59'52.184"W 0.000
 ##############################################################
 Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))
 5540944.47  499999.999	49d59'59.36"N	179d59'52.133"W 0.000
```
