### PR TITLE
add fallback strategy for tinshift transform to use closest triangle for points not in any

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -129,6 +129,8 @@ EXTRA_DIST = proj.ini GL27 nad.lst nad27 nad83 \
 		tests/tinshift_crs_implicit.json \
 		tests/tinshift_simplified_kkj_etrs.json \
 		tests/tinshift_simplified_n60_n2000.json \
+		tests/tinshift_fallback_nearest_side.json \
+		tests/tinshift_fallback_nearest_centroid.json \
 		generate_proj_db.cmake sql_filelist.cmake \
 		$(SQL_ORDERED_LIST)
 

--- a/data/tests/tinshift_fallback_nearest_centroid.json
+++ b/data/tests/tinshift_fallback_nearest_centroid.json
@@ -1,0 +1,17 @@
+{
+  "file_type": "triangulation_file",
+  "format_version": "1.1",
+  "fallback_strategy": "nearest_centroid",
+  "transformed_components": [ "horizontal" ],
+  "vertices_columns": [ "source_x", "source_y", "target_x", "target_y" ],
+  "triangles_columns": [ "idx_vertex1", "idx_vertex2", "idx_vertex3" ],
+  "vertices": [
+	  [0, 0, 0, 0],
+	  [1, 0, 1, 0],
+	  [1, 1, 1, 1],
+	  [4, 0, 100, 0],
+	  [100, 0, 100, 1],
+	  [100, 1, 4, 0]
+  ],
+  "triangles": [ [0, 1, 2], [3, 4, 5] ]
+}

--- a/data/tests/tinshift_fallback_nearest_side.json
+++ b/data/tests/tinshift_fallback_nearest_side.json
@@ -1,0 +1,15 @@
+{
+  "file_type": "triangulation_file",
+  "format_version": "1.1",
+  "fallback_strategy": "nearest_side",
+  "transformed_components": [ "horizontal" ],
+  "vertices_columns": [ "source_x", "source_y", "target_x", "target_y" ],
+  "triangles_columns": [ "idx_vertex1", "idx_vertex2", "idx_vertex3" ],
+  "vertices": [
+	  [0, 0, 0, 0],
+	  [1, 0, 2, 0],
+	  [1, 1, 2, 2],
+	  [0, 1, 0, 2]
+  ],
+  "triangles": [ [0, 1, 2], [0, 2, 3] ]
+}

--- a/data/triangulation.schema.json
+++ b/data/triangulation.schema.json
@@ -13,7 +13,7 @@
     "format_version": {
       "type": "string",
       "enum": [
-        "1.0"
+        "1.0", "1.1"
       ]
     },
     "name": {
@@ -27,6 +27,14 @@
     "publication_date": {
       "$ref": "#/definitions/datetime",
       "description": "The date on which this version of the triangulation was published (or possibly the date on which it takes effect?)"
+    },
+    "fallback_strategy": {
+      "type": "string",
+      "enum": [
+        "none",
+        "nearest_side",
+        "nearest_centroid"
+      ]
     },
     "license": {
       "type": "string",

--- a/docs/source/operations/transformations/tinshift.rst
+++ b/docs/source/operations/transformations/tinshift.rst
@@ -166,6 +166,20 @@ transformed_components
   vertical component is transformed.
 
 
+fallback_strategy
+  String identifying how to treat points that do not fall into any of the
+  specified triangles. This item is available for ``format_version`` >= 1.1.
+  Possible values are ``none``, ``nearest_side`` and ``nearest_centroid``. The
+  default is ``none`` and signifies, that points that fall outside the
+  specified triangles are not transformed. This is also the behaviour for
+  ``format_version`` before 1.1. If ``fallback_strategy`` is set to
+  ``nearest_side``, then points that do not fall into any triangle are 
+  transformed according to the triangle closest to them by euclidean distance.
+  If ``fallback_strategy`` is set to ``nearest_centroid``, then points that do
+  not fall into any triangle are transformed according to the triangle with the
+  closest centroid (intersection of its medians).
+
+
 vertices_columns
   Specify the name of the columns of the rows in the ``vertices``
   array. There must be exactly as many elements in ``vertices_columns`` as in a

--- a/src/transformations/tinshift.hpp
+++ b/src/transformations/tinshift.hpp
@@ -53,6 +53,12 @@
 
 namespace TINSHIFT_NAMESPACE {
 
+enum FallbackStrategy {
+    FALLBACK_NONE,
+    FALLBACK_NEAREST_SIDE,
+    FALLBACK_NEAREST_CENTROID,
+};
+
 using json = nlohmann::json;
 
 // ---------------------------------------------------------------------------
@@ -92,6 +98,10 @@ class TINShiftFile {
     /** Get a text description of the model. Intended to be longer than name()
      */
     const std::string &publicationDate() const { return mPublicationDate; }
+
+    const enum FallbackStrategy &fallbackStrategy() const {
+        return mFallbackStrategy;
+    }
 
     /** Basic information on the agency responsible for the model. */
     struct Authority {
@@ -204,6 +214,7 @@ class TINShiftFile {
     std::string mLicense{};
     std::string mDescription{};
     std::string mPublicationDate{};
+    enum FallbackStrategy mFallbackStrategy {};
     Authority mAuthority{};
     std::vector<Link> mLinks{};
     std::string mInputCRS{};

--- a/test/gie/tinshift.gie
+++ b/test/gie/tinshift.gie
@@ -47,4 +47,16 @@ accept      3210000.0000 6700000.0000   10.0
 expect      3210000.0000 6700000.0000   10.2886
 roundtrip   1
 
+# Test fallback strategy nearest_side
+operation   +proj=tinshift +file=tests/tinshift_fallback_nearest_side.json
+accept    2    3
+expect    4    6
+roundtrip 1
+
+# Test fallback strategy nearest_centroid
+operation   +proj=tinshift +file=tests/tinshift_fallback_nearest_centroid.json
+accept    3    0
+expect    3    0
+roundtrip 1
+
 </gie-strict>


### PR DESCRIPTION
Hi,

this is a WIP pull request for #2903 and I'm asking for guidance to finish it up. Open questions are:

 - is "fallback_strategy" a good name? The default does not change the current behaviour.
 - should "fallback_strategy" be part of the json or the proj string?
 - currently "fallback_strategy" is a string -- should it be an enum? Maybe there are other strategies that could be useful in future implementations?
 - should the json version be bumped because of the new field?
 - is there a way to compute distance to a triangle with less computations? I can only come up with heuristics like the commented out piece of code which is not precise but only checks the vertices of the triangles.
 - the quadtree does not seem to be ready for performing a nearest-neighbor kind of search. It would need to be extended to support a distance function and a shared variable to track the currently found closest feature. For my own use-case, the current implementation that does not use the quad tree is sufficient.

TODO:

 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API