### PR TITLE
Fix github path for crs2crs2grid.py in HTDP

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -305,7 +305,7 @@ Getting :file:`crs2crs2grid.py`
 ................................................................................
 
 The :file:`crs2crs2grid.py` script can be found at
-https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/samples/crs2crs2grid.py
+https://github.com/OSGeo/gdal/blob/master/swig/python/gdal-utils/osgeo_utils/samples/crs2crs2grid.py
 
 The script depends on having the GDAL Python bindings operational; if they are not you
 will get an error such as:


### PR DESCRIPTION
While going through the documentation of proj I found that the current github path for `crs2crs2grid.py` was not correct, so updated with the correct one.
![image](https://user-images.githubusercontent.com/23361280/144282123-107e019e-259d-44ef-ac32-59c8f9b6a61e.png)


 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API