### PR TITLE
DOCS: Add doxygen entry for proj_context_set_search_paths.

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -880,6 +880,9 @@ Setting custom I/O functions
 .. doxygenfunction:: proj_context_set_sqlite3_vfs_name
    :project: doxygen_api
 
+.. doxygenfunction:: proj_context_set_search_paths
+   :project: doxygen_api
+
 
 Network related functionality
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/proj.h
+++ b/src/proj.h
@@ -381,7 +381,9 @@ PJ_CONTEXT PROJ_DLL *proj_context_clone (PJ_CONTEXT *ctx);
 typedef const char* (*proj_file_finder) (PJ_CONTEXT *ctx, const char*, void* user_data);
 
 void PROJ_DLL proj_context_set_file_finder(PJ_CONTEXT *ctx, proj_file_finder finder, void* user_data);
+/*! @endcond */
 void PROJ_DLL proj_context_set_search_paths(PJ_CONTEXT *ctx, int count_paths, const char* const* paths);
+/*! @cond Doxygen_Suppress */
 void PROJ_DLL proj_context_set_ca_bundle_path(PJ_CONTEXT *ctx, const char *path);
 void PROJ_DLL proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable);
 int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_legacy_code_path);


### PR DESCRIPTION
Also remove the setting LATEXT_SOURCE_CODE from Doxyfile, because
Doxygen was warning that the setting was obsolete.

Refs #2540.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes