### PR TITLE
CMake: remove external nlohmann_json from INTERFACE_LINK_LIBRARIES target

### DIFF
--- a/src/bin_projsync.cmake
+++ b/src/bin_projsync.cmake
@@ -8,10 +8,6 @@ set_target_properties(bin_projsync
   OUTPUT_NAME projsync)
 target_link_libraries(bin_projsync PRIVATE ${PROJ_LIBRARIES})
 target_compile_options(bin_projsync PRIVATE ${PROJ_CXX_WARN_FLAGS})
-if(NLOHMANN_JSON STREQUAL "external")
-  target_compile_definitions(bin_projsync PRIVATE EXTERNAL_NLOHMANN_JSON)
-  target_link_libraries(bin_projsync PRIVATE nlohmann_json::nlohmann_json)
-endif()
 
 install(TARGETS bin_projsync
   DESTINATION ${BINDIR})

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -399,7 +399,8 @@ target_link_libraries(proj PRIVATE ${SQLITE3_LIBRARY})
 
 if(NLOHMANN_JSON STREQUAL "external")
   target_compile_definitions(proj PRIVATE EXTERNAL_NLOHMANN_JSON)
-  target_link_libraries(proj PRIVATE nlohmann_json::nlohmann_json)
+  target_link_libraries(proj
+    PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 endif()
 
 if(TIFF_ENABLED)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -166,10 +166,6 @@ add_executable(test_defmodel
 target_link_libraries(test_defmodel
   PRIVATE GTest::gtest
   PRIVATE ${PROJ_LIBRARIES})
-if(NLOHMANN_JSON STREQUAL "external")
-  target_compile_definitions(test_defmodel PRIVATE EXTERNAL_NLOHMANN_JSON)
-  target_link_libraries(test_defmodel PRIVATE nlohmann_json::nlohmann_json)
-endif()
 add_test(NAME test_defmodel COMMAND test_defmodel)
 set_property(TEST test_defmodel
   PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})
@@ -180,10 +176,6 @@ add_executable(test_tinshift
 target_link_libraries(test_tinshift
   PRIVATE GTest::gtest
   PRIVATE ${PROJ_LIBRARIES})
-if(NLOHMANN_JSON STREQUAL "external")
-  target_compile_definitions(test_tinshift PRIVATE EXTERNAL_NLOHMANN_JSON)
-  target_link_libraries(test_tinshift PRIVATE nlohmann_json::nlohmann_json)
-endif()
 add_test(NAME test_tinshift COMMAND test_tinshift)
 set_property(TEST test_tinshift
   PROPERTY ENVIRONMENT ${PROJ_TEST_ENVIRONMENT})


### PR DESCRIPTION
It seemed that when external nlohmann_json was enabled, the INTERFACE_LINK_LIBRARIES property from the PROJ::proj CMake target included `$<LINK_ONLY:nlohmann_json::nlohmann_json>`. This causes issues while static linking in downstream projects, and was apparent with some of my contributions to #2686 with projsync and two tests (now removed in this PR). This possible resolution (with the help of [this issue discussion](https://gitlab.kitware.com/cmake/cmake/-/issues/15415)) uses [`$<BUILD_INTERFACE:...>`](https://cmake.org/cmake/help/v3.9/manual/cmake-generator-expressions.7.html):
> Content of ... when the property is exported using export(), or when the target is used by another target in the same buildsystem. Expands to the empty string otherwise.

This fix has been verified locally with a forthcoming post-install suite that includes static linking.

Closes #2762