### PR TITLE
DOCS: Remove LATEX_SOURCE_CODE setting from Doxyfile.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1729,16 +1729,6 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
-
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
 # http://en.wikipedia.org/wiki/BibTeX and \cite for more info.


### PR DESCRIPTION
Doxygen was issuing warnings that this setting is now obsolete, which
was causing the docs build process to abort.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
 