### PR TITLE
CMake: fix installation of executables on iOS

### DIFF
--- a/src/bin_cct.cmake
+++ b/src/bin_cct.cmake
@@ -12,7 +12,7 @@ target_link_libraries(cct PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(cct PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS cct
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(cct PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_cs2cs.cmake
+++ b/src/bin_cs2cs.cmake
@@ -11,7 +11,7 @@ target_link_libraries(cs2cs PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(cs2cs PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS cs2cs
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(cs2cs PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_geod.cmake
+++ b/src/bin_geod.cmake
@@ -13,7 +13,7 @@ target_link_libraries(geod PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(geod PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS geod
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(geod PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_gie.cmake
+++ b/src/bin_gie.cmake
@@ -12,7 +12,7 @@ target_link_libraries(gie PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(gie PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS gie
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(gie PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_proj.cmake
+++ b/src/bin_proj.cmake
@@ -14,7 +14,7 @@ target_link_libraries(binproj PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(binproj PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS binproj
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(binproj PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_projinfo.cmake
+++ b/src/bin_projinfo.cmake
@@ -10,7 +10,7 @@ target_link_libraries(binprojinfo PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(binprojinfo PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS binprojinfo
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(binprojinfo PRIVATE PROJ_MSVC_DLL_IMPORT=1)

--- a/src/bin_projsync.cmake
+++ b/src/bin_projsync.cmake
@@ -14,7 +14,7 @@ if(NLOHMANN_JSON STREQUAL "external")
 endif()
 
 install(TARGETS bin_projsync
-  RUNTIME DESTINATION ${BINDIR})
+  DESTINATION ${BINDIR})
 
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(bin_projsync PRIVATE PROJ_MSVC_DLL_IMPORT=1)


### PR DESCRIPTION
Since a CMake version I can't remember, CMake wants BUNDLE DESTINATION for executables on iOS, RUNTIME DESTINATION is ignored, otherwise configuration fails with:

```
CMake Error at PROJ/src/bin_cct.cmake:14 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "cct".
```

 Therefore it's easier to just use DESTINATION when TARGETS in install() command are executables.