### PR TITLE
CMake: add a BUILD_APPS to be able to disable build of all applications

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -322,33 +322,43 @@ CMake configure options
 Options to configure a CMake are provided using ``-D<var>=<value>``.
 All cached entries can be viewed using ``cmake -LAH`` from a build directory.
 
+.. option:: BUILD_APPS=ON
+
+    Build PROJ applications. Default is ON. Control the default value for
+    BUILD_CCT, BUILD_CS2CS, BUILD_GEOD, BUILD_GIE, BUILD_PROJ, BUILD_PROJINFO
+    and BUILD_PROJSYNC.
+    Note that changing its value after having configured once will not change
+    the value of the individual BUILD_CCT, ... options.
+
+    .. versionchanged:: 8.2
+
 .. option:: BUILD_CCT=ON
 
-    Build :ref:`cct`, default ON.
+    Build :ref:`cct`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_CS2CS=ON
 
-    Build :ref:`cs2cs`, default ON.
+    Build :ref:`cs2cs`,default is the value of BUILD_APPS.
 
 .. option:: BUILD_GEOD=ON
 
-    Build :ref:`geod`, default ON.
+    Build :ref:`geod`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_GIE=ON
 
-    Build :ref:`gie`, default ON.
+    Build :ref:`gie`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_PROJ=ON
 
-    Build :ref:`proj`, default ON.
+    Build :ref:`proj`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_PROJINFO=ON
 
-    Build :ref:`projinfo`, default ON.
+    Build :ref:`projinfo`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_PROJSYNC=ON
 
-    Build :ref:`projsync`, default ON.
+    Build :ref:`projsync`, default is the value of BUILD_APPS.
 
 .. option:: BUILD_SHARED_LIBS
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,20 +3,23 @@
 include(lib_proj.cmake)
 
 # configure executable build
+option(BUILD_APPS
+  "Build PROJ applications (default value for BUILD_CCT, BUILD_CS2CS, etc.)" ON)
+
 option(BUILD_CCT
-  "Build cct (coordinate conversion and transformation tool)" ON)
+  "Build cct (coordinate conversion and transformation tool)" "${BUILD_APPS}")
 option(BUILD_CS2CS
-  "Build cs2cs (coordinate systems to coordinate systems translation tool)" ON)
+  "Build cs2cs (coordinate systems to coordinate systems translation tool)" "${BUILD_APPS}")
 option(BUILD_GEOD
-  "Build geod (computation of geodesic lines)" ON)
+  "Build geod (computation of geodesic lines)" "${BUILD_APPS}")
 option(BUILD_GIE
-  "Build gie (geospatial integrity investigation environment)" ON)
+  "Build gie (geospatial integrity investigation environment)" "${BUILD_APPS}")
 option(BUILD_PROJ
-  "Build proj (cartographic projection tool)" ON)
+  "Build proj (cartographic projection tool)" "${BUILD_APPS}")
 option(BUILD_PROJINFO
-  "Build projinfo (SRS and coordinate operation metadata/query tool)" ON)
+  "Build projinfo (SRS and coordinate operation metadata/query tool)" "${BUILD_APPS}")
 option(BUILD_PROJSYNC
-  "Build projsync (synchronize transformation support data)" ON)
+  "Build projsync (synchronize transformation support data)" "${BUILD_APPS}")
 
 if(NOT MSVC)
 


### PR DESCRIPTION
This makes it easier to turn off all programs, rather than individually.
Useful for example to avoid https://github.com/OSGeo/gdal/blob/master/gdal/fuzzers/build.sh#L138
