### PR TITLE
run reformat_cpp.sh to fix some leftovers

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -2676,8 +2676,9 @@ PROJ_STRING_LIST proj_get_codes_from_database(PJ_CONTEXT *ctx,
 
 /** \brief Enumerate celestial bodies from the database.
  *
- * The returned object is an array of PROJ_CELESTIAL_BODY_INFO* pointers, whose last
- * entry is NULL. This array should be freed with proj_celestial_body_list_destroy()
+ * The returned object is an array of PROJ_CELESTIAL_BODY_INFO* pointers, whose
+ * last entry is NULL. This array should be freed with
+ * proj_celestial_body_list_destroy()
  *
  * @param ctx PROJ context, or NULL for default context
  * @param auth_name Authority name, used to restrict the search.
@@ -2688,9 +2689,8 @@ PROJ_STRING_LIST proj_get_codes_from_database(PJ_CONTEXT *ctx,
  * proj_celestial_body_list_destroy(), or NULL in case of error.
  * @since 8.1
  */
-PROJ_CELESTIAL_BODY_INFO **proj_get_celestial_body_list_from_database(PJ_CONTEXT *ctx,
-                                              const char *auth_name,
-                                              int *out_result_count) {
+PROJ_CELESTIAL_BODY_INFO **proj_get_celestial_body_list_from_database(
+    PJ_CONTEXT *ctx, const char *auth_name, int *out_result_count) {
     SANITIZE_CTX(ctx);
     PROJ_CELESTIAL_BODY_INFO **ret = nullptr;
     int i = 0;
@@ -2740,7 +2740,6 @@ void proj_celestial_body_list_destroy(PROJ_CELESTIAL_BODY_INFO **list) {
         delete[] list;
     }
 }
-
 
 // ---------------------------------------------------------------------------
 

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -7478,13 +7478,11 @@ AuthorityFactory::UnitInfo::UnitInfo()
       deprecated{} {}
 //! @endcond
 
-
 // ---------------------------------------------------------------------------
 
 //! @cond Doxygen_Suppress
 AuthorityFactory::CelestialBodyInfo::CelestialBodyInfo() : authName{}, name{} {}
 //! @endcond
-
 
 // ---------------------------------------------------------------------------
 
@@ -7563,7 +7561,6 @@ AuthorityFactory::getCelestialBodyList() const {
     }
     return res;
 }
-
 
 // ---------------------------------------------------------------------------
 

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -809,14 +809,14 @@ TEST(gie, proj_create_crs_to_crs_with_area_large) {
     // Test bugfix for https://github.com/OSGeo/gdal/issues/3695
     auto area = proj_area_create();
     proj_area_set_bbox(area, -14.1324, 49.5614, 3.76488, 62.1463);
-    auto P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, "EPSG:4277", "EPSG:4326",
-                                    area);
+    auto P =
+        proj_create_crs_to_crs(PJ_DEFAULT_CTX, "EPSG:4277", "EPSG:4326", area);
     proj_area_destroy(area);
     ASSERT_TRUE(P != nullptr);
     PJ_COORD c;
 
     c.xyzt.x = 50; // Lat in deg
-    c.xyzt.y = -2;  // Long in deg
+    c.xyzt.y = -2; // Long in deg
     c.xyzt.z = 0;
     c.xyzt.t = HUGE_VAL;
     c = proj_trans(P, PJ_FWD, c);

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -3903,7 +3903,8 @@ TEST_F(CApi, proj_get_celestial_body_list_from_database) {
     { proj_celestial_body_list_destroy(nullptr); }
 
     {
-        auto list = proj_get_celestial_body_list_from_database(nullptr, nullptr, 0);
+        auto list =
+            proj_get_celestial_body_list_from_database(nullptr, nullptr, 0);
         ASSERT_NE(list, nullptr);
         ASSERT_NE(list[0], nullptr);
         ASSERT_NE(list[0]->auth_name, nullptr);
@@ -3912,7 +3913,8 @@ TEST_F(CApi, proj_get_celestial_body_list_from_database) {
     }
     {
         int result_count = 0;
-        auto list = proj_get_celestial_body_list_from_database(nullptr, "ESRI", &result_count);
+        auto list = proj_get_celestial_body_list_from_database(nullptr, "ESRI",
+                                                               &result_count);
         ASSERT_NE(list, nullptr);
         EXPECT_GT(result_count, 1);
         EXPECT_EQ(list[result_count], nullptr);


### PR DESCRIPTION
Editing the code, clang-format was changing other parts of the file. Looks like clang-format was not run the last time.
This PR is only the result of running `reformat_cpp.sh`