### PR TITLE
CMake: "make dist" workalike via CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,3 +293,60 @@ if(UNIX OR MINGW)
     ${CMAKE_CURRENT_BINARY_DIR}/proj.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
+
+################################################################################
+# "make dist" workalike
+################################################################################
+
+set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "proj-${PROJ_VERSION}")
+set(CPACK_PACKAGE_VENDOR "OSGeo")
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJ_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJ_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJ_VERSION_PATCH})
+set(CPACK_VERBATIM_VARIABLES TRUE)
+set(CPACK_SOURCE_IGNORE_FILES
+  /\\..*  # any file/directory starting with .
+  /.*\\.yml
+  /.*\\.gz
+  /.*\\.zip
+  /.*build.*/
+  \\.deps
+  /autogen\\.sh
+  /autom4te\\.cache
+  /CODE_OF_CONDUCT.md
+  /CONTRIBUTING.md
+  /Dockerfile
+  /docs/
+  /Doxyfile
+  /examples/
+  /HOWTO-RELEASE
+  /m4/lt*
+  /m4/libtool*
+  /media/
+  /schemas/
+  /scripts/
+  /test/fuzzers/
+  /test/gigs/.*gie\\.failing
+  /test/postinstall/
+  /travis/
+  ${PROJECT_BINARY_DIR}
+)
+
+include(CPack)
+
+# Simplify README.md to README
+add_custom_target(README
+  COMMAND ${CMAKE_COMMAND}
+    -D PROJ_SOURCE_DIR=${PROJ_SOURCE_DIR}
+    -P ${PROJ_SOURCE_DIR}/cmake/ProjReadme.cmake
+)
+
+get_property(_is_multi_config_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _is_multi_config_generator)
+  add_custom_target(dist
+    COMMAND ${CMAKE_MAKE_PROGRAM} package_source
+    DEPENDS README
+  )
+  message(STATUS "PROJ: Configured 'dist' target")
+endif()

--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = CMakeLists.txt \
 			proj_config.cmake.in \
 			ProjConfig.cmake \
 			ProjMac.cmake \
+			ProjReadme.cmake \
 			ProjTest.cmake \
 			ProjVersion.cmake \
 			policies.cmake \

--- a/cmake/ProjReadme.cmake
+++ b/cmake/ProjReadme.cmake
@@ -1,0 +1,28 @@
+#
+# CMake script to modify README.md to create simpler README file
+#
+# This is equivalent to: fgrep -v "[!["
+#
+
+set(SourceFile "${PROJ_SOURCE_DIR}/README.md")
+set(DestFile "${PROJ_SOURCE_DIR}/README")
+
+# Below is based on https://stackoverflow.com/a/30227627
+
+file(READ ${SourceFile} Contents)
+
+# Set the variable "Esc" to the ASCII value 27 as a special escape value
+string(ASCII 27 Esc)
+
+# Turn the contents into a list of strings, each ending with Esc
+string(REGEX REPLACE "\n" "${Esc};" ContentsAsList "${Contents}")
+
+unset(ModifiedContents)
+foreach(Line ${ContentsAsList})
+  if(NOT "${Line}" MATCHES "\\[!\\[")
+    # Swap the appended Esc character back out in favour of a line feed
+    string(REGEX REPLACE "${Esc}" "\n" Line ${Line})
+    set(ModifiedContents "${ModifiedContents}${Line}")
+  endif()
+endforeach()
+file(WRITE ${DestFile} ${ModifiedContents})

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -28,7 +28,19 @@ make dist-all >/dev/null
 TAR_FILENAME=`ls *.tar.gz`
 TAR_DIRECTORY=`basename $TAR_FILENAME .tar.gz`
 tar xvzf $TAR_FILENAME
-cd $TAR_DIRECTORY
+cd ..
+
+# compare with CMake's dist
+mkdir build_cmake
+cd build_cmake
+cmake -DBUILD_TESTING=OFF ..
+make dist
+tar xzf $TAR_FILENAME
+cd ..
+diff -qr build_autoconf/$TAR_DIRECTORY build_cmake/$TAR_DIRECTORY || true
+
+# continue build from autoconf
+cd build_autoconf/$TAR_DIRECTORY
 
 # There's a nasty #define CS in a Solaris system header. Avoid being caught about that again
 CXXFLAGS="-DCS=do_not_use_CS_for_solaris_compat $CXXFLAGS"


### PR DESCRIPTION
This PR adds "make dist" to the CMake set-up, to allow similar functionality that is provided by Autotools.

The process (at the moment) is:
```
git clean -dfx  # danger! this will delete any uncommitted files in a repo
./autogen.sh
./configure
make dist  # optional step, to generate autotools archive to compare
make distclean
mkdir build && cd build
cmake ..
make dist
```
this builds two sets of source distributions with *.tar.gz and *.zip formats. Comparing the two extracted archives:
```
$ diff -qr autotools/proj-8.1.0/ cmake/proj-8.1.0/
Only in cmake/proj-8.1.0/data: epsg-deprecated
Only in cmake/proj-8.1.0/data: proj_outIGNF.dist-real
Only in cmake/proj-8.1.0/data/sql: method_triggers.sql
Only in cmake/proj-8.1.0/m4: libtool.m4
Only in cmake/proj-8.1.0/m4: lt~obsolete.m4
Only in cmake/proj-8.1.0/m4: ltoptions.m4
Only in cmake/proj-8.1.0/m4: ltsugar.m4
Only in cmake/proj-8.1.0/m4: ltversion.m4
Only in autotools/proj-8.1.0/: README
Only in cmake/proj-8.1.0/src: general_doc.dox
Only in cmake/proj-8.1.0/src: runmultistresstest.sh
Only in cmake/proj-8.1.0/test: fuzzers
Only in cmake/proj-8.1.0/test/gie: nkg.gie
Only in cmake/proj-8.1.0/test/gigs: 5101.4-jhs.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5102.2.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5105.1.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5108.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5110.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5111.2.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5203.1.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5204.1.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5205.1.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5206.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5207.1.gie.failing
Only in cmake/proj-8.1.0/test/gigs: 5207.2.gie.failing
Only in cmake/proj-8.1.0/test: postinstall
```
this shows that the CMake version grabs a few extra files that are not included in the respective Makefile.am files. For some reason, CPack refuses to take README, and I'm not sure why.

---

There are a few potentially dangerous things with the approach:

1. While not part of this PR, the recommendation to use `git clean -dfx` will delete uncommitted work-in-progress, but is the only sure way to clear up extra files in a repo
2.  If there are any extra files that don't fit the `CPACK_SOURCE_IGNORE_FILES` pattern, these will be swept up in the archive
3. Many commands in the correct order (shown above) are required to generate a source archive with configure, etc., so this is easy to mess up
4. It's a bit awkward to `mkdir build && cd build && cmake .. && make dist` i.e. in a subfolder

An alternative idea is to leverage [git archive](https://git-scm.com/docs/git-archive) to build a source archive based on committed files, which could be brought into a Makefile. This approach could potentially be more robust, but it can't work with the generated files from ./autogen.sh

---

This PR is based on parts of [GEOS' CMakeLists.txt](https://github.com/libgeos/geos/blob/200ff644ea5682a4f6314efc6de1a2dc057d5acf/CMakeLists.txt#L382-L417); thanks GEOS devs for great ideas!