### PR TITLE
Add projinfo option --list-crs (supports --area)

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -294,7 +294,7 @@ The following control parameters can appear in any order:
     If no filter is provided all authority names and types of non deprecated CRSs are dumped.
     list-crs-filter is a comma separated combination of: allow_deprecated,geodetic,geocentric,
     geographic,geographic_2d,geographic_3d,vertical,projected,compound.
-    Affected by options :option:`--authority`, :option:`--area` and :option:`--bbox`
+    Affected by options :option:`--authority`, :option:`--area`, :option:`--bbox` and :option:`--spatial-test`
 
 .. option:: --3d
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -294,6 +294,7 @@ The following control parameters can appear in any order:
     If no filter is provided all authority names and types of non deprecated CRSs are dumped.
     list-crs-filter is a comma separated combination of: allow_deprecated,geodetic,geocentric,
     geographic,geographic_2d,geographic_3d,vertical,projected,compound.
+    Affected by options `--authority`, `--bbox`, `--main-db-path` and `--aux-db-path`    
 
 .. option:: --3d
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -292,9 +292,8 @@ The following control parameters can appear in any order:
 
     Outputs a list (authority name:code and CRS name) of the filtered CRSs from the database.
     If no filter is provided all authority names and types of non deprecated CRSs are dumped.
-    list-crs-filter is a comma separated combination of: auth_name=XXX,allow_deprecated,geodetic,geocentric,
-    geographic,geographic_2d,geographic_3d,vertical,protected,compound,temporal,engineering,bound,other
-    where XXX is the authority. When auth_name is provided multiple times, it is included for each one.
+    list-crs-filter is a comma separated combination of: allow_deprecated,geodetic,geocentric,
+    geographic,geographic_2d,geographic_3d,vertical,projected,compound.
 
 .. option:: --3d
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -294,7 +294,7 @@ The following control parameters can appear in any order:
     If no filter is provided all authority names and types of non deprecated CRSs are dumped.
     list-crs-filter is a comma separated combination of: allow_deprecated,geodetic,geocentric,
     geographic,geographic_2d,geographic_3d,vertical,projected,compound.
-    Affected by options `--authority`, `--bbox`, `--main-db-path` and `--aux-db-path`    
+    Affected by options :option:`--authority`, :option:`--area` and :option:`--bbox`
 
 .. option:: --3d
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -58,9 +58,6 @@ Synopsis
     - a PROJJSON string. The jsonschema is at https://proj.org/schemas/v0.2/projjson.schema.json (*added in 6.2*)
     - a compound CRS made from two object names separated with " + ". e.g. "WGS 84 + EGM96 height" (*added in 7.1*)
 
-    [list-crs-filter] is a comma separated combination of: auth_name=XXX,allow_deprecated,geodetic,geocentric,
-    geographic,geographic_2d,geographic_3d,vertical,protected,compound,temporal,engineering,bound,other
-
     {object_reference} is a filename preceded by the '@' character.  The
     file referenced by the {object_reference} must contain a valid
     {object_definition}.

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -32,6 +32,7 @@ Synopsis
     |    [--output-id AUTH:CODE]
     |    [--c-ify] [--single-line]
     |    --searchpaths | --remote-data |
+    |    --list-crs [list-crs-filter] |
     |    --dump-db-structure [{object_definition} | {object_reference}] |
     |    {object_definition} | {object_reference} | (-s {srs_def} -t {srs_def})
     |
@@ -56,6 +57,9 @@ Synopsis
       (e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618")
     - a PROJJSON string. The jsonschema is at https://proj.org/schemas/v0.2/projjson.schema.json (*added in 6.2*)
     - a compound CRS made from two object names separated with " + ". e.g. "WGS 84 + EGM96 height" (*added in 7.1*)
+
+    [list-crs-filter] is a comma separated combination of: auth_name=XXX,allow_deprecated,geodetic,geocentric,
+    geographic,geographic_2d,geographic_3d,vertical,protected,compound,temporal,engineering,bound,other
 
     {object_reference} is a filename preceded by the '@' character.  The
     file referenced by the {object_reference} must contain a valid
@@ -284,6 +288,16 @@ The following control parameters can appear in any order:
     database. This option can be specified as the only switch of the utility.
     If also specifying a CRS object and the :option:`--output-id` option, the
     definition of the object as SQL statements will be appended.
+
+.. option:: --list-crs [list-crs-filter]
+
+    .. versionadded:: 8.1
+
+    Outputs a list (authority name:code and CRS name) of the filtered CRSs from the database.
+    If no filter is provided all authority names and types of non deprecated CRSs are dumped.
+    list-crs-filter is a comma separated combination of: auth_name=XXX,allow_deprecated,geodetic,geocentric,
+    geographic,geographic_2d,geographic_3d,vertical,protected,compound,temporal,engineering,bound,other
+    where XXX is the authority. When auth_name is provided multiple times, it is included for each one.
 
 .. option:: --3d
 

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -1304,6 +1304,10 @@ int main(int argc, char **argv) {
                 types.push_back(PJ_TYPE_BOUND_CRS);
             } else if (ci_equal(token, "other")) {
                 types.push_back(PJ_TYPE_OTHER_CRS);
+            } else {
+                std::cerr << "Unrecognized value for option --list-crs: " << token
+                          << std::endl;
+                usage();
             }
         }
 

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -847,6 +847,7 @@ int main(int argc, char **argv) {
     std::string objectKind;
     bool summary = false;
     ExtentPtr bboxFilter = nullptr;
+    std::vector<double> bboxValues;
     std::string area;
     bool spatialCriterionExplicitlySpecified = false;
     CoordinateOperationContext::SpatialCriterion spatialCriterion =
@@ -986,9 +987,10 @@ int main(int argc, char **argv) {
                 usage();
             }
             try {
+                bboxValues = {c_locale_stod(bbox[0]), c_locale_stod(bbox[1]),
+                              c_locale_stod(bbox[2]), c_locale_stod(bbox[3])};
                 bboxFilter = Extent::createFromBBOX(
-                                 c_locale_stod(bbox[0]), c_locale_stod(bbox[1]),
-                                 c_locale_stod(bbox[2]), c_locale_stod(bbox[3]))
+                                 bboxValues[0], bboxValues[1], bboxValues[2], bboxValues[3])
                                  .as_nullable();
             } catch (const std::exception &e) {
                 std::cerr << "Invalid value for option --bbox: " << bboxStr
@@ -1300,6 +1302,15 @@ int main(int argc, char **argv) {
         }
         params->typesCount = types.size();
         params->types = types.data();
+
+        if (bboxValues.size() == 4) {
+            params->bbox_valid = true;
+            params->crs_area_of_use_contains_bbox = false;
+            params->west_lon_degree = bboxValues[0];
+            params->south_lat_degree = bboxValues[1];
+            params->east_lon_degree = bboxValues[2];
+            params->north_lat_degree = bboxValues[3];
+        }
 
         PJ_CONTEXT* ctx = proj_context_create();
         std::vector<const char*> auxPaths;

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -322,8 +322,24 @@ echo 'Testing --list-crs | grep deprecated | sort' >> ${OUT}
 $EXE --list-crs | grep deprecated | sort >> ${OUT}
 echo "" >>${OUT}
 
-echo 'Testing --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort' >> ${OUT}
-$EXE --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort >> ${OUT}
+echo 'Testing --list-crs vertical --bbox 0,40,1,41 --spatial-test intersects | grep "Alicante\|NAVD88" | sort' >> ${OUT}
+$EXE --list-crs vertical --bbox 0,40,1,41 --spatial-test intersects | grep "Alicante\|NAVD88" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs vertical --bbox -10,35,5,45 --spatial-test contains | grep "Alicante\|NAVD88" | sort' >> ${OUT}
+$EXE --list-crs vertical --bbox -10,35,5,45 --spatial-test contains | grep "Alicante\|NAVD88" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs --area Spain --spatial-test intersects | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort' >> ${OUT}
+$EXE --list-crs --area Spain --spatial-test intersects | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs --area Spain --spatial-test contains | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort' >> ${OUT}
+$EXE --list-crs --area Spain --spatial-test contains | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs --area Spain | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort' >> ${OUT}
+$EXE --list-crs --area Spain | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort >> ${OUT}
 echo "" >>${OUT}
 
 echo 'Testing --list-crs geodetic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort' >> ${OUT}
@@ -338,12 +354,12 @@ echo 'Testing --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|
 $EXE --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort >> ${OUT}
 echo "" >>${OUT}
 
-echo 'Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort' >> ${OUT}
-$EXE --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort >> ${OUT}
+echo 'Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 --spatial-test intersects | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort' >> ${OUT}
+$EXE --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 --spatial-test intersects | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort >> ${OUT}
 echo "" >>${OUT}
 
-echo 'Testing --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort' >> ${OUT}
-$EXE --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort >> ${OUT}
+echo 'Testing --list-crs projected --bbox -100,40,-90,41 --spatial-test intersects | grep "(2011).*Missouri East\|York" | sort' >> ${OUT}
+$EXE --list-crs projected --bbox -100,40,-90,41 --spatial-test intersects | grep "(2011).*Missouri East\|York" | sort >> ${OUT}
 echo "" >>${OUT}
 
 # do 'diff' with distribution results

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -310,6 +310,42 @@ echo 'Checks that ED50 to ETRS89 (12) is in the output (superseded transformatio
 $EXE -s EPSG:23030 -t EPSG:25830 --bbox -6,40,-5,41 --grid-check known_available --hide-ballpark --summary >>${OUT} 2>&1
 echo "" >>${OUT}
 
+echo 'Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort' >> ${OUT}
+$EXE --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort' >> ${OUT}
+$EXE --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs | grep deprecated | sort' >> ${OUT}
+$EXE --list-crs | grep deprecated | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort' >> ${OUT}
+$EXE --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs geodetic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort' >> ${OUT}
+$EXE --list-crs geodetic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs geographic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort' >> ${OUT}
+$EXE --list-crs geographic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort' >> ${OUT}
+$EXE --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort' >> ${OUT}
+$EXE --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort >> ${OUT}
+echo "" >>${OUT}
+
+echo 'Testing --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort' >> ${OUT}
+$EXE --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort >> ${OUT}
+echo "" >>${OUT}
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testprojinfo_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testprojinfo_out.dist

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1600,3 +1600,41 @@ Candidate operations found: 2
 unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (12) + UTM zone 30N, 0.2 m, Spain - mainland, Balearic Islands, Ceuta and Melila - onshore.
 unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (7) + UTM zone 30N, 1.5 m, Spain - onshore mainland except northwest (north of 41°30'N and west of 4°30'W).
 
+Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort
+EPSG:32632 "WGS 84 / UTM zone 32N"
+ESRI:103668 "NAD_1983_HARN_Adj_MN_Ramsey_Meters"
+OGC:CRS27 "NAD27 (CRS27)"
+OGC:CRS83 "NAD83 (CRS83)"
+OGC:CRS84 "WGS 84 (CRS84)"
+
+Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort
+EPSG:4326 "WGS 84"
+OGC:CRS27 "NAD27 (CRS27)"
+OGC:CRS83 "NAD83 (CRS83)"
+OGC:CRS84 "WGS 84 (CRS84)"
+
+Testing --list-crs | grep deprecated | sort
+
+Testing --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort
+EPSG:5782 "Alicante height"
+
+Testing --list-crs geodetic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort
+EPSG:4326 "WGS 84"
+EPSG:4978 "WGS 84"
+EPSG:4979 "WGS 84"
+
+Testing --list-crs geographic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort
+EPSG:4326 "WGS 84"
+EPSG:4979 "WGS 84"
+
+Testing --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort
+EPSG:4978 "WGS 84"
+EPSG:4979 "WGS 84"
+
+Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort
+EPSG:8449 "NAD83(FBN)" [deprecated]
+ESRI:104010 "GCS_IGS08" [deprecated]
+
+Testing --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort
+EPSG:6512 "NAD83(2011) / Missouri East"
+

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1615,8 +1615,24 @@ OGC:CRS84 "WGS 84 (CRS84)"
 
 Testing --list-crs | grep deprecated | sort
 
-Testing --list-crs vertical --bbox 0,40,1,41 | grep "Alicante\|NAVD88" | sort
+Testing --list-crs vertical --bbox 0,40,1,41 --spatial-test intersects | grep "Alicante\|NAVD88" | sort
 EPSG:5782 "Alicante height"
+
+Testing --list-crs vertical --bbox -10,35,5,45 --spatial-test contains | grep "Alicante\|NAVD88" | sort
+EPSG:5782 "Alicante height"
+
+Testing --list-crs --area Spain --spatial-test intersects | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort
+EPSG:4258 "ETRS89"
+EPSG:9398 "Tenerife height"
+EPSG:9505 "ETRS89 + Alicante height"
+
+Testing --list-crs --area Spain --spatial-test contains | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort
+EPSG:9398 "Tenerife height"
+EPSG:9505 "ETRS89 + Alicante height"
+
+Testing --list-crs --area Spain | grep "EPSG:9505\|EPSG:9398\|EPSG:4258\|EPSG:5703" | sort
+EPSG:9398 "Tenerife height"
+EPSG:9505 "ETRS89 + Alicante height"
 
 Testing --list-crs geodetic | grep "EPSG:4326\|EPSG:4979\|EPSG:4978" | sort
 EPSG:4326 "WGS 84"
@@ -1631,10 +1647,10 @@ Testing --list-crs geocentric,geographic_3d | grep "EPSG:4326\|EPSG:4979\|EPSG:4
 EPSG:4978 "WGS 84"
 EPSG:4979 "WGS 84"
 
-Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort
+Testing --list-crs geographic_2d,allow_deprecated --bbox -100,40,-90,41 --spatial-test intersects | grep deprecated | grep "NAD83(FBN)\|GCS_IGS08" | sort
 EPSG:8449 "NAD83(FBN)" [deprecated]
 ESRI:104010 "GCS_IGS08" [deprecated]
 
-Testing --list-crs projected --bbox -100,40,-90,41 | grep "(2011).*Missouri East\|York" | sort
+Testing --list-crs projected --bbox -100,40,-90,41 --spatial-test intersects | grep "(2011).*Missouri East\|York" | sort
 EPSG:6512 "NAD83(2011) / Missouri East"
 


### PR DESCRIPTION
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API

Variation of #2655. (Same behavior, different implementation).

It also uses the option `--area`. For that it creates an `Extent` from `--bbox` or `--area` (in the same way as other parts of `projinfo`. New function `makeBboxFilter` for that purpose) and intersects every CRS listed. The behavior is driven by `--spatial-test`

It does not use the C API, but directly the C++ function `getCRSInfoList()`.