### PR TITLE
pj_obj_create(): avoid passing invalid ellipsoid parameters ot pj_calc_ellipsoid_params()

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -222,6 +222,13 @@ static PJ *pj_obj_create(PJ_CONTEXT *ctx, const IdentifiedObjectNNPtr &objIn) {
                     const auto &ellps = geodCRS->ellipsoid();
                     const double a = ellps->semiMajorAxis().getSIValue();
                     const double es = ellps->squaredEccentricity();
+                    if (!(a > 0 && es >= 0)) {
+                        proj_log_error(pj, _("Invalid ellipsoid parameters"));
+                        proj_errno_set(pj,
+                                       PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE);
+                        proj_destroy(pj);
+                        return nullptr;
+                    }
                     pj_calc_ellipsoid_params(pj, a, es);
                     assert(pj->geod == nullptr);
                     pj->geod = static_cast<struct geod_geodesic *>(

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -346,6 +346,32 @@ TEST_F(CApi, proj_create_from_wkt) {
         ObjectKeeper keeper(obj);
         EXPECT_NE(obj, nullptr);
     }
+    {
+        // Invalid ellipsoidal parameter (semi major axis)
+        auto obj = proj_create_from_wkt(
+            m_ctxt,
+            "GEOGCS[\"test\",\n"
+            "    DATUM[\"test\",\n"
+            "        SPHEROID[\"test\",0,298.257223563,\"unused\"]],\n"
+            "    PRIMEM[\"Greenwich\",0],\n"
+            "    UNIT[\"degree\",0.0174532925199433]]",
+            nullptr, nullptr, nullptr);
+        ObjectKeeper keeper(obj);
+        EXPECT_EQ(obj, nullptr);
+    }
+    {
+        // Invalid ellipsoidal parameter (inverse flattening)
+        auto obj = proj_create_from_wkt(
+            m_ctxt,
+            "GEOGCS[\"test\",\n"
+            "    DATUM[\"test\",\n"
+            "        SPHEROID[\"test\",6378137,-1,\"unused\"]],\n"
+            "    PRIMEM[\"Greenwich\",0],\n"
+            "    UNIT[\"degree\",0.0174532925199433]]",
+            nullptr, nullptr, nullptr);
+        ObjectKeeper keeper(obj);
+        EXPECT_EQ(obj, nullptr);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31964