### PR TITLE
GeoTIFF grid reading: perf improvements (fixes #2785)

### DIFF
--- a/include/proj/internal/lru_cache.hpp
+++ b/include/proj/internal/lru_cache.hpp
@@ -160,6 +160,21 @@ class Cache {
     keys_.splice(keys_.begin(), keys_, iter->second);
     return iter->second->value;
   }
+
+  /**
+   *	The const reference returned here is only
+   *    guaranteed to be valid till the next insert/delete
+   */
+  const Value* getPtr(const Key& k) {
+    Guard g(lock_);
+    const auto iter = cache_.find(k);
+    if (iter == cache_.end()) {
+      return nullptr;
+    }
+    keys_.splice(keys_.begin(), keys_, iter->second);
+    return &(iter->second->value);
+  }
+
   /**
    * returns a copy of the stored object (if found)
    */

--- a/src/fwd.cpp
+++ b/src/fwd.cpp
@@ -38,9 +38,12 @@
 #define OUTPUT_UNITS P->right
 
 
-static PJ_COORD fwd_prepare (PJ *P, PJ_COORD coo) {
+static void fwd_prepare (PJ *P, PJ_COORD& coo) {
     if (HUGE_VAL==coo.v[0] || HUGE_VAL==coo.v[1] || HUGE_VAL==coo.v[2])
-        return proj_coord_error ();
+    {
+        coo = proj_coord_error ();
+        return;
+    }
 
     /* The helmert datum shift will choke unless it gets a sensible 4D coordinate */
     if (HUGE_VAL==coo.v[2] && P->helmert) coo.v[2] = 0.0;
@@ -56,13 +59,15 @@ static PJ_COORD fwd_prepare (PJ *P, PJ_COORD coo) {
         {
             proj_log_error(P, _("Invalid latitude"));
             proj_errno_set (P, PROJ_ERR_COORD_TRANSFM_INVALID_COORD);
-            return proj_coord_error ();
+            coo = proj_coord_error ();
+            return;
         }
         if (coo.lp.lam > 10  ||  coo.lp.lam < -10)
         {
             proj_log_error(P, _("Invalid longitude"));
             proj_errno_set (P, PROJ_ERR_COORD_TRANSFM_INVALID_COORD);
-            return proj_coord_error ();
+            coo = proj_coord_error ();
+            return;
         }
 
 
@@ -89,7 +94,7 @@ static PJ_COORD fwd_prepare (PJ *P, PJ_COORD coo) {
             coo = proj_trans (P->cart,       PJ_INV, coo); /* Go back to angular using local ellps */
         }
         if (coo.lp.lam==HUGE_VAL)
-            return coo;
+            return;
         if (P->vgridshift)
             coo = proj_trans (P->vgridshift, PJ_FWD, coo); /* Go orthometric from geometric */
 
@@ -100,18 +105,18 @@ static PJ_COORD fwd_prepare (PJ *P, PJ_COORD coo) {
         if (0==P->over)
             coo.lp.lam = adjlon(coo.lp.lam);
 
-        return coo;
+        return;
     }
 
 
     /* We do not support gridshifts on cartesian input */
     if (INPUT_UNITS==PJ_IO_UNITS_CARTESIAN && P->helmert)
-            return proj_trans (P->helmert, PJ_INV, coo);
-    return coo;
+            coo = proj_trans (P->helmert, PJ_INV, coo);
+    return;
 }
 
 
-static PJ_COORD fwd_finalize (PJ *P, PJ_COORD coo) {
+static void fwd_finalize (PJ *P, PJ_COORD& coo) {
 
     switch (OUTPUT_UNITS) {
 
@@ -161,29 +166,28 @@ static PJ_COORD fwd_finalize (PJ *P, PJ_COORD coo) {
 
     if (P->axisswap)
         coo = proj_trans (P->axisswap, PJ_FWD, coo);
-
-    return coo;
 }
 
 
-static PJ_COORD error_or_coord(PJ *P, PJ_COORD coord, int last_errno) {
-    if (proj_errno(P))
+static inline PJ_COORD error_or_coord(PJ *P, PJ_COORD coord, int last_errno) {
+    if (P->ctx->last_errno)
         return proj_coord_error();
 
-    proj_errno_restore(P, last_errno);
+    P->ctx->last_errno = last_errno;
+
     return coord;
 }
 
 
 PJ_XY pj_fwd(PJ_LP lp, PJ *P) {
-    int last_errno;
     PJ_COORD coo = {{0,0,0,0}};
     coo.lp = lp;
 
-    last_errno = proj_errno_reset(P);
+    const int last_errno = P->ctx->last_errno;
+    P->ctx->last_errno = 0;
 
     if (!P->skip_fwd_prepare)
-        coo = fwd_prepare (P, coo);
+        fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0] || HUGE_VAL==coo.v[1])
         return proj_coord_error ().xy;
 
@@ -202,7 +206,7 @@ PJ_XY pj_fwd(PJ_LP lp, PJ *P) {
         return proj_coord_error ().xy;
 
     if (!P->skip_fwd_finalize)
-        coo = fwd_finalize (P, coo);
+        fwd_finalize (P, coo);
 
     return error_or_coord(P, coo, last_errno).xy;
 }
@@ -210,14 +214,14 @@ PJ_XY pj_fwd(PJ_LP lp, PJ *P) {
 
 
 PJ_XYZ pj_fwd3d(PJ_LPZ lpz, PJ *P) {
-    int last_errno;
     PJ_COORD coo = {{0,0,0,0}};
     coo.lpz = lpz;
 
-    last_errno = proj_errno_reset(P);
+    const int last_errno = P->ctx->last_errno;
+    P->ctx->last_errno = 0;
 
     if (!P->skip_fwd_prepare)
-        coo = fwd_prepare (P, coo);
+        fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ().xyz;
 
@@ -236,7 +240,7 @@ PJ_XYZ pj_fwd3d(PJ_LPZ lpz, PJ *P) {
         return proj_coord_error ().xyz;
 
     if (!P->skip_fwd_finalize)
-        coo = fwd_finalize (P, coo);
+        fwd_finalize (P, coo);
 
     return error_or_coord(P, coo, last_errno).xyz;
 }
@@ -244,10 +248,12 @@ PJ_XYZ pj_fwd3d(PJ_LPZ lpz, PJ *P) {
 
 
 PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
-    int last_errno = proj_errno_reset(P);
+
+    const int last_errno = P->ctx->last_errno;
+    P->ctx->last_errno = 0;
 
     if (!P->skip_fwd_prepare)
-        coo = fwd_prepare (P, coo);
+        fwd_prepare (P, coo);
     if (HUGE_VAL==coo.v[0])
         return proj_coord_error ();
 
@@ -266,7 +272,7 @@ PJ_COORD pj_fwd4d (PJ_COORD coo, PJ *P) {
         return proj_coord_error ();
 
     if (!P->skip_fwd_finalize)
-        coo = fwd_finalize (P, coo);
+        fwd_finalize (P, coo);
 
     return error_or_coord(P, coo, last_errno);
 }

--- a/src/grids.hpp
+++ b/src/grids.hpp
@@ -45,6 +45,10 @@ struct ExtentAndRes {
     double north;      // in radian for geographic, in CRS units otherwise
     double resX;       // in radian for geographic, in CRS units otherwise
     double resY;       // in radian for geographic, in CRS units otherwise
+    double invResX;    // = 1 / resX;
+    double invResY;    // = 1 / resY;
+
+    void computeInvRes();
 
     bool fullWorldLongitude() const;
     bool contains(const ExtentAndRes &other) const;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -918,6 +918,7 @@ void pj_acquire_lock(void);
 void pj_release_lock(void);
 void pj_cleanup_lock(void);
 
+bool pj_log_active( PJ_CONTEXT *ctx, int level );
 void pj_log( PJ_CONTEXT * ctx, int level, const char *fmt, ... );
 void pj_stderr_logger( void *, int, const char * );
 

--- a/src/proj_symbol_rename.h
+++ b/src/proj_symbol_rename.h
@@ -71,6 +71,7 @@
 #define pj_is_latlong internal_pj_is_latlong
 #define pj_latlong_from_proj internal_pj_latlong_from_proj
 #define pj_log internal_pj_log
+#define pj_log_active internal_pj_log_active
 #define pj_malloc internal_pj_malloc
 #define pj_open_lib internal_pj_open_lib
 #define pj_pr_list internal_pj_pr_list


### PR DESCRIPTION
With this commit, and the 2 previous ones, given mytest.cpp
```

int main()
{
    PJ* pj = proj_create(nullptr, "+proj=vgridshift +grids=us_nga_egm96_15.tif");
    for( int i = 0; i < 5*1000*1000; i++)
    {
        PJ_COORD coord;
        coord.lpz.lam = 0;
        coord.lpz.phi = 0;
        coord.lpz.z = 0;
        proj_trans(pj, PJ_FWD, coord);
    }
    return 0;
}
```

we get a x2 speedup

Before:
```
$ PROJ_LIB=data:$HOME/proj/PROJ-data/us_nga LD_LIBRARY_PATH=src/.libs  hyperfine --warmup 1 'taskset -c 11 ./mytest'
Benchmark #1: taskset -c 11 ./mytest
  Time (mean ± σ):      1.950 s ±  0.014 s    [User: 1.945 s, System: 0.005 s]
  Range (min … max):    1.937 s …  1.971 s
```

After:
```
$ PROJ_LIB=data:$HOME/proj/PROJ-data/us_nga LD_LIBRARY_PATH=src/.libs  hyperfine --warmup 1 'taskset -c 11 ./mytest'
Benchmark #1: taskset -c 11 ./mytest
  Time (mean ± σ):     984.4 ms ±   3.1 ms    [User: 977.0 ms, System: 7.2 ms]
  Range (min … max):   979.3 ms … 990.5 ms
```
