### PR TITLE
proj_trans/cs2cs: If two operations have the same accuracy, use the one that is contained within a larger one

### DIFF
--- a/docs/source/operations/operations_computation.rst
+++ b/docs/source/operations/operations_computation.rst
@@ -59,9 +59,9 @@ From a code point of view, the entry point of the algorithm is the C++
 
 It combines several strategies:
 
-- look up in the PROJ database for available operations
-- consider the pair (source CRS, target CRS) to synthetize operations depending
-  on the nature of the source and target CRS.
+  - look up in the PROJ database for available operations
+  - consider the pair (source CRS, target CRS) to synthetize operations depending
+    on the nature of the source and target CRS.
 
 Geographic CRS to Geographic CRS, with known identifiers
 --------------------------------------------------------
@@ -155,6 +155,18 @@ performed in the order they are listed below:
     have the same length, consider as more relevant the one whose name comes last in
     lexicographic order (e.g. "FOO to BAR (3)" will have higher precedence than
     "FOO to BAR (2)")
+
+.. note::
+
+    :c:func:`proj_trans`, on the results returned by :c:func:`proj_create_crs_to_crs`,
+    will not necessarily use the operation that
+    is listed in first position due to the above algorithm. :c:func:`proj_trans`
+    has more context, since it has the coordinate to transform, so it can compare
+    this coordinate to the area of use of operations. Typically, the above criteria
+    will favor an operation that has a larger area of use over another one with a
+    smaller area, due to it being more generally applicable. But once coordinates are known,
+    :c:func:`proj_trans` can select an operation with a smaller
+    area of use that applies to the coordinate to transform.
 
 Geodetic/geographic CRS to Geodetic/geographic CRS, without known identifiers
 -----------------------------------------------------------------------------

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -243,7 +243,15 @@ int pj_get_suggested_operation(PJ_CONTEXT*,
             // onshore. So in a general way, prefer a onshore area to a
             // offshore one.
             if( iBest < 0 ||
-                (alt.accuracy >= 0 && alt.accuracy < bestAccuracy &&
+                (alt.accuracy >= 0 &&
+                (alt.accuracy < bestAccuracy ||
+                 // If two operations have the same accuracy, use the one that
+                 // is contained within a larger one
+                 (alt.accuracy == bestAccuracy &&
+                  alt.minxSrc > opList[iBest].minxSrc &&
+                  alt.minySrc > opList[iBest].minySrc &&
+                  alt.maxxSrc < opList[iBest].maxxSrc &&
+                  alt.maxySrc < opList[iBest].maxySrc)) &&
                 !alt.isOffshore) ) {
                 iBest = i;
                 bestAccuracy = alt.accuracy;

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1047,6 +1047,12 @@ $EXE -E EPSG:2636 "WGS 84" >> ${OUT} <<EOF
 5540944.47  500000.001
 EOF
 
+echo  "##############################################################" >> ${OUT}
+echo  "Check that we select the operation that has the smallest area of use, when 2 have the same accuracy" >> ${OUT}
+$EXE -E EPSG:4326 "NAD83(HARN)" >> ${OUT} <<EOF
+34 -120
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -504,3 +504,6 @@ Check that we can use a transformation spanning the antimeridian (should use Pul
 Check that we can use a transformation spanning the antimeridian (should use Pulkovo 1942 to WGS 84 (20))
 5540944.47  499999.999	49d59'59.36"N	179d59'52.133"W 0.000
 5540944.47  500000.001	49d59'59.36"N	179d59'52.133"W 0.000
+##############################################################
+Check that we select the operation that has the smallest area of use, when 2 have the same accuracy
+34 -120	33d59'59.983"N	119d59'59.955"W 0.000


### PR DESCRIPTION
Relates to https://github.com/OSGeo/gdal/issues/3998

Before that change, cs2cs on a NAD83(HARN) to WGS84 transformation would
use the "NAD83(HARN) to WGS 84 (1)" transformation (a null Helmert
shift) that is valid for whole US, including non-CONUS areas, even when
used on points located on CONUS that has a "NAD83(HARN) to WGS 84 (3)"
transformation (non-null Helmert shift) with same accuracy (1m).

But if doing  EPSG:2874 "NAD83(HARN) / California zone 5 (ftUS)" to
WGS84, we would use this later "NAD83(HARN) to WGS 84 (3)"
transformation because the area of use of EPSG:2874 restricts to CONUS.
This isn't consistant.

With that change, we now have more consistent behavior, even if it can
be argued which of the 2 transformations is the best...

$ echo 34 -120 | src/cs2cs -d 8 EPSG:4326 "NAD83(HARN)" | src/cs2cs "NAD83(HARN)"  EPSG:2874
5955507.74	1828410.98 0.00

$ echo 34 -120 | src/cs2cs  EPSG:4326   EPSG:2874
5955507.74	1828410.98 0.00