### PR TITLE
TST/DOC: upgrade CSA to use ubuntu-18.04; sync docs

### DIFF
--- a/.github/workflows/clang_static_analyzer.yml
+++ b/.github/workflows/clang_static_analyzer.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   clang_static_analyzer:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout

--- a/.github/workflows/clang_static_analyzer/start.sh
+++ b/.github/workflows/clang_static_analyzer/start.sh
@@ -7,8 +7,8 @@ sudo apt update
 DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
     autoconf automake libtool g++ make sqlite3 libsqlite3-dev libtiff-dev libcurl4-openssl-dev jq
 
-CLANG_LLVM=clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04
-wget http://releases.llvm.org/9.0.0/$CLANG_LLVM.tar.xz
+CLANG_LLVM=clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04
+wget -nv https://releases.llvm.org/9.0.0/$CLANG_LLVM.tar.xz
 tar xJf $CLANG_LLVM.tar.xz
 mv $CLANG_LLVM clang+llvm-9
 

--- a/docs/source/community/code_contributions.rst
+++ b/docs/source/community/code_contributions.rst
@@ -120,21 +120,21 @@ Preliminary step: install clang. For example:
 
 ::
 
-    wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    tar xJf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    mv clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04 clang+llvm-6
+    wget https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    tar xJf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang+llvm-9
 
 Run configure under the scan-build utility of clang:
 
 ::
 
-    ./clang+llvm-6/bin/scan-build ./configure
+    ./clang+llvm-9/bin/scan-build ./configure
 
 Build under scan-build:
 
 ::
 
-    ./clang+llvm-6/bin/scan-build make [-j8]
+    ./clang+llvm-9/bin/scan-build make [-j8]
 
 If CSA finds errors, they will be emitted during the build. And in which case,
 at the end of the build process, scan-build will emit a warning message
@@ -143,7 +143,7 @@ is with someling like
 
 ::
 
-    ./clang+llvm-6/bin/scan-view /tmp/scan-build-2018-03-15-121416-17476-1
+    ./clang+llvm-9/bin/scan-view /tmp/scan-build-2021-03-15-121416-17476-1
 
 
 This will open a web browser with the interactive report.


### PR DESCRIPTION
According to the [Ubuntu release schedule](https://wiki.ubuntu.com/Releases), Ubuntu Xenial 16.04 is to reach it's end of standard support in a few days. Upgrading to [`ubuntu-18.04`](https://github.com/actions/virtual-environments) (Bionic).

Also synchronizing contribution docs to use same `clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04` as used in CI.