### PR TITLE
Fix windows.h conflict with Criterion::STRICT

### DIFF
--- a/include/proj/util.hpp
+++ b/include/proj/util.hpp
@@ -33,6 +33,11 @@
 #error Must have C++11 or newer.
 #endif
 
+// windows.h can confict with Criterion::STRICT
+#ifdef STRICT
+#undef STRICT
+#endif
+
 #include <exception>
 #include <map>
 #include <memory>


### PR DESCRIPTION
If window.h is included in the same compilation unit we can expect this kind of errors:
```
util.hpp:348:15: error: expected identifier before ‘,’ token
  348 |         STRICT,
```

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API