### PR TITLE
test_network.cpp: try to fix 'Please include winsock2.h before windows.h' warning with msys

### DIFF
--- a/test/unit/test_network.cpp
+++ b/test/unit/test_network.cpp
@@ -38,14 +38,14 @@
 #include <sqlite3.h>
 #include <time.h>
 
+#ifdef CURL_ENABLED
+#include <curl/curl.h>
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <unistd.h>
-#endif
-
-#ifdef CURL_ENABLED
-#include <curl/curl.h>
 #endif
 
 namespace {


### PR DESCRIPTION
```
In file included from D:/a/_temp/msys/msys64/mingw64/include/curl/system.h:422,
                 from D:/a/_temp/msys/msys64/mingw64/include/curl/curl.h:38,
                 from D:/a/PROJ/PROJ/test/unit/test_network.cpp:48:
D:/a/_temp/msys/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
   15 | #warning Please include winsock2.h before windows.h
      |  ^~~~~~~
```

Seems to be what is described in https://curl.se/mail/lib-2016-12/0047.html
