### PR TITLE
Add support for Degree Sign on input

### DIFF
--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -261,7 +261,7 @@ The following script
 ::
 
     cs2cs +proj=latlong +datum=NAD83 +to +proj=utm +zone=10 +datum=NAD27 -r <<EOF
-    45d15'33.1" 111.5W
+    45°15'33.1" 111.5W
     45d15.551666667N -111d30
     +45.25919444444 111d30'000w
     EOF

--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -29,7 +29,7 @@ dmstor(const char *is, char **rs) {
 dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 	int n, nl, adv;
 	char *s, work[MAX_WORK];
-        const char* p;
+	const char* p;
 	double v, tv;
 
 	if (rs)
@@ -39,11 +39,18 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 	n = MAX_WORK;
 	s = work;
 	p = (char *)is;
+
+	/*
+	 * Copy characters into work until we hit a non-printable character or run
+	 * out of space in the buffer.  Make a special exception for the bytes 0xc2
+	 * and 0xb0, because they comprise Degree Sign U+00B0 in UTF-8.
+	 *
+	 * It is possible that a really odd input (like lots of leading zeros)
+	 * could be truncated in copying into work.  But ...
+	 */
 	while ((isgraph(*p) || *p == (char) 0xc2 || *p == (char) 0xb0) && --n)
 		*s++ = *p++;
 	*s = '\0';
-	/* it is possible that a really odd input (like lots of leading
-		zeros) could be truncated in copying into work.  But ... */
 	int sign = *(s = work);
 	if (sign == '+' || sign == '-') s++;
 	else sign = '+';

--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -67,7 +67,12 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 			return tv;
 		int adv = 1;
 
-		if (*s == 'D' || *s == 'd') {
+		if (*s == 'D' || *s == 'd' || *s == DEG_SIGN2) {
+			/*
+			 * Accept \xb0 as a single-byte degree symbol. This byte is the
+			 * degree symbol in various single-byte encodings: multiple ISO
+			 * 8859 parts, several Windows code pages and others.
+			 */
 			n = 0;
 		} else if (*s == '\'') {
 			n = 1;

--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -60,33 +60,32 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 		if ((tv = proj_strtod(s, &s)) == HUGE_VAL)
 			return tv;
 		adv = 1;
-		switch (*s) {
-		case 'D': case 'd':
-			n = 0; break;
-		case '\'':
-			n = 1; break;
-		case '"':
-			n = 2; break;
-		/* degree symbol ("\xc2\xb0" in UTF-8) */
-		case (char) 0xc2:
-			if (s[1] == (char) 0xb0) {
-				n = 0;
-				adv = 2;
-				break;
-			}
-		case 'r': case 'R':
+
+		if (*s == 'D' || *s == 'd') {
+			n = 0;
+		} else if (*s == '\'') {
+			n = 1;
+		} else if (*s == '"') {
+			n = 2;
+		} else if (s[0] == (char) 0xc2 && s[1] == (char) 0xb0) {
+			/* degree symbol ("\xc2\xb0" in UTF-8) */
+			n = 0;
+			adv = 2;
+		} else if (*s == 'r' || *s == 'R') {
 			if (nl) {
 				proj_context_errno_set( ctx, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE );
 				return HUGE_VAL;
 			}
 			++s;
 			v = tv;
-			goto skip;
-		default:
+			n = 4;
+			continue;
+		} else {
 			v += tv * vm[nl];
-		skip:	n = 4;
+			n = 4;
 			continue;
 		}
+
 		if (n < nl) {
 			proj_context_errno_set( ctx, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE );
 			return HUGE_VAL;

--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -20,6 +20,12 @@ vm[] = {
 	.0002908882086657216,
 	.0000048481368110953599
 };
+/* byte sequence for Degree Sign U+00B0 in UTF-8. */
+	static constexpr char
+DEG_SIGN1 = '\xc2';
+	static constexpr char
+DEG_SIGN2 = '\xb0';
+
 	double
 dmstor(const char *is, char **rs) {
 	return dmstor_ctx( pj_get_default_ctx(), is, rs );
@@ -42,13 +48,13 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 
 	/*
 	 * Copy characters into work until we hit a non-printable character or run
-	 * out of space in the buffer.  Make a special exception for the bytes 0xc2
-	 * and 0xb0, because they comprise Degree Sign U+00B0 in UTF-8.
+	 * out of space in the buffer.  Make a special exception for the bytes of
+	 * the Degree Sign in UTF-8.
 	 *
 	 * It is possible that a really odd input (like lots of leading zeros)
 	 * could be truncated in copying into work.  But ...
 	 */
-	while ((isgraph(*p) || *p == (char) 0xc2 || *p == (char) 0xb0) && --n)
+	while ((isgraph(*p) || *p == DEG_SIGN1 || *p == DEG_SIGN2) && --n)
 		*s++ = *p++;
 	*s = '\0';
 	int sign = *(s = work);
@@ -67,8 +73,8 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 			n = 1;
 		} else if (*s == '"') {
 			n = 2;
-		} else if (s[0] == (char) 0xc2 && s[1] == (char) 0xb0) {
-			/* degree symbol ("\xc2\xb0" in UTF-8) */
+		} else if (s[0] == DEG_SIGN1 && s[1] == DEG_SIGN2) {
+			/* degree symbol in UTF-8 */
 			n = 0;
 			adv = 2;
 		} else if (*s == 'r' || *s == 'R') {

--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -33,7 +33,7 @@ dmstor(const char *is, char **rs) {
 
 	double
 dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
-	int n, nl, adv;
+	int n, nl;
 	char *s, work[MAX_WORK];
 	const char* p;
 	double v, tv;
@@ -65,7 +65,7 @@ dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
 		if (!(isdigit(*s) || *s == '.')) break;
 		if ((tv = proj_strtod(s, &s)) == HUGE_VAL)
 			return tv;
-		adv = 1;
+		int adv = 1;
 
 		if (*s == 'D' || *s == 'd') {
 			n = 0;

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -442,6 +442,9 @@ TEST(gie, info_functions) {
     /* we can't expect perfect numerical accuracy so testing with a tolerance */
     ASSERT_NEAR(-2.0, proj_dmstor(&buf[0], NULL), 1e-7);
 
+    /* test degree sign on DMS input */
+    ASSERT_NEAR(0.34512432, proj_dmstor("19°46'27\"E", NULL), 1e-7);
+
     /* test proj_derivatives_retrieve() and proj_factors_retrieve() */
     P = proj_create(PJ_DEFAULT_CTX, "+proj=merc +ellps=WGS84");
     a = proj_coord(0, 0, 0, 0);

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -446,7 +446,7 @@ TEST(gie, info_functions) {
     ASSERT_NEAR(0.34512432, proj_dmstor("19°46'27\"E", NULL), 1e-7);
 
     /* test ISO 8859-1, cp1252, et al. degree sign on DMS input */
-    ASSERT_NEAR(0.34512432, proj_dmstor("19\26046'27\"E", NULL), 1e-7);
+    ASSERT_NEAR(0.34512432, proj_dmstor("19" "\260" "46'27\"E", NULL), 1e-7);
 
     /* test proj_derivatives_retrieve() and proj_factors_retrieve() */
     P = proj_create(PJ_DEFAULT_CTX, "+proj=merc +ellps=WGS84");

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -442,8 +442,11 @@ TEST(gie, info_functions) {
     /* we can't expect perfect numerical accuracy so testing with a tolerance */
     ASSERT_NEAR(-2.0, proj_dmstor(&buf[0], NULL), 1e-7);
 
-    /* test degree sign on DMS input */
+    /* test UTF-8 degree sign on DMS input */
     ASSERT_NEAR(0.34512432, proj_dmstor("19°46'27\"E", NULL), 1e-7);
+
+    /* test ISO 8859-1, cp1252, et al. degree sign on DMS input */
+    ASSERT_NEAR(0.34512432, proj_dmstor("19\26046'27\"E", NULL), 1e-7);
 
     /* test proj_derivatives_retrieve() and proj_factors_retrieve() */
     P = proj_create(PJ_DEFAULT_CTX, "+proj=merc +ellps=WGS84");


### PR DESCRIPTION
This PR adds support in dsmtor() for a Degree Sign (U+00B0), encoded
as UTF-8 (`\xc2\xb0`), as an alternative symbol to `D`/`d` to designate
the degree unit.

No encodings other than UTF-8 are supported.

I had previously suggested in #2712 that I was willing to take a swing at this, for UTF-8 only, and nobody jumped in to dissuade me, so here goes.

I also correct a typo in a code comment and some fix some rogue whitespace on the way past.

I have added a test to test/unit/gie_self_test, but I wasn't able to run a clean red/green on the new test, due to an unrelated failure earlier in the same test block (line 411, currently failing on 'master').  My new test does pass if I comment out those failing tests.  As an aside, it would probably be a good idea to break this block up into smaller units that can run independently of each other.

As for the documentation, I have tweaked one of the examples in the `cs2cs` docs to demonstrate use of the degrees sign, but I didn't see anywhere in the docs that we give a general description of allowed DMS formats.  If I've missed it, or there is anywhere else in the docs that should be updated for this change, please let me know.  It's my first time offering a PR to this project so please do be gentle.

Cheers,
Brendan

Fixes #2712.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2712
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API