### PR TITLE
projsync: make it filter out files not intended for the current version

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -99,7 +99,16 @@ If needed, update the year in `CITATION`.
 *Commit the changes to master.*
 
 
-1.5 Create maintenance branch
+1.5 Update `PROJ_DATA.VERSION`
+-------------------------------------------------------------------------------
+
+If the database references data from an updated PROJ-data package, update
+`PROJ_DATA.VERSION` in `data/sql/metadata.sql`.
+
+*Commit the changes to master.*
+
+
+1.6 Create maintenance branch
 -------------------------------------------------------------------------------
 
 *Skip this step if you are preparing a patch release or RC2 and later.*
@@ -117,7 +126,7 @@ subsequently cherry-picked to the maintenance branch.
 *Push branch upstream.*
 
 
-1.6 Prepare and upload archives
+1.7 Prepare and upload archives
 -------------------------------------------------------------------------------
 
 Run autoconf and configure the build:
@@ -148,13 +157,13 @@ scp proj-x.y.zRCn.* warmerdam@download.osgeo.org:/osgeo/download/proj
 Adjust version numbers and usernames accordingly.
 
 
-1.7 Announce the release candidate
+1.8 Announce the release candidate
 -------------------------------------------------------------------------------
 
 Announce the release candidate on the PROJ mailing list.
 
 
-1.8 Promotion to final release
+1.9 Promotion to final release
 -------------------------------------------------------------------------------
 
 When you are confident that the latest release candidate is ready for promotion

--- a/data/sql/metadata.sql
+++ b/data/sql/metadata.sql
@@ -15,3 +15,7 @@ INSERT INTO "metadata" VALUES('EPSG.DATE', '2021-05-16');
 -- The value of ${PROJ_VERSION} is substituted at build time by the actual
 -- value.
 INSERT INTO "metadata" VALUES('PROJ.VERSION', '${PROJ_VERSION}');
+
+-- Version of the PROJ-data package with which this database is the most
+-- compatible.
+INSERT INTO "metadata" VALUES('PROJ_DATA.VERSION', '1.7');

--- a/docs/source/apps/projsync.rst
+++ b/docs/source/apps/projsync.rst
@@ -24,7 +24,8 @@ Synopsis
     |      [--source-id ID] [--area-of-use NAME]
     |      [--file NAME]
     |      [--all] [--exclude-world-coverage]
-    |      [--quiet] [--dry-run] [--list-files]
+    |      [--quiet | --verbose] [--dry-run] [--list-files]
+    |      [--no-version-filtering]
 
 Description
 ***********
@@ -108,6 +109,12 @@ The following control parameters can appear in any order:
 
     Quiet mode
 
+.. option:: --verbose
+
+    .. versionadded:: 8.1
+
+    Verbose mode (more than default)
+
 .. option:: --dry-run
 
     Simulate the behavior of the tool without downloading resource files.
@@ -115,6 +122,16 @@ The following control parameters can appear in any order:
 .. option:: --list-files
 
     List file names, with the source_id and area_of_use properties.
+
+.. option:: --no-version-filtering
+
+    .. versionadded:: 8.1
+
+    By default, projsync only downloads files that are compatible of
+    the PROJ_DATA.VERSION metadata of :file:`proj.db`, taking into account the
+    ``version_added`` and ``version_removed`` properties of entries in :file:`files.geojson`.
+    When specifying this switch, all files referenced in :file:`files.geojson`
+    will be candidate (combined with other filters).
 
 
 At least one of  :option:`--list-files`,  :option:`--file`,  :option:`--source-id`,

--- a/test/cli/test_projsync
+++ b/test/cli/test_projsync
@@ -188,6 +188,28 @@ fi
 cat ${TMP_OUT} | grep "nz_linz_nzgeoid2009.tif" >/dev/null || (cat ${TMP_OUT}; exit 100)
 cat ${TMP_OUT} | grep "us_noaa_alaska.tif" >/dev/null || (cat ${TMP_OUT}; exit 100)
 
+cat > dummy.geojson <<EOF
+{
+"type": "FeatureCollection",
+"features": [
+{ "type": "Feature", "properties": { "url": "https://example.com/removed_in_1.7.tif", "name": "removed_in_1.7", "area_of_use": "Australia", "type": "VERTICAL_OFFSET_GEOGRAPHIC_TO_VERTICAL", "source_crs_code": "EPSG:7843", "source_crs_name": "GDA2020", "target_crs_code": "EPSG:9458", "target_crs_name": "AVWS height", "source": "Geoscience Australia", "source_country": "Australia", "source_id": "au_ga", "source_url": "http://www.ga.gov.au", "description": "GDA2020 (EPSG:7843) to AVWS height (EPSG:9458)", "file_size": 60878523, "sha256sum": "c06f24dae030587cc2556a316782ade83b6d91f1b8d03922ddd0ce58f3868baa", "version_removed": "1.7" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 93.0083333, -61.0083333 ], [ 174.0083333, -61.0083333 ], [ 174.0083333, -8.0083333 ], [ 93.0083333, -8.0083333 ], [ 93.0083333, -61.0083333 ] ] ] } },
+{ "type": "Feature", "properties": { "url": "https://example.com/added_in_99_99.tif", "name": "added_in_99_99.tif", "area_of_use": "Australia", "type": "VERTICAL_OFFSET_GEOGRAPHIC_TO_VERTICAL", "source_crs_code": "EPSG:7843", "source_crs_name": "GDA2020", "target_crs_code": "EPSG:9458", "target_crs_name": "AVWS height", "source": "Geoscience Australia", "source_country": "Australia", "source_id": "au_ga", "source_url": "http://www.ga.gov.au", "description": "GDA2020 (EPSG:7843) to AVWS height (EPSG:9458)", "file_size": 60878523, "sha256sum": "c06f24dae030587cc2556a316782ade83b6d91f1b8d03922ddd0ce58f3868baa", "version_added": "99.99" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 93.0083333, -61.0083333 ], [ 174.0083333, -61.0083333 ], [ 174.0083333, -8.0083333 ], [ 93.0083333, -8.0083333 ], [ 93.0083333, -61.0083333 ] ] ] } },
+{ "type": "Feature", "properties": { "url": "https://example.com/without_version.tif", "name": "without_version.tif", "area_of_use": "Australia", "type": "VERTICAL_OFFSET_GEOGRAPHIC_TO_VERTICAL", "source_crs_code": "EPSG:7843", "source_crs_name": "GDA2020", "target_crs_code": "EPSG:9458", "target_crs_name": "AVWS height", "source": "Geoscience Australia", "source_country": "Australia", "source_id": "au_ga", "source_url": "http://www.ga.gov.au", "description": "GDA2020 (EPSG:7843) to AVWS height (EPSG:9458)", "file_size": 60878523, "sha256sum": "c06f24dae030587cc2556a316782ade83b6d91f1b8d03922ddd0ce58f3868baa" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 93.0083333, -61.0083333 ], [ 174.0083333, -61.0083333 ], [ 174.0083333, -8.0083333 ], [ 93.0083333, -8.0083333 ], [ 93.0083333, -61.0083333 ] ] ] } }
+]
+}
+EOF
+
+echo "Testing $EXE --source-id au_ga --verbose --dry-run --local-geojson-file dummy.geojson"
+if ! $EXE --source-id au_ga --verbose --dry-run --local-geojson-file dummy.geojson > ${TMP_OUT}; then
+    echo "--source-id au_ga --verbose --dry-run --local-geojson-file dummy.geojson"
+    cat ${TMP_OUT}
+    exit 100
+fi
+rm dummy.geojson
+cat ${TMP_OUT} | grep "Skipping removed_in_1.7 as it is no longer useful starting with PROJ-data 1.7" >/dev/null || (cat ${TMP_OUT}; exit 100)
+cat ${TMP_OUT} | grep "Skipping added_in_99_99.tif as it is only useful starting with PROJ-data 99.99" >/dev/null || (cat ${TMP_OUT}; exit 100)
+cat ${TMP_OUT} | grep "Would download https://cdn.proj.org/without_version.tif" >/dev/null || (cat ${TMP_OUT}; exit 100)
+
 rm -rf ${PROJ_USER_WRITABLE_DIRECTORY}
 rm ${TMP_OUT}
 


### PR DESCRIPTION
* Add a PROJ_DATA.VERSION in proj.db to indicate the target PROJ-data
  package version
* Make projsync use that information and the version_added and
  version_removed properties added in https://github.com/OSGeo/PROJ-data/pull/67
  to filter out files that are not relevant
* Add --no-version-filtering and --verbose switches