### PR TITLE
Update docs About page to pull in license text from COPYING.

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -26,4 +26,4 @@ was moved under the MIT license. The full text of the license follows, and can
 also be found in the file ``COPYING``, at the top level of the source
 distribution package.
 
-.. include:: ../../COPYING
+.. literalinclude:: ../../COPYING

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -22,25 +22,8 @@ License
 
 PROJ uses the MIT license. The software was initially released by the USGS in
 the public domain. When Frank Warmerdam took over the development of PROJ it
-was moved under the MIT license. The license is as follows:
+was moved under the MIT license. The full text of the license follows, and can
+also be found in the file ``COPYING``, at the top level of the source
+distribution package.
 
-     Copyright (c) 2000, Frank Warmerdam
-
-     Permission is hereby granted, free of charge, to any person obtaining a
-     copy of this software and associated documentation files (the "Software"),
-     to deal in the Software without restriction, including without limitation
-     the rights to use, copy, modify, merge, publish, distribute, sublicense,
-     and/or sell copies of the Software, and to permit persons to whom the
-     Software is furnished to do so, subject to the following conditions:
-
-     The above copyright notice and this permission notice shall be included
-     in all copies or substantial portions of the Software.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-     THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-     DEALINGS IN THE SOFTWARE.
-
+.. include:: ../../COPYING


### PR DESCRIPTION
In response to issue #2709 which points out that the license information on the About page is outdated compared to COPYING in the source code.  This commit updates the text introducing the license, and pulls the license itself in directly from COPYING, just as it does for CITATION.

This change looks sensible to me, but I haven't been able to prove that it builds correctly yet.  Getting the docs to build on my Mac has turned out to be surprisingly difficult.

Fixes #2709.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2709 
 - [x] Added clear title that can be used to generate release notes
