### PR TITLE
Update link in docs to Dutch coord transform website.

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -249,7 +249,7 @@ Brazil
 Netherlands
 ................................................................................
 
-`Dutch grid <https://zakelijk.kadaster.nl/transformatie-van-coordinaten>`__ (Registration required before download)
+`Dutch grid <https://www.nsgi.nl/geodetische-infrastructuur/coordinatentransformatie>`__ (Registration required before download)
 
 Portugal
 ................................................................................


### PR DESCRIPTION
Just a simple fix of a link. https://www.nsgi.nl/geodetische-infrastructuur/coordinatentransformatie is the correct address now for the Dutch coordinate transformation. (Kadaster that the former link belonged to is part of the NSGI). 

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [X] Added clear title that can be used to generate release notes
 - [X] Fully documented, including updating `docs/source/*.rst` for new API