### PR TITLE
cmake: remove unused configure checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,6 @@ endif()
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
 
-include(CheckIncludeFiles)
-
 include(CheckCSourceCompiles)
 if(MSVC)
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX /W4")

--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -7,28 +7,14 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # https://www.boost.org/LICENSE_1_0.txt)
 ################################################################################
-include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckFunctionExists)
 
 # check needed include file
-check_include_files(dlfcn.h HAVE_DLFCN_H)
-check_include_files(inttypes.h HAVE_INTTYPES_H)
-check_include_files(memory.h HAVE_MEMORY_H)
-check_include_files(stdint.h HAVE_STDINT_H)
-check_include_files(stdlib.h HAVE_STDLIB_H)
-check_include_files(string.h HAVE_STRING_H)
-check_include_files(sys/stat.h HAVE_SYS_STAT_H)
-check_include_files(sys/types.h HAVE_SYS_TYPES_H)
-check_include_files(unistd.h HAVE_UNISTD_H)
-check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
-
 check_function_exists(localeconv HAVE_LOCALECONV)
 check_function_exists(strerror HAVE_STRERROR)
 if(NOT WIN32)
     check_library_exists(dl dladdr "" HAVE_LIBDL)
-    # check libm need on unix
-    check_library_exists(m ceil "" HAVE_LIBM)
 endif()
 
 set(PACKAGE "proj")

--- a/cmake/proj_config.cmake.in
+++ b/cmake/proj_config.cmake.in
@@ -1,44 +1,11 @@
-/* Define to 1 if you have the <dlfcn.h> header file. */
-#cmakedefine HAVE_DLFCN_H 1
-
-/* Define to 1 if you have the <inttypes.h> header file. */
-#cmakedefine HAVE_INTTYPES_H 1
-
 /* Define to 1 if you have the `dl' library (-ldl). */
 #cmakedefine HAVE_LIBDL 1
-
-/* Define to 1 if you have the `m' library (-lm). */
-#cmakedefine HAVE_LIBM 1
 
 /* Define to 1 if you have localeconv */
 #cmakedefine HAVE_LOCALECONV 1
 
-/* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#cmakedefine HAVE_STDINT_H 1
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#cmakedefine HAVE_STDLIB_H 1
-
 /* Define to 1 if you have the `strerror' function. */
 #cmakedefine HAVE_STRERROR 1
-
-/* Define to 1 if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H 1
-
-/* Define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H 1
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#cmakedefine HAVE_SYS_STAT_H 1
-
-/* Define to 1 if you have the <sys/types.h> header file. */
-#cmakedefine HAVE_SYS_TYPES_H 1
-
-/* Define to 1 if you have the <unistd.h> header file. */
-#cmakedefine HAVE_UNISTD_H 1
 
 /* Name of package */
 #cmakedefine PACKAGE "${PACKAGE}"
@@ -57,9 +24,6 @@
 
 /* Define to the version of this package. */
 #cmakedefine PACKAGE_VERSION "${PACKAGE_VERSION}"
-
-/* Define to 1 if you have the ANSI C header files. */
-#cmakedefine STDC_HEADERS 1
 
 /* Version number of package */
 #cmakedefine VERSION "${VERSION}"


### PR DESCRIPTION
These results are just not used anywhere, so there's no need to check
them (as the compiler will do it anyways).

 - [x] Added clear title that can be used to generate release notes