### PR TITLE
Get geoid models for a CRS code

### DIFF
--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -1000,6 +1000,9 @@ class PROJ_GCC_DLL AuthorityFactory {
         const std::string &sourceCRSCode,
         const std::string &targetCRSCode) const;
 
+    PROJ_DLL std::list<std::string>
+    getAvailableGeoidmodels(const std::string &code) const;
+
     PROJ_DLL const std::string &getAuthority() PROJ_PURE_DECL;
 
     /** Object type. */

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -1001,7 +1001,7 @@ class PROJ_GCC_DLL AuthorityFactory {
         const std::string &targetCRSCode) const;
 
     PROJ_DLL std::list<std::string>
-    getAvailableGeoidmodels(const std::string &code) const;
+    getGeoidModels(const std::string &code) const;
 
     PROJ_DLL const std::string &getAuthority() PROJ_PURE_DECL;
 

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -971,6 +971,7 @@ proj_get_crs_info_list_from_database
 proj_get_crs_list_parameters_create
 proj_get_crs_list_parameters_destroy
 proj_get_ellipsoid
+proj_get_geoid_models_from_database
 proj_get_id_auth_name
 proj_get_id_code
 proj_get_insert_statements

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -347,10 +347,10 @@ osgeo::proj::io::AuthorityFactory::CRSInfo::CRSInfo()
 osgeo::proj::io::AuthorityFactory::databaseContext() const
 osgeo::proj::io::AuthorityFactory::getAuthorityCodes(osgeo::proj::io::AuthorityFactory::ObjectType const&, bool) const
 osgeo::proj::io::AuthorityFactory::getAuthority() const
-osgeo::proj::io::AuthorityFactory::getAvailableGeoidmodels(std::string const&) const
 osgeo::proj::io::AuthorityFactory::getCelestialBodyList() const
 osgeo::proj::io::AuthorityFactory::getCRSInfoList() const
 osgeo::proj::io::AuthorityFactory::getDescriptionText(std::string const&) const
+osgeo::proj::io::AuthorityFactory::getGeoidModels(std::string const&) const
 osgeo::proj::io::AuthorityFactory::getOfficialNameFromAlias(std::string const&, std::string const&, std::string const&, bool, std::string&, std::string&, std::string&) const
 osgeo::proj::io::AuthorityFactory::getUnitList() const
 osgeo::proj::io::AuthorityFactory::identifyBodyFromSemiMajorAxis(double, double) const

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -347,6 +347,7 @@ osgeo::proj::io::AuthorityFactory::CRSInfo::CRSInfo()
 osgeo::proj::io::AuthorityFactory::databaseContext() const
 osgeo::proj::io::AuthorityFactory::getAuthorityCodes(osgeo::proj::io::AuthorityFactory::ObjectType const&, bool) const
 osgeo::proj::io::AuthorityFactory::getAuthority() const
+osgeo::proj::io::AuthorityFactory::getAvailableGeoidmodels(std::string const&) const
 osgeo::proj::io::AuthorityFactory::getCelestialBodyList() const
 osgeo::proj::io::AuthorityFactory::getCRSInfoList() const
 osgeo::proj::io::AuthorityFactory::getDescriptionText(std::string const&) const

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5764,6 +5764,62 @@ AuthorityFactory::createFromCoordinateReferenceSystemCodes(
 
 // ---------------------------------------------------------------------------
 
+/** \brief Returns a list of geoid models available for that crs
+ *
+ * The list includes the geoid models connected directly with the crs,
+ * or via "Height Depth Reversal" or "Change of Vertical Unit" transformations
+ *
+ * @param code crs code allocated by authority.
+ * @return list of geoid model names
+ * @throw FactoryException
+ */
+std::list<std::string>
+AuthorityFactory::getAvailableGeoidmodels(const std::string &code) const {
+    /// The second part of the query is for CRSs that use that geoid model via
+    /// Height Depth Reversal (EPSG:1068) or Change of Vertical Unit (EPSG:1069)
+    ListOfParams params;
+    std::string sql = "SELECT DISTINCT GM0.name "
+                      " FROM geoid_model GM0 "
+                      "INNER JOIN grid_transformation GT0 "
+                      " ON  GT0.code = GM0.operation_code "
+                      " AND GT0.auth_name = GM0.operation_auth_name "
+                      " AND GT0.target_crs_code = ? ";
+    params.emplace_back(code);
+    if (d->hasAuthorityRestriction()) {
+        sql += " AND GT0.target_crs_auth_name = ? ";
+        params.emplace_back(d->authority());
+    }
+
+    sql += "UNION "
+           "SELECT DISTINCT GM0.name "
+           " FROM geoid_model GM0 "
+           "INNER JOIN grid_transformation GT1 "
+           " ON  GT1.code = GM0.operation_code "
+           " AND GT1.auth_name = GM0.operation_auth_name "
+           "INNER JOIN other_transformation OT1 "
+           " ON  OT1.source_crs_code = GT1.target_crs_code "
+           " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
+           " AND OT1.method_auth_name = \"EPSG\" "
+           " AND OT1.method_code IN (1068, 1069) "
+           " AND OT1.target_crs_code = ? ";
+
+    params.emplace_back(code);
+    if (d->hasAuthorityRestriction()) {
+        sql += " AND OT1.target_crs_auth_name = ? ";
+        params.emplace_back(d->authority());
+    }
+    sql += " ORDER BY 1 ";
+
+    auto sqlRes = d->run(sql, params);
+    std::list<std::string> res;
+    for (const auto &row : sqlRes) {
+        res.push_back(row[0]);
+    }
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+
 /** \brief Returns a list operation::CoordinateOperation between two CRS.
  *
  * The list is ordered with preferred operations first. No attempt is made

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5775,22 +5775,24 @@ AuthorityFactory::createFromCoordinateReferenceSystemCodes(
  */
 
 std::list<std::string>
-AuthorityFactory::getAvailableGeoidmodels(const std::string &code) const {
-    /// The second part of the query is for CRSs that use that geoid model via
-    /// Height Depth Reversal (EPSG:1068) or Change of Vertical Unit (EPSG:1069)
+AuthorityFactory::getGeoidModels(const std::string &code) const {
+
     ListOfParams params;
-    std::string sql = "SELECT DISTINCT GM0.name "
-                      " FROM geoid_model GM0 "
-                      "INNER JOIN grid_transformation GT0 "
-                      " ON  GT0.code = GM0.operation_code "
-                      " AND GT0.auth_name = GM0.operation_auth_name "
-                      " AND GT0.target_crs_code = ? ";
+    std::string sql;
+    sql += "SELECT DISTINCT GM0.name "
+           " FROM geoid_model GM0 "
+           "INNER JOIN grid_transformation GT0 "
+           " ON  GT0.code = GM0.operation_code "
+           " AND GT0.auth_name = GM0.operation_auth_name "
+           " AND GT0.target_crs_code = ? ";
     params.emplace_back(code);
     if (d->hasAuthorityRestriction()) {
         sql += " AND GT0.target_crs_auth_name = ? ";
         params.emplace_back(d->authority());
     }
 
+    /// The second part of the query is for CRSs that use that geoid model via
+    /// Height Depth Reversal (EPSG:1068) or Change of Vertical Unit (EPSG:1069)
     sql += "UNION "
            "SELECT DISTINCT GM0.name "
            " FROM geoid_model GM0 "
@@ -5803,7 +5805,6 @@ AuthorityFactory::getAvailableGeoidmodels(const std::string &code) const {
            " AND OT1.method_auth_name = 'EPSG' "
            " AND OT1.method_code IN (1068, 1069) "
            " AND OT1.target_crs_code = ? ";
-
     params.emplace_back(code);
     if (d->hasAuthorityRestriction()) {
         sql += " AND OT1.target_crs_auth_name = ? ";

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5773,6 +5773,7 @@ AuthorityFactory::createFromCoordinateReferenceSystemCodes(
  * @return list of geoid model names
  * @throw FactoryException
  */
+
 std::list<std::string>
 AuthorityFactory::getAvailableGeoidmodels(const std::string &code) const {
     /// The second part of the query is for CRSs that use that geoid model via
@@ -5799,7 +5800,7 @@ AuthorityFactory::getAvailableGeoidmodels(const std::string &code) const {
            "INNER JOIN other_transformation OT1 "
            " ON  OT1.source_crs_code = GT1.target_crs_code "
            " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
-           " AND OT1.method_auth_name = \"EPSG\" "
+           " AND OT1.method_auth_name = 'EPSG' "
            " AND OT1.method_code IN (1068, 1069) "
            " AND OT1.target_crs_code = ? ";
 

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5803,7 +5803,7 @@ AuthorityFactory::getGeoidModels(const std::string &code) const {
            " ON  OT1.source_crs_code = GT1.target_crs_code "
            " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
            " AND OT1.method_auth_name = 'EPSG' "
-           " AND OT1.method_code IN (1068, 1069) "
+           " AND OT1.method_code IN (1068, 1069, 1104) "
            " AND OT1.target_crs_code = ? ";
     params.emplace_back(code);
     if (d->hasAuthorityRestriction()) {
@@ -5823,11 +5823,11 @@ AuthorityFactory::getGeoidModels(const std::string &code) const {
            " ON  OT1.source_crs_code = GT1.target_crs_code "
            " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
            " AND OT1.method_auth_name = 'EPSG' "
-           " AND OT1.method_code IN (1068, 1069) "
+           " AND OT1.method_code IN (1068, 1069, 1104) "
            "INNER JOIN other_transformation OT2 "
            " ON  OT2.source_crs_code = OT1.target_crs_code "
            " AND OT2.source_crs_auth_name = OT1.target_crs_auth_name "
-           " AND OT2.method_code IN (1068, 1069) "
+           " AND OT2.method_code IN (1068, 1069, 1104) "
            " AND OT2.target_crs_code = ? ";
     params.emplace_back(code);
     if (d->hasAuthorityRestriction()) {

--- a/src/proj.h
+++ b/src/proj.h
@@ -1188,6 +1188,12 @@ PJ_OBJ_LIST PROJ_DLL *proj_identify(PJ_CONTEXT *ctx,
                                         const char* const *options,
                                         int **out_confidence);
 
+PROJ_STRING_LIST PROJ_DLL proj_get_geoid_models_from_database(
+                               PJ_CONTEXT *ctx,
+                               const char *auth_name,
+                               const char *code,
+                               const char *const *options);
+
 void PROJ_DLL proj_int_list_destroy(int* list);
 
 /* ------------------------------------------------------------------------- */

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -5622,11 +5622,6 @@ TEST_F(CApi, proj_get_insert_statements) {
 // ---------------------------------------------------------------------------
 
 TEST_F(CApi, proj_get_geoid_models_from_database) {
-
-    const std::string GEOID12B{"GEOID12B"};
-    const std::string GEOID18{"GEOID18"};
-    const std::string OSGM15{"OSGM15"};
-
     auto findInList = [](PROJ_STRING_LIST list, const std::string &ref) {
         while (list && *list) {
             if (std::string(*list) == ref) {
@@ -5637,47 +5632,12 @@ TEST_F(CApi, proj_get_geoid_models_from_database) {
         return false;
     };
 
-    {
-        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "4326",
-                                                        nullptr);
-        ListFreer freer(list);
-        ASSERT_NE(list, nullptr);
-        EXPECT_EQ(list[0], nullptr);
-    }
-
-    {
-        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "5703",
-                                                        nullptr);
-        ListFreer freer(list);
-        EXPECT_TRUE(findInList(list, GEOID12B));
-        EXPECT_TRUE(findInList(list, GEOID18));
-        EXPECT_FALSE(findInList(list, OSGM15));
-    }
-    {
-        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "8228",
-                                                        nullptr);
-        ListFreer freer(list);
-        EXPECT_TRUE(findInList(list, GEOID12B));
-        EXPECT_TRUE(findInList(list, GEOID18));
-        EXPECT_FALSE(findInList(list, OSGM15));
-    }
-    {
-        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "6358",
-                                                        nullptr);
-        ListFreer freer(list);
-        EXPECT_TRUE(findInList(list, GEOID12B));
-        EXPECT_TRUE(findInList(list, GEOID18));
-        EXPECT_FALSE(findInList(list, OSGM15));
-    }
-
-    {
-        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "5701",
-                                                        nullptr);
-        ListFreer freer(list);
-        EXPECT_FALSE(findInList(list, GEOID12B));
-        EXPECT_FALSE(findInList(list, GEOID18));
-        EXPECT_TRUE(findInList(list, OSGM15));
-    }
+    auto list =
+        proj_get_geoid_models_from_database(m_ctxt, "EPSG", "5703", nullptr);
+    ListFreer freer(list);
+    EXPECT_TRUE(findInList(list, "GEOID12B"));
+    EXPECT_TRUE(findInList(list, "GEOID18"));
+    EXPECT_FALSE(findInList(list, "OSGM15"));
 }
 
 } // namespace

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -5619,5 +5619,65 @@ TEST_F(CApi, proj_get_insert_statements) {
         proj_insert_object_session_destroy(m_ctxt, session);
     }
 }
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_get_geoid_models_from_database) {
+
+    const std::string GEOID12B{"GEOID12B"};
+    const std::string GEOID18{"GEOID18"};
+    const std::string OSGM15{"OSGM15"};
+
+    auto findInList = [](PROJ_STRING_LIST list, const std::string &ref) {
+        while (list && *list) {
+            if (std::string(*list) == ref) {
+                return true;
+            }
+            list++;
+        }
+        return false;
+    };
+
+    {
+        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "4326",
+                                                        nullptr);
+        ListFreer freer(list);
+        ASSERT_NE(list, nullptr);
+        EXPECT_EQ(list[0], nullptr);
+    }
+
+    {
+        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "5703",
+                                                        nullptr);
+        ListFreer freer(list);
+        EXPECT_TRUE(findInList(list, GEOID12B));
+        EXPECT_TRUE(findInList(list, GEOID18));
+        EXPECT_FALSE(findInList(list, OSGM15));
+    }
+    {
+        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "8228",
+                                                        nullptr);
+        ListFreer freer(list);
+        EXPECT_TRUE(findInList(list, GEOID12B));
+        EXPECT_TRUE(findInList(list, GEOID18));
+        EXPECT_FALSE(findInList(list, OSGM15));
+    }
+    {
+        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "6358",
+                                                        nullptr);
+        ListFreer freer(list);
+        EXPECT_TRUE(findInList(list, GEOID12B));
+        EXPECT_TRUE(findInList(list, GEOID18));
+        EXPECT_FALSE(findInList(list, OSGM15));
+    }
+
+    {
+        auto list = proj_get_geoid_models_from_database(m_ctxt, "EPSG", "5701",
+                                                        nullptr);
+        ListFreer freer(list);
+        EXPECT_FALSE(findInList(list, GEOID12B));
+        EXPECT_FALSE(findInList(list, GEOID18));
+        EXPECT_TRUE(findInList(list, OSGM15));
+    }
+}
 
 } // namespace

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2146,7 +2146,7 @@ TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
 
     const std::string OSGM15{"OSGM15"};
 
-    auto chechNavd88 = [&navd88geoidmodels](const std::list<std::string> &res) {
+    auto checkNavd88 = [&navd88geoidmodels](const std::list<std::string> &res) {
         ASSERT_EQ(res.size(), navd88geoidmodels.size());
         auto it = navd88geoidmodels.cbegin();
         for (const auto &model : res) {
@@ -2158,34 +2158,34 @@ TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
         AuthorityFactory::create(DatabaseContext::create(), std::string());
 
     {
-        auto res = factory->getAvailableGeoidmodels("4326");
+        auto res = factory->getGeoidModels("4326");
         ASSERT_TRUE(res.empty());
     }
 
     {
-        auto res = factory->getAvailableGeoidmodels("5703");
-        chechNavd88(res);
+        auto res = factory->getGeoidModels("5703");
+        checkNavd88(res);
     }
     {
-        auto res = factory->getAvailableGeoidmodels("6360");
-        chechNavd88(res);
+        auto res = factory->getGeoidModels("6360");
+        checkNavd88(res);
     }
     {
-        auto res = factory->getAvailableGeoidmodels("8228");
-        chechNavd88(res);
+        auto res = factory->getGeoidModels("8228");
+        checkNavd88(res);
     }
     {
-        auto res = factory->getAvailableGeoidmodels("6357");
-        chechNavd88(res);
+        auto res = factory->getGeoidModels("6357");
+        checkNavd88(res);
     }
 
     {
-        auto res = factory->getAvailableGeoidmodels("5701");
+        auto res = factory->getGeoidModels("5701");
         ASSERT_EQ(res.size(), 1U);
         EXPECT_EQ(OSGM15, res.front());
     }
     {
-        auto res = factory->getAvailableGeoidmodels("5732");
+        auto res = factory->getGeoidModels("5732");
         ASSERT_EQ(res.size(), 1U);
         EXPECT_EQ(OSGM15, res.front());
     }

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2142,13 +2142,19 @@ TEST(
 TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
 
     const std::string OSGM15{"OSGM15"};
+    const std::string GEOID12B{"GEOID12B"};
+    const std::string GEOID18{"GEOID18"};
 
-    auto checkNavd88 = [&OSGM15](const std::list<std::string> &res) {
-        const std::string GEOID12B{"GEOID12B"};
-        const std::string GEOID18{"GEOID18"};
+    auto checkNavd88 = [&](const std::list<std::string> &res) {
         EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID12B));
         EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID18));
         EXPECT_FALSE(res.end() != std::find(res.begin(), res.end(), OSGM15));
+    };
+
+    auto checkOdn = [&](const std::list<std::string> &res) {
+        EXPECT_FALSE(res.end() != std::find(res.begin(), res.end(), GEOID12B));
+        EXPECT_FALSE(res.end() != std::find(res.begin(), res.end(), GEOID18));
+        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), OSGM15));
     };
 
     auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
@@ -2159,29 +2165,33 @@ TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
     }
 
     {
-        auto res = factory->getGeoidModels("5703");
+        auto res = factory->getGeoidModels("5703"); // "NAVD88 height"
         checkNavd88(res);
     }
     {
-        auto res = factory->getGeoidModels("6360");
+        auto res = factory->getGeoidModels("6360"); // "NAVD88 height (ftUS)"
         checkNavd88(res);
     }
     {
-        auto res = factory->getGeoidModels("8228");
+        auto res = factory->getGeoidModels("8228"); // "NAVD88 height (ft)"
         checkNavd88(res);
     }
     {
-        auto res = factory->getGeoidModels("6357");
+        auto res = factory->getGeoidModels("6357"); // "NAVD88 depth"
+        checkNavd88(res);
+    }
+    {
+        auto res = factory->getGeoidModels("6358"); // "NAVD88 depth (ftUS)"
         checkNavd88(res);
     }
 
     {
-        auto res = factory->getGeoidModels("5701");
-        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), OSGM15));
+        auto res = factory->getGeoidModels("5701"); // "ODN height"
+        checkOdn(res);
     }
     {
-        auto res = factory->getGeoidModels("5732");
-        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), OSGM15));
+        auto res = factory->getGeoidModels("5732"); // "Belfast height"
+        checkOdn(res);
     }
 }
 

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2140,22 +2140,17 @@ TEST(
 }
 
 TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
-    const std::list<std::string> navd88geoidmodels{
-        "GEOID03",  "GEOID06", "GEOID09", "GEOID12A",
-        "GEOID12B", "GEOID18", "GEOID99"};
 
     const std::string OSGM15{"OSGM15"};
 
-    auto checkNavd88 = [&navd88geoidmodels](const std::list<std::string> &res) {
-        ASSERT_EQ(res.size(), navd88geoidmodels.size());
-        auto it = navd88geoidmodels.cbegin();
-        for (const auto &model : res) {
-            EXPECT_EQ(*it, model);
-            it++;
-        }
+    auto checkNavd88 = [](const std::list<std::string> &res) {
+        const std::string GEOID12B{"GEOID12B"};
+        const std::string GEOID18{"GEOID18"};
+        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID12B));
+        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID18));
     };
-    auto factory =
-        AuthorityFactory::create(DatabaseContext::create(), std::string());
+
+    auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
 
     {
         auto res = factory->getGeoidModels("4326");
@@ -2181,13 +2176,11 @@ TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
 
     {
         auto res = factory->getGeoidModels("5701");
-        ASSERT_EQ(res.size(), 1U);
-        EXPECT_EQ(OSGM15, res.front());
+        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), OSGM15));
     }
     {
         auto res = factory->getGeoidModels("5732");
-        ASSERT_EQ(res.size(), 1U);
-        EXPECT_EQ(OSGM15, res.front());
+        EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), OSGM15));
     }
 }
 

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2143,11 +2143,12 @@ TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
 
     const std::string OSGM15{"OSGM15"};
 
-    auto checkNavd88 = [](const std::list<std::string> &res) {
+    auto checkNavd88 = [&OSGM15](const std::list<std::string> &res) {
         const std::string GEOID12B{"GEOID12B"};
         const std::string GEOID18{"GEOID18"};
         EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID12B));
         EXPECT_TRUE(res.end() != std::find(res.begin(), res.end(), GEOID18));
+        EXPECT_FALSE(res.end() != std::find(res.begin(), res.end(), OSGM15));
     };
 
     auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2139,6 +2139,58 @@ TEST(
     }
 }
 
+TEST(factory, AuthorityFactory_getAvailableGeoidmodels) {
+    const std::list<std::string> navd88geoidmodels{
+        "GEOID03",  "GEOID06", "GEOID09", "GEOID12A",
+        "GEOID12B", "GEOID18", "GEOID99"};
+
+    const std::string OSGM15{"OSGM15"};
+
+    auto chechNavd88 = [&navd88geoidmodels](const std::list<std::string> &res) {
+        ASSERT_EQ(res.size(), navd88geoidmodels.size());
+        auto it = navd88geoidmodels.cbegin();
+        for (const auto &model : res) {
+            EXPECT_EQ(*it, model);
+            it++;
+        }
+    };
+    auto factory =
+        AuthorityFactory::create(DatabaseContext::create(), std::string());
+
+    {
+        auto res = factory->getAvailableGeoidmodels("4326");
+        ASSERT_TRUE(res.empty());
+    }
+
+    {
+        auto res = factory->getAvailableGeoidmodels("5703");
+        chechNavd88(res);
+    }
+    {
+        auto res = factory->getAvailableGeoidmodels("6360");
+        chechNavd88(res);
+    }
+    {
+        auto res = factory->getAvailableGeoidmodels("8228");
+        chechNavd88(res);
+    }
+    {
+        auto res = factory->getAvailableGeoidmodels("6357");
+        chechNavd88(res);
+    }
+
+    {
+        auto res = factory->getAvailableGeoidmodels("5701");
+        ASSERT_EQ(res.size(), 1U);
+        EXPECT_EQ(OSGM15, res.front());
+    }
+    {
+        auto res = factory->getAvailableGeoidmodels("5732");
+        ASSERT_EQ(res.size(), 1U);
+        EXPECT_EQ(OSGM15, res.front());
+    }
+}
+
 // ---------------------------------------------------------------------------
 
 TEST_F(FactoryWithTmpDatabase,


### PR DESCRIPTION
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API

Given a CRS code, this new method returns the list of possible geoid models that apply to it.
(use case: give the user a list of available geoid models, to select the desired one).

The sql query has two parts. The second covers CRSs like EPSG:6360, that is the ftUS version of EPSG:5703 (NAVD88 height).

In a later PR, I was thinking on adding at least these geoid models to the db:
 - `AUSGeoid2020`,`AUSGeoid09`, `AUSGeoid98` for `AHD height` (Australia)
 - `RAF09`, `RAF18` for `NGF-IGN69 height` (France)
(those are the cases I found with more than one grid file with the same target VCRS)

CC @snowman2 