### PR TITLE
Doc: fix links to :c:func:`proj_...` by specifying "h" as "c" domain

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -411,6 +411,9 @@ texinfo_documents = [
 breathe_projects = {
     "doxygen_api":"../build/xml/",
 }
+breathe_domain_by_extension = {
+    "h" : "c",
+}
 
 import redirects
 redirect_files = redirects.gather_redirects()

--- a/src/proj.h
+++ b/src/proj.h
@@ -559,7 +559,7 @@ PJ PROJ_DLL *proj_create_crs_to_crs_from_pj(PJ_CONTEXT *ctx,
                                             const PJ *target_crs,
                                             PJ_AREA *area,
                                             const char* const *options);
-/*! @endcond Doxygen_Suppress */
+/*! @endcond */
 PJ PROJ_DLL *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj);
 /*! @cond Doxygen_Suppress */
 void PROJ_DLL proj_assign_context(PJ* pj, PJ_CONTEXT* ctx);


### PR DESCRIPTION
Current online docs don't provide navigable links for several functions, e.g. see the second column of [this table](https://proj.org/development/migration.html#function-mapping-from-old-to-new-api) where `proj_normalize_for_visualization()` is specified using `` :c:func:`proj_normalize_for_visualization` ``.

This can be modified by changing [breathe_domain_by_extension](https://breathe.readthedocs.io/en/latest/directives.html#confval-breathe_domain_by_extension) to assume "h" extensions are in the "c" domain (not "cpp" domain).

This change will automatically allow navigable links for many other functions that are currently "unclickable".

One consequence is that some "permalinks" for (e.g.) `proj_normalize_for_visualization` will change from (1) to (2): 

1. https://proj.org/development/reference/functions.html#_CPPv432proj_normalize_for_visualizationP10PJ_CONTEXTPK2PJ
2. https://proj.org/development/reference/functions.html#c.proj_normalize_for_visualization

Also, remove a stray "Doxygen_Suppress" that slipped into the docs (this is the only instance).