### PR TITLE
Parse compound id with two authorities, like ESRI:103668+EPSG:5703

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -6438,31 +6438,15 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
             const auto &authName2 = tokensCenter[1];
             const auto &code2 = tokens[2];
 
-            crs::CRSPtr crs1 = nullptr;
-            crs::CRSPtr crs2 = nullptr;
-
-            const auto authorities = dbContextNNPtr->getAuthorities();
-            for (const auto &authCandidate : authorities) {
-                if (ci_equal(authCandidate, authName1)) {
-                    auto factory =
-                        AuthorityFactory::create(dbContextNNPtr, authCandidate);
-                    crs1 =
-                        factory->createCoordinateReferenceSystem(code1, false);
-                }
-                if (ci_equal(authCandidate, authName2)) {
-                    auto factory =
-                        AuthorityFactory::create(dbContextNNPtr, authCandidate);
-                    crs2 =
-                        factory->createCoordinateReferenceSystem(code2, false);
-                }
-            }
-            if (crs1 && crs2) {
-                return CompoundCRS::createLax(
-                    util::PropertyMap().set(IdentifiedObject::NAME_KEY,
-                                            crs1->nameStr() + " + " +
-                                                crs2->nameStr()),
-                    {NN_NO_CHECK(crs1), NN_NO_CHECK(crs2)}, dbContext);
-            }
+            auto factory1 = AuthorityFactory::create(dbContextNNPtr, authName1);
+            auto crs1 = factory1->createCoordinateReferenceSystem(code1, false);
+            auto factory2 = AuthorityFactory::create(dbContextNNPtr, authName2);
+            auto crs2 = factory2->createCoordinateReferenceSystem(code2, false);
+            return CompoundCRS::createLax(
+                util::PropertyMap().set(IdentifiedObject::NAME_KEY,
+                                        crs1->nameStr() + " + " +
+                                            crs2->nameStr()),
+                {crs1, crs2}, dbContext);
         }
     }
 

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -6827,6 +6827,7 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
  * <li> OGC URN combining references for compound coordinate reference systems
  *      e.g. "urn:ogc:def:crs,crs:EPSG::2393,crs:EPSG::5717"
  *      We also accept a custom abbreviated syntax EPSG:2393+5717
+ *      or ESRI:103668+EPSG:5703
  * </li>
  * <li> OGC URN combining references for references for projected or derived
  * CRSs

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -10307,6 +10307,8 @@ TEST(io, createFromUserInput) {
     EXPECT_THROW(createFromUserInput("+proj=unhandled +type=crs", nullptr),
                  ParsingException);
     EXPECT_THROW(createFromUserInput("EPSG:4326", nullptr), ParsingException);
+    EXPECT_THROW(createFromUserInput("ESRI:103668+EPSG:5703", nullptr),
+                 ParsingException);
     EXPECT_THROW(
         createFromUserInput("urn:ogc:def:unhandled:EPSG::4326", dbContext),
         ParsingException);
@@ -10386,6 +10388,26 @@ TEST(io, createFromUserInput) {
         EXPECT_EQ(crs->nameStr(),
                   "KKJ / Finland Uniform Coordinate System + N60 height");
     }
+
+    {
+        auto obj = createFromUserInput("EPSG:2393+EPSG:5717", dbContext);
+        auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(),
+                  "KKJ / Finland Uniform Coordinate System + N60 height");
+    }
+    {
+        auto obj = createFromUserInput("ESRI:103668+EPSG:5703", dbContext);
+        auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(),
+                  "NAD_1983_HARN_Adj_MN_Ramsey_Meters + NAVD88 height");
+    }
+    EXPECT_THROW(createFromUserInput("ESRI:42+EPSG:5703", dbContext),
+                 NoSuchAuthorityCodeException);
+    EXPECT_THROW(createFromUserInput("ESRI:103668+EPSG:999999", dbContext),
+                 NoSuchAuthorityCodeException);
+
     {
         auto obj = createFromUserInput(
             "urn:ogc:def:crs,crs:EPSG::2393,crs:EPSG::5717", dbContext);


### PR DESCRIPTION
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes

Following the suggestion here, https://lists.osgeo.org/pipermail/proj/2021-April/010166.html
this PR parses an identifier that combines two authorities.

Useful to add NAVD88 to many ESRI crs not defined in EPSG.