### PR TITLE
Refactor proj.pc to use EXTRA_LIBS; add -lpthread to Libs.private

### DIFF
--- a/cmake/ProjUtilities.cmake
+++ b/cmake/ProjUtilities.cmake
@@ -76,21 +76,25 @@ function(configure_proj_pc)
   set(datadir "$\{datarootdir\}")
   set(PACKAGE "proj")
   set(VERSION ${PROJ_VERSION})
-  set(SQLITE3_LIBS -lsqlite3)
+  # Build list for Libs.private
+  set(EXTRA_LIBS
+    -lstdc++
+    -lsqlite3
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
   if(TIFF_ENABLED)
-    set(TIFF_LIBS -ltiff)
+    list(APPEND EXTRA_LIBS -ltiff)
   endif()
   if(CURL_ENABLED)
-    set(CURL_LIBS -lcurl)
+    list(APPEND EXTRA_LIBS -lcurl)
   endif()
-  set(EXTRA_LIBS "-lstdc++")
   if(HAVE_LIBM)
-    list(APPEND EXTRA_LIBS "-lm")
+    list(APPEND EXTRA_LIBS -lm)
   endif()
   if(HAVE_LIBDL)
-    list(APPEND EXTRA_LIBS "-ldl")
+    list(APPEND EXTRA_LIBS -ldl)
   endif()
-  # Join list with a space
+  # Join list with a space; list(JOIN) added CMake 3.12
   string(REPLACE ";" " " _tmp_str "${EXTRA_LIBS}")
   set(EXTRA_LIBS "${_tmp_str}")
 

--- a/configure.ac
+++ b/configure.ac
@@ -325,7 +325,16 @@ dnl ---------------------------------------------------------------------------
 dnl Check for extra libraries, required for static linking with pkg-config
 dnl ---------------------------------------------------------------------------
 
-EXTRA_LIBS="-lstdc++"
+EXTRA_LIBS="-lstdc++ -lsqlite3"
+if test "no$THREAD_LIB" != "no"; then
+  EXTRA_LIBS="$EXTRA_LIBS $THREAD_LIB"
+fi
+if test "x$enable_tiff" != "xno" -o "x$enable_tiff" = ""; then
+  EXTRA_LIBS="$EXTRA_LIBS -ltiff"
+fi
+if test "$FOUND_CURL" = "yes" ; then
+  EXTRA_LIBS="$EXTRA_LIBS -lcurl"
+fi
 if test "$HAVE_LIBM" != "no" ; then
   EXTRA_LIBS="$EXTRA_LIBS -lm"
 fi

--- a/proj.pc.in
+++ b/proj.pc.in
@@ -10,5 +10,5 @@ Description: Coordinate transformation software library
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -lproj
-Libs.private: @SQLITE3_LIBS@ @TIFF_LIBS@ @CURL_LIBS@ @EXTRA_LIBS@
+Libs.private: @EXTRA_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This primarily fixes a static linking issue with GCC 4.8 on a 3rd party C app:
```
$ gcc-4.8 -I/tmp/proj_autoconf_install_from_dist_all/include -Werror    -o c_app c_app-c_app.o -L/tmp/proj_autoconf_install_from_dist_all/lib -Wl,-Bstatic -lproj -Wl,-Bdynamic -lsqlite3 -ltiff -lcurl -lstdc++ -lm -ldl
/tmp/proj_autoconf_install_from_dist_all/lib/libproj.a(factory.o): In function `osgeo::proj::io::SQLiteHandleCache::getHandle(std::string const&, pj_ctx*)':
factory.cpp:(.text+0x25aa): undefined reference to `pthread_atfork'
```
this doesn't happen with other compilers, as I suppose there are some implicitly linked libraries. The `proj.pc` file for linux should normally have `Libs.private: -lstdc++ -lsqlite3 -lpthread -ltiff -lcurl -lm -ldl`

Also, this fix is separate to a post-install refactor that I'm preparing [here](https://github.com/mwtoews/PROJ/tree/postinstall2), which could be ready for a PR in the next week. Backporting to 8.2 to preserve the autotools changes somehow, as these will be dropped at some point.