### PR TITLE
DOC: fix the inclusion of the custom css file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,6 +196,10 @@ html_favicon = '../images/favicon.png'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+htm_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+]
+
 html_context = {
     'display_github': True,
     'theme_vcs_pageview_mode': 'edit',
@@ -203,9 +207,6 @@ html_context = {
     'github_repo': 'PROJ',
     # TODO: edit when switching active branch
     'github_version': '/8.0/docs/source/',
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-    ],
 }
 
 # Add any extra paths that contain custom files (such as robots.txt or


### PR DESCRIPTION
See mailing list message about broken css of proj.org. It seems that the readthedoc theme's css was no longer included in the `<head>` (only the css overrides of proj itself). Might be triggered due to changes in sphinx_rtd_theme 1.0, which was just released, but didn't verify that.

I _think_ this patch fixes that (because sphinx puts the parent theme's css in `css_files`, and thus the conf.py overrides this. And starting with sphinx_rtd_theme, it only relies on that https://github.com/readthedocs/sphinx_rtd_theme/commit/836467e4b92d7de5506dd8f996d87a7fc56d0b5d), and in any case it now includes the custom css as documented by rtd (https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html)