### PR TITLE
CRS::normalizeForVisualization(): propagate domains/extent of original CRS (fixes #2603)

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -142,7 +142,7 @@ class PROJ_GCC_DLL CRS : public common::ObjectUsage,
 
     PROJ_INTERNAL bool mustAxisOrderBeSwitchedForVisualization() const;
 
-    PROJ_INTERNAL CRSNNPtr normalizeForVisualization() const;
+    PROJ_FOR_TEST CRSNNPtr normalizeForVisualization() const;
 
     PROJ_INTERNAL CRSNNPtr allowNonConformantWKT1Export() const;
 

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -117,6 +117,7 @@ osgeo::proj::crs::CRS::extractGeographicCRS() const
 osgeo::proj::crs::CRS::extractVerticalCRS() const
 osgeo::proj::crs::CRS::getNonDeprecated(dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::io::DatabaseContext> > const&) const
 osgeo::proj::crs::CRS::identify(std::shared_ptr<osgeo::proj::io::AuthorityFactory> const&) const
+osgeo::proj::crs::CRS::normalizeForVisualization() const
 osgeo::proj::crs::CRS::promoteTo3D(std::string const&, std::shared_ptr<osgeo::proj::io::DatabaseContext> const&) const
 osgeo::proj::crs::CRS::shallowClone() const
 osgeo::proj::crs::CRS::stripVerticalComponent() const

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -162,7 +162,7 @@ static BaseObjectNNPtr buildObject(
     const std::string &kind, const std::string &context,
     bool buildBoundCRSToWGS84,
     CoordinateOperationContext::IntermediateCRSUse allowUseIntermediateCRS,
-    bool promoteTo3D, bool quiet) {
+    bool promoteTo3D, bool normalizeAxisOrder, bool quiet) {
     BaseObjectPtr obj;
 
     std::string l_user_string(user_string);
@@ -307,6 +307,13 @@ static BaseObjectNNPtr buildObject(
         auto crs = std::dynamic_pointer_cast<CRS>(obj);
         if (crs) {
             obj = crs->promoteTo3D(std::string(), dbContext).as_nullable();
+        }
+    }
+
+    if (normalizeAxisOrder) {
+        auto crs = std::dynamic_pointer_cast<CRS>(obj);
+        if (crs) {
+            obj = crs->normalizeForVisualization().as_nullable();
         }
     }
 
@@ -712,12 +719,12 @@ static void outputOperations(
     CoordinateOperationContext::IntermediateCRSUse allowUseIntermediateCRS,
     const std::vector<std::pair<std::string, std::string>> &pivots,
     const std::string &authority, bool usePROJGridAlternatives,
-    bool showSuperseded, bool promoteTo3D, double minimumAccuracy,
-    const OutputOptions &outputOpt, bool summary) {
+    bool showSuperseded, bool promoteTo3D, bool normalizeAxisOrder,
+    double minimumAccuracy, const OutputOptions &outputOpt, bool summary) {
     auto sourceObj =
         buildObject(dbContext, sourceCRSStr, "crs", "source CRS", false,
                     CoordinateOperationContext::IntermediateCRSUse::NEVER,
-                    promoteTo3D, outputOpt.quiet);
+                    promoteTo3D, normalizeAxisOrder, outputOpt.quiet);
     auto sourceCRS = nn_dynamic_pointer_cast<CRS>(sourceObj);
     if (!sourceCRS) {
         std::cerr << "source CRS string is not a CRS" << std::endl;
@@ -728,7 +735,7 @@ static void outputOperations(
     auto targetObj =
         buildObject(dbContext, targetCRSStr, "crs", "target CRS", false,
                     CoordinateOperationContext::IntermediateCRSUse::NEVER,
-                    promoteTo3D, outputOpt.quiet);
+                    promoteTo3D, normalizeAxisOrder, outputOpt.quiet);
     auto targetCRS = nn_dynamic_pointer_cast<CRS>(targetObj);
     if (!targetCRS) {
         std::cerr << "target CRS string is not a CRS" << std::endl;
@@ -862,6 +869,7 @@ int main(int argc, char **argv) {
     bool identify = false;
     bool showSuperseded = false;
     bool promoteTo3D = false;
+    bool normalizeAxisOrder = false;
     double minimumAccuracy = -1;
     bool outputAll = false;
     bool dumpDbStructure = false;
@@ -1143,6 +1151,9 @@ int main(int argc, char **argv) {
             outputOpt.ballparkAllowed = false;
         } else if (ci_equal(arg, "--3d")) {
             promoteTo3D = true;
+        } else if (ci_equal(arg, "--normalize-axis-order")) {
+            // Undocumented for now
+            normalizeAxisOrder = true;
         } else if (arg == "--output-id" && i + 1 < argc) {
             i++;
             const auto tokens = split(argv[i], ':');
@@ -1288,7 +1299,7 @@ int main(int argc, char **argv) {
             auto obj(buildObject(dbContext, user_string, objectKind,
                                  "input string", buildBoundCRSToWGS84,
                                  allowUseIntermediateCRS, promoteTo3D,
-                                 outputOpt.quiet));
+                                 normalizeAxisOrder, outputOpt.quiet));
             if (guessDialect) {
                 auto dialect = WKTParser().guessDialect(user_string);
                 std::cout << "Guessed WKT dialect: ";
@@ -1443,12 +1454,13 @@ int main(int argc, char **argv) {
         }
 
         try {
-            outputOperations(
-                dbContext, sourceCRSStr, targetCRSStr, bboxFilter,
-                spatialCriterion, spatialCriterionExplicitlySpecified,
-                crsExtentUse, gridAvailabilityUse, allowUseIntermediateCRS,
-                pivots, authority, usePROJGridAlternatives, showSuperseded,
-                promoteTo3D, minimumAccuracy, outputOpt, summary);
+            outputOperations(dbContext, sourceCRSStr, targetCRSStr, bboxFilter,
+                             spatialCriterion,
+                             spatialCriterionExplicitlySpecified, crsExtentUse,
+                             gridAvailabilityUse, allowUseIntermediateCRS,
+                             pivots, authority, usePROJGridAlternatives,
+                             showSuperseded, promoteTo3D, normalizeAxisOrder,
+                             minimumAccuracy, outputOpt, summary);
         } catch (const std::exception &e) {
             std::cerr << "outputOperations() failed with: " << e.what()
                       << std::endl;

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -135,6 +135,11 @@ echo "Testing -s EPSG:32631 -t EPSG:4326+3855 --3d --summary" >> ${OUT}
 $EXE -s EPSG:32631 -t EPSG:4326+3855 --3d --summary >>${OUT} 2>&1
 echo "" >>${OUT}
 
+# Undocumented option: --normalize-axis-order
+echo "Testing -s EPSG:4326 -t EPSG:32661 --normalize-axis-order -o PROJ -q --single-line" >> ${OUT}
+$EXE -s EPSG:4326 -t EPSG:32661 --normalize-axis-order -o PROJ -q --single-line >>${OUT} 2>&1
+echo "" >>${OUT}
+
 echo "Testing -s EPSG:4936 -t EPSG:4978 --spatial-test intersects --summary where WGS 84 to ETRS89 (2) uses a transformation method not supported by PROJ currently (time-specific Helmert), and thus must be sorted last" >> ${OUT}
 $EXE -s EPSG:4936 -t EPSG:4978 --spatial-test intersects --summary >>${OUT} 2>&1
 echo "" >>${OUT}

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1238,6 +1238,9 @@ unknown id, Inverse of UTM zone 31N + WGS 84 to EGM2008 height (1), 1 m, World.
 unknown id, Inverse of UTM zone 31N + WGS 84 to EGM2008 height (2), 0.5 m, World.
 unknown id, Inverse of UTM zone 31N + Inverse of Transformation from EGM2008 height to WGS 84 (ballpark vertical transformation, without ellipsoid height to vertical height correction), unknown accuracy, World, has ballpark transformation
 
+Testing -s EPSG:4326 -t EPSG:32661 --normalize-axis-order -o PROJ -q --single-line
++proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere +lat_0=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +ellps=WGS84
+
 Testing -s EPSG:4936 -t EPSG:4978 --spatial-test intersects --summary where WGS 84 to ETRS89 (2) uses a transformation method not supported by PROJ currently (time-specific Helmert), and thus must be sorted last
 Candidate operations found: 2
 unknown id, Ballpark geocentric translation from ETRS89 to WGS 84, unknown accuracy, World, has ballpark transformation

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -1002,6 +1002,10 @@ TEST(crs, EPSG_32661_projected_north_pole_north_east) {
     EXPECT_EQ(
         opNormalized->exportToPROJString(PROJStringFormatter::create().get()),
         proj_string_normalized);
+
+    EXPECT_EQ(opNormalized->sourceCRS()->domains().size(), 1U);
+    EXPECT_EQ(opNormalized->sourceCRS()->remarks(),
+              "Axis order reversed compared to EPSG:4326");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Only first commit to be backported in 8.0 branch