### PR TITLE
Add some filename lint #2838 to output error messages

### DIFF
--- a/src/grids.cpp
+++ b/src/grids.cpp
@@ -1403,7 +1403,7 @@ VerticalShiftGridSet::open(PJ_CONTEXT *ctx, const std::string &filename) {
 #endif
     }
 
-    pj_log(ctx, PJ_LOG_ERROR, _("Unrecognized vertical grid format"));
+    pj_log(ctx, PJ_LOG_ERROR, "Unrecognized vertical grid format for filename '%s'", filename.c_str());
     return nullptr;
 }
 
@@ -2399,7 +2399,7 @@ HorizontalShiftGridSet::open(PJ_CONTEXT *ctx, const std::string &filename) {
 #endif
     }
 
-    pj_log(ctx, PJ_LOG_ERROR, _("Unrecognized horizontal grid format"));
+    pj_log(ctx, PJ_LOG_ERROR, "Unrecognized horizontal grid format for filename '%s'", filename.c_str());
     return nullptr;
 }
 
@@ -2735,7 +2735,7 @@ GenericShiftGridSet::open(PJ_CONTEXT *ctx, const std::string &filename) {
 #endif
     }
 
-    pj_log(ctx, PJ_LOG_ERROR, _("Unrecognized generic grid format"));
+    pj_log(ctx, PJ_LOG_ERROR, "Unrecognized generic grid format for filename '%s'", filename.c_str());
     return nullptr;
 }
 


### PR DESCRIPTION
Some filename hints so the user has an idea which grids are failing.