### PR TITLE
Improvements related to DerivedVerticalCRS using Change Unit and Height/Depth reversal methods

### DIFF
--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -5620,6 +5620,32 @@ TEST(crs, DerivedVerticalCRS_WKT1) {
 
 // ---------------------------------------------------------------------------
 
+TEST(crs, DerivedVerticalCRS_WKT1_when_simple_derivation) {
+
+    auto derivingConversion =
+        Conversion::createChangeVerticalUnit(PropertyMap().set(
+            IdentifiedObject::NAME_KEY, "Vertical Axis Unit Conversion"));
+
+    auto crs = DerivedVerticalCRS::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "Derived vertCRS"),
+        createVerticalCRS(), derivingConversion,
+        VerticalCS::createGravityRelatedHeight(UnitOfMeasure::FOOT));
+
+    auto expected = "VERT_CS[\"Derived vertCRS\",\n"
+                    "    VERT_DATUM[\"Ordnance Datum Newlyn\",2005,\n"
+                    "        AUTHORITY[\"EPSG\",\"5101\"]],\n"
+                    "    UNIT[\"foot\",0.3048,\n"
+                    "        AUTHORITY[\"EPSG\",\"9002\"]],\n"
+                    "    AXIS[\"Gravity-related height\",UP]]";
+
+    EXPECT_EQ(
+        crs->exportToWKT(
+            WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL).get()),
+        expected);
+}
+
+// ---------------------------------------------------------------------------
+
 static DerivedEngineeringCRSNNPtr createDerivedEngineeringCRS() {
 
     auto derivingConversion = Conversion::create(

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -10585,6 +10585,7 @@ TEST(io, createFromUserInput) {
         EXPECT_EQ(crs->coordinateSystem()->getEPSGCode(), 4400);
         EXPECT_EQ(crs->derivingConversion()->getEPSGCode(), 16031);
     }
+
     {
         // DerivedVerticalCRS based on "NAVD88 height", using a foot UP axis,
         // and EPSG:7813 "Vertical Axis Unit Conversion" conversion
@@ -10594,9 +10595,69 @@ TEST(io, createFromUserInput) {
                                        dbContext);
         auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
         ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 height (ft)");
         EXPECT_EQ(crs->baseCRS()->getEPSGCode(), 5703);
         EXPECT_EQ(crs->coordinateSystem()->getEPSGCode(), 1030);
         EXPECT_EQ(crs->derivingConversion()->getEPSGCode(), 7813);
+    }
+
+    {
+        // DerivedVerticalCRS based on "NAVD88 height", using a ftUS UP axis,
+        // and EPSG:7813 "Vertical Axis Unit Conversion" conversion
+        auto obj = createFromUserInput("urn:ogc:def:crs,crs:EPSG::5703,"
+                                       "cs:EPSG::6497,"
+                                       "coordinateOperation:EPSG::7813",
+                                       dbContext);
+        auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 height (ftUS)");
+    }
+
+    {
+        // DerivedVerticalCRS based on "NAVD88 height (ftUS)", using a metre UP
+        // axis, and EPSG:7813 "Vertical Axis Unit Conversion" conversion
+        auto obj = createFromUserInput("urn:ogc:def:crs,crs:EPSG::6360,"
+                                       "cs:EPSG::6499,"
+                                       "coordinateOperation:EPSG::7813",
+                                       dbContext);
+        auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 height");
+    }
+    {
+        // DerivedVerticalCRS based on "NAVD88 height", using a metre DOWN axis,
+        // and EPSG:7812 "Height / Depth reversal" conversion
+        auto obj = createFromUserInput("urn:ogc:def:crs,crs:EPSG::5703,"
+                                       "cs:EPSG::6498,"
+                                       "coordinateOperation:EPSG::7812",
+                                       dbContext);
+        auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 depth");
+    }
+
+    {
+        // DerivedVerticalCRS based on "NAVD88 height (ftUS)", using a ftUS DOWN
+        // axis, and EPSG:7812 "Height / Depth reversal" conversion
+        auto obj = createFromUserInput("urn:ogc:def:crs,crs:EPSG::6360,"
+                                       "cs:EPSG::1043,"
+                                       "coordinateOperation:EPSG::7812",
+                                       dbContext);
+        auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 depth (ftUS)");
+    }
+
+    {
+        // DerivedVerticalCRS based on "NAVD88 depth (ftUS)", using a ftUS UP
+        // axis, and EPSG:7812 "Height / Depth reversal" conversion
+        auto obj = createFromUserInput("urn:ogc:def:crs,crs:EPSG::6358,"
+                                       "cs:EPSG::6497,"
+                                       "coordinateOperation:EPSG::7812",
+                                       dbContext);
+        auto crs = nn_dynamic_pointer_cast<DerivedVerticalCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NAVD88 height (ftUS)");
     }
 
     {


### PR DESCRIPTION
- For instantiation from urn combined references, create a better name, using conventions of EPSG vertical CRS
- For exportToWKT(), allow export in WKT < WKT2 for such DerivedVerticalCRS