### PR TITLE
CMake: fix warning with external googletest

### DIFF
--- a/.github/workflows/linux_gcc_5_4.yml
+++ b/.github/workflows/linux_gcc_5_4.yml
@@ -1,10 +1,10 @@
-name: Linux GCC 4.8
+name: Linux GCC 5.4
 
 on: [push, pull_request]
 
 jobs:
 
-  linux_gcc_4_8:
+  linux_gcc_5_4:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
@@ -17,11 +17,11 @@ jobs:
         with:
           path: |
                 ${{ github.workspace }}/ccache.tar.gz
-          key: ${{ runner.os }}-cache-gcc-4-8-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-cache-gcc-4-8-
+          key: ${{ runner.os }}-cache-gcc-5-4-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-cache-gcc-5-4-
 
       - name: Run
-        run: docker run -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:16.04 $PWD/.github/workflows/linux_gcc_4_8/start.sh
+        run: docker run -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:16.04 $PWD/.github/workflows/linux_gcc_5_4/start.sh
 
       - name: Coveralls
         uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/linux_gcc_5_4/start.sh
+++ b/.github/workflows/linux_gcc_5_4/start.sh
@@ -9,7 +9,7 @@ export TRAVIS_BUILD_DIR="$WORK_DIR"
 apt update -y
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    autoconf automake libtool g++-4.8 sqlite3 \
+    autoconf automake libtool g++ sqlite3 \
     python3-pip python3-setuptools \
     make cmake ccache pkg-config tar zip \
     libsqlite3-dev libtiff-dev libcurl4-openssl-dev \
@@ -23,8 +23,8 @@ python3 -m pip install --user cmake==3.9.6
 
 export PATH=$HOME/.local/bin:$PATH
 
-export CC="ccache gcc-4.8"
-export CXX="ccache g++-4.8"
+export CC="ccache gcc"
+export CXX="ccache g++"
 
 NPROC=$(nproc)
 echo "NPROC=${NPROC}"

--- a/test/googletest/CMakeLists.txt.in
+++ b/test/googletest/CMakeLists.txt.in
@@ -1,12 +1,12 @@
 # Source https://github.com/google/googletest/blob/master/googletest/README.md
-cmake_minimum_required(VERSION 2.8.2) # minimum version for ExternalProject_Add
+cmake_minimum_required(VERSION 2.8.12)
 
 project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  URL https://github.com/google/googletest/archive/release-1.8.1.zip
-  URL_HASH SHA1=7b41ea3682937069e3ce32cb06619fead505795e
+  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
   DOWNLOAD_NO_PROGRESS ON
   SOURCE_DIR        "${PROJ_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${PROJ_BINARY_DIR}/googletest-build"


### PR DESCRIPTION
Recent CMake versions throw the following warning when building
googletest 1.8.1. Bumping to 1.11.0 that has a minimum version of 2.8.12
fixes that
```
 CMake Deprecation Warning at build/googletest-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.
```
