### PR TITLE
Fix unreachable code in projections/isea.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -108,9 +108,6 @@
    directories, so that proj can be used as a subdirectory of a larger
    project (#2913)
 
- o Fix unreachable internal code in Icosahedral Snyder Equal Area projection
-   (#423)
-
 
  THANKS TO
  ---------

--- a/NEWS
+++ b/NEWS
@@ -108,6 +108,9 @@
    directories, so that proj can be used as a subdirectory of a larger
    project (#2913)
 
+ o Fix unreachable internal code in Icosahedral Snyder Equal Area projection
+   (#423)
+
 
  THANKS TO
  ---------

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -887,26 +887,25 @@ static long isea_disn(struct isea_dgg *g, int quadz, struct isea_pt *di) {
  * d' = d << 4 + q, d = d' >> 4, q = d' & 0xf
  */
 /* convert a q2di to global hex coord */
-static int isea_hex(struct isea_dgg *g, int tri,
+static void isea_hex(struct isea_dgg *g, int tri,
                     struct isea_pt *pt, struct isea_pt *hex) {
     struct isea_pt v;
-#ifdef FIXME
     long sidelength;
     long d, i, x, y;
-#endif
     int quadz;
 
     quadz = isea_ptdi(g, tri, pt, &v);
 
-    if( v.x < (INT_MIN >> 4) || v.x > (INT_MAX >> 4) )
+    if(v.x < (INT_MIN >> 4) || v.x > (INT_MAX >> 4))
     {
         throw "Invalid shift";
     }
     hex->x = ((int)v.x * 16) + quadz;
     hex->y = v.y;
 
-    return 1;
-#ifdef FIXME
+    if (g->aperture < 3 || g->aperture > 4)
+        return;
+
     d = lround(floor(v.x));
     i = lround(floor(v.y));
 
@@ -932,7 +931,7 @@ static int isea_hex(struct isea_dgg *g, int tri,
 
         hex->x = x + offset / 3;
         hex->y = y + 2 * offset / 3;
-        return 1;
+        return;
     }
 
     /* aperture 3 even resolutions and aperture 4 */
@@ -949,8 +948,7 @@ static int isea_hex(struct isea_dgg *g, int tri,
         hex->y = i + sidelength * ((g->quad-1) % 5);
     }
 
-    return 1;
-#endif
+    return;
 }
 
 static struct isea_pt isea_forward(struct isea_dgg *g, struct isea_geo *in)

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -947,8 +947,6 @@ static void isea_hex(struct isea_dgg *g, int tri,
         if (g->quad > 5) hex->x += sidelength;
         hex->y = i + sidelength * ((g->quad-1) % 5);
     }
-
-    return;
 }
 
 static struct isea_pt isea_forward(struct isea_dgg *g, struct isea_geo *in)

--- a/src/projections/isea.cpp
+++ b/src/projections/isea.cpp
@@ -913,8 +913,8 @@ static void isea_hex(struct isea_dgg *g, int tri,
     if (g->aperture == 3 && g->resolution % 2 != 0) {
         long offset = lround((pow(3.0, g->resolution - 1) + 0.5));
 
-        d += offset * ((g->quadz-1) % 5);
-        i += offset * ((g->quadz-1) % 5);
+        d += offset * ((g->quad-1) % 5);
+        i += offset * ((g->quad-1) % 5);
 
         if (quadz == 0) {
             d = 0;

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -2399,6 +2399,30 @@ operation +proj=isea   +mode=hex +resolution=31
 accept  0 0
 expect  failure
 
+operation +proj=isea   +mode=hex +aperture=3 +resolution=5
+accept  0 0
+expect  542141645.00 707973207.00
+accept  2 1
+expect  542141645.00 714351344.00
+accept  2 -1
+expect  542141645.00 714351344.00
+accept  -2 1
+expect  535763508.00 714351344.00
+accept  -2 -1
+expect  542141645.00 707973207.00
+
+operation +proj=isea   +mode=hex +aperture=4 +resolution=4
+accept  0 0
+expect  235991069.00	235991069.00
+accept  2 1
+expect  242369206.00	242369206.00
+accept  2 -1
+expect  242369206.00	242369206.00
+accept  -2 1
+expect  235991069.00	235991069.00
+accept  -2 -1
+expect  235991069.00	235991069.00
+
 ===============================================================================
 # Kavraisky V
 # 	PCyl., Sph.


### PR DESCRIPTION
The internal helper function isea_hex() had an early unconditional
return, which made most of the code in the function totally unreachable.

Based on the comments in the unreachable section, I speculate that the
original author meant for this early return to occur for aperture values
other than 3 or 4.

In passing, change the function's return type to void, since it was
always returning 1 anyway and the return was not used (per #947), and
clean up some rogue whitespace.

Fixes #423.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #423 
 - [x] Fully documented, including updating `docs/source/*.rst` for new API