### PR TITLE
doc: clarify use of +datum option with +proj=latlon

### DIFF
--- a/docs/source/operations/conversions/latlon.rst
+++ b/docs/source/operations/conversions/latlon.rst
@@ -30,8 +30,15 @@ However, the parameters below can be used in a declarative manner when used with
 
 .. option:: +datum=<value>
 
-    Declare the datum used with the coordinates. See ``cs2cs -ld`` for a
-    list of available datums.
+    Declare the datum used with the coordinates. Available options are:
+    ``WGS84``, ``GGRS87``, ``NAD38``, ``NAD27``, ``potsdam``, ``carthage``,
+    ``hermannskogel``, ``ire65``, ``nzgd49``, ``OSGB336``.
+
+    .. note::
+
+        The ``+datum`` option is primarily available to support the legacy
+        use of PROJ.4 strings as CRS descriptors and should in most cases
+        be avoided.
 
 .. option:: +towgs84=<list>
 


### PR DESCRIPTION
In relation to https://lists.osgeo.org/pipermail/proj/2021-September/010357.html