### PR TITLE
Minor changes to address lint in geodesic.c

### DIFF
--- a/src/geodesic.c
+++ b/src/geodesic.c
@@ -56,7 +56,7 @@ static unsigned digits, maxit1, maxit2;
 static real epsilon, realmin, pi, degree, NaN,
   tiny, tol0, tol1, tol2, tolb, xthresh;
 
-static void Init() {
+static void Init(void) {
   if (!init) {
     digits = DBL_MANT_DIG;
     epsilon = DBL_EPSILON;
@@ -210,6 +210,7 @@ static real atan2dx(real y, real x) {
   case 1: ang = (y >= 0 ? 180 : -180) - ang; break;
   case 2: ang =  90 - ang; break;
   case 3: ang = -90 + ang; break;
+  default: break;
   }
   return ang;
 }


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This addresses some compiler warning reported to me by Marc Emery <memery@myotest.com>.  The changes are super-innocuous.  For the record, the compiler flags were:
```
-Wall -Wextra -Wpointer-arith -Wcast-align -Wwrite-strings -Wswitch-default
-Wunreachable-code -Winit-self -Wmissing-field-initializers
-Wno-unknown-pragmas -Wstrict-prototypes -Wundef -Wold-style-definition -std=c99
```

And to show what a novice I am at **C** programming, I didn't konw the exact meaning of the C declaration
```
static void Init();
```
i.e., that it's not the same as
```
static void Init(void);
```
