### PR TITLE
projinfo --list-crs --area: make it work when multiple areas matches the specified name

### DIFF
--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -362,6 +362,11 @@ echo 'Testing --list-crs projected --bbox -100,40,-90,41 --spatial-test intersec
 $EXE --list-crs projected --bbox -100,40,-90,41 --spatial-test intersects | grep "(2011).*Missouri East\|York" | sort >> ${OUT}
 echo "" >>${OUT}
 
+# Test case where --area has several matches
+echo 'Testing --list-crs projected --area France | grep "RGF93 / Lambert-93\|UTM zone 11N" | sort' >> ${OUT}
+$EXE --list-crs projected --area France | grep "RGF93 / Lambert-93\|UTM zone 11N" | sort >> ${OUT}
+echo "" >>${OUT}
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testprojinfo_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testprojinfo_out.dist

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1654,3 +1654,6 @@ ESRI:104010 "GCS_IGS08" [deprecated]
 Testing --list-crs projected --bbox -100,40,-90,41 --spatial-test intersects | grep "(2011).*Missouri East\|York" | sort
 EPSG:6512 "NAD83(2011) / Missouri East"
 
+Testing --list-crs projected --area France | grep "RGF93 / Lambert-93\|UTM zone 11N" | sort
+EPSG:2154 "RGF93 / Lambert-93"
+


### PR DESCRIPTION
"France" was for example ambiguous. When there are several areas that match the area name, do the CRS filtering at hand by only keeping those whose area name contains the specified name.

CC @jjimenezshaw 