### PR TITLE
fix MSVC 2019 build: C2491 - definitions can't be `dllimport`

### DIFF
--- a/src/strerrno.cpp
+++ b/src/strerrno.cpp
@@ -34,7 +34,7 @@ static const struct
     { PROJ_ERR_OTHER_NETWORK_ERROR,                      _("Network error when accessing a remote resource") },
 };
 
-const char PROJ_DLL * proj_context_errno_string(PJ_CONTEXT* ctx, int err)
+const char * proj_context_errno_string(PJ_CONTEXT* ctx, int err)
 {
     if( ctx == nullptr )
         ctx = pj_get_default_ctx();


### PR DESCRIPTION
Fix building with VS 2019, C2491: definitions can't be `dllimport`

 - [*] Added clear title that can be used to generate release notes
