### PR TITLE
proj.pc.in: add -lm -ldl in Libs.private

### DIFF
--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -15,6 +15,7 @@ check_function_exists(localeconv HAVE_LOCALECONV)
 check_function_exists(strerror HAVE_STRERROR)
 if(NOT WIN32)
     check_library_exists(dl dladdr "" HAVE_LIBDL)
+    check_library_exists(m exp "" HAVE_LIBM)
 endif()
 
 set(PACKAGE "proj")

--- a/cmake/ProjUtilities.cmake
+++ b/cmake/ProjUtilities.cmake
@@ -83,6 +83,16 @@ function(configure_proj_pc)
   if(CURL_ENABLED)
     set(CURL_LIBS -lcurl)
   endif()
+  set(EXTRA_LIBS "-lstdc++")
+  if(HAVE_LIBM)
+    list(APPEND EXTRA_LIBS "-lm")
+  endif()
+  if(HAVE_LIBDL)
+    list(APPEND EXTRA_LIBS "-ldl")
+  endif()
+  # Join list with a space
+  string(REPLACE ";" " " _tmp_str "${EXTRA_LIBS}")
+  set(EXTRA_LIBS "${_tmp_str}")
 
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/proj.pc.in

--- a/configure.ac
+++ b/configure.ac
@@ -181,7 +181,7 @@ esac
 dnl Checks for libraries.
 save_CFLAGS="$CFLAGS"
 CFLAGS=`echo "$CFLAGS" | sed "s/-Werror/ /"`
-AC_CHECK_LIB(m,exp,,,)
+AC_CHECK_LIB(m,exp,,HAVE_LIBM=no,)
 CFLAGS="$save_CFLAGS"
 
 dnl We check for headers
@@ -198,7 +198,7 @@ AC_SEARCH_LIBS([sqrt], [m])
 
 AC_CHECK_FUNC(localeconv, [AC_DEFINE(HAVE_LOCALECONV,1,[Define to 1 if you have localeconv])])
 AC_CHECK_FUNCS([strerror])
-AC_CHECK_LIB(dl,dladdr,,,)
+AC_CHECK_LIB(dl,dladdr,,HAVE_LIBDL=no,)
 
 dnl ---------------------------------------------------------------------------
 dnl Provide a mechanism to disable real mutex support (if lacking win32 or
@@ -321,6 +321,18 @@ AC_SUBST(CURL_LIBS,$CURL_LIBS)
 AC_SUBST(CURL_ENABLED_FLAGS,$CURL_ENABLED_FLAGS)
 AM_CONDITIONAL(HAVE_CURL, [test "x$FOUND_CURL" = "xyes"])
 
+dnl ---------------------------------------------------------------------------
+dnl Check for extra libraries, required for static linking with pkg-config
+dnl ---------------------------------------------------------------------------
+
+EXTRA_LIBS="-lstdc++"
+if test "$HAVE_LIBM" != "no" ; then
+  EXTRA_LIBS="$EXTRA_LIBS -lm"
+fi
+if test "$HAVE_LIBDL" != "no" ; then
+  EXTRA_LIBS="$EXTRA_LIBS -ldl"
+fi
+AC_SUBST(EXTRA_LIBS,$EXTRA_LIBS)
 
 dnl ---------------------------------------------------------------------------
 dnl proj-lib-env-var-tried-last

--- a/proj.pc.in
+++ b/proj.pc.in
@@ -10,5 +10,5 @@ Description: Coordinate transformation software library
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj
-Libs.private: @SQLITE3_LIBS@ @TIFF_LIBS@ @CURL_LIBS@ -lstdc++
+Libs.private: @SQLITE3_LIBS@ @TIFF_LIBS@ @CURL_LIBS@ @EXTRA_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This fixes static linking using `pkg-config proj --libs --static`

Note there currently isn't any coverage for this type of test, but I've been refactoring the postinstall suite locally, which isn't ready yet (preview at https://github.com/mwtoews/PROJ/tree/postinstall2)