### PR TITLE
createOperationsCompoundToCompound(): fix null pointer dereference when connection to proj.db doesn't exist.

### DIFF
--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -5250,8 +5250,10 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
     // and a geoid model for Belfast height referenced to ETRS89
     if (verticalTransforms.size() == 1 &&
         verticalTransforms.front()->hasBallparkTransformation()) {
-        auto dbContext =
-            context.context->getAuthorityFactory()->databaseContext();
+        const auto &authFactory = context.context->getAuthorityFactory();
+        auto dbContext = authFactory
+                             ? authFactory->databaseContext().as_nullable()
+                             : nullptr;
         const auto intermGeogSrc =
             srcGeog->promoteTo3D(std::string(), dbContext);
         const bool intermGeogSrcIsSameAsIntermGeogDst =


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40955
