### PR TITLE
ConcatenatedOperation::fixStepsDirection(): fix bad chaining of steps…

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -7425,6 +7425,8 @@ const std::string &PROJStringFormatter::toString() const {
         } else if (step.name == "pop" && step.inverted) {
             step.name = "push";
             step.inverted = false;
+        } else if (step.name == "noop" && d->steps_.size() > 1) {
+            iter = d->steps_.erase(iter);
         } else {
             ++iter;
         }


### PR DESCRIPTION
… when inverse map projection is involved in non-final step (fixes #2817)
