### PR TITLE
proj_create(): do not open proj.db if string is a PROJ string, …

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -6944,7 +6944,12 @@ BaseObjectNNPtr createFromUserInput(const std::string &text, PJ_CONTEXT *ctx) {
     DatabaseContextPtr dbContext;
     try {
         if (ctx != nullptr && ctx->cpp_context) {
-            dbContext = ctx->cpp_context->getDatabaseContext().as_nullable();
+            // Only connect to proj.db if needed
+            if (text.find("proj=") == std::string::npos ||
+                text.find("init=") != std::string::npos) {
+                dbContext =
+                    ctx->cpp_context->getDatabaseContext().as_nullable();
+            }
         }
     } catch (const std::exception &) {
     }


### PR DESCRIPTION
…even if proj_context_set_autoclose_database() has been set (fixes #2734)
