### PR TITLE
Revert "proj_create_crs_to_crs_from_pj(): do not use PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION if area is specified"

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1358,11 +1358,9 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
                                             area->east_lon_degree,
                                             area->north_lat_degree);
     }
-    else {
-        proj_operation_factory_context_set_spatial_criterion(
-            ctx, operation_ctx, PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION);
-    }
 
+    proj_operation_factory_context_set_spatial_criterion(
+        ctx, operation_ctx, PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION);
     proj_operation_factory_context_set_grid_availability_use(
         ctx, operation_ctx,
         proj_context_is_network_enabled(ctx) ?

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -804,6 +804,30 @@ TEST(gie, proj_create_crs_to_crs_outside_area_of_use) {
 
 // ---------------------------------------------------------------------------
 
+TEST(gie, proj_create_crs_to_crs_with_area_large) {
+
+    // Test bugfix for https://github.com/OSGeo/gdal/issues/3695
+    auto area = proj_area_create();
+    proj_area_set_bbox(area, -14.1324, 49.5614, 3.76488, 62.1463);
+    auto P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, "EPSG:4277", "EPSG:4326",
+                                    area);
+    proj_area_destroy(area);
+    ASSERT_TRUE(P != nullptr);
+    PJ_COORD c;
+
+    c.xyzt.x = 50; // Lat in deg
+    c.xyzt.y = -2;  // Long in deg
+    c.xyzt.z = 0;
+    c.xyzt.t = HUGE_VAL;
+    c = proj_trans(P, PJ_FWD, c);
+    EXPECT_NEAR(c.xy.x, 50.00065628, 1e-8);
+    EXPECT_NEAR(c.xy.y, -2.00133989, 1e-8);
+
+    proj_destroy(P);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(gie, proj_trans_generic) {
     // GDA2020 to WGS84 (G1762)
     auto P = proj_create(


### PR DESCRIPTION
This reverts commit ebe3425bf66287e004958eb53976d3837f88b9e1.

It was found to break gdalwarp usage in
https://github.com/OSGeo/gdal/issues/3695 when passing a bbox that is
quite large.
