### PR TITLE
Update website for 8.2 release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -206,7 +206,7 @@ html_context = {
     'github_user': 'OSGeo',
     'github_repo': 'PROJ',
     # TODO: edit when switching active branch
-    'github_version': '/8.0/docs/source/',
+    'github_version': '8.2/docs/source/',
 }
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -13,8 +13,8 @@ distribution of the source code and various resource file archives. See
 Current Release
 --------------------------------------------------------------------------------
 
-* **2021-09-01** `proj-8.2.0.tar.gz`_ (`md5`_)
-* **2021-07-01** `proj-data-1.8.tar.gz`_
+* **2021-11-01** `proj-8.2.0.tar.gz`_ (`md5`_)
+* **2021-11-01** `proj-data-1.8.tar.gz`_
 * **PDF Manual** `proj.pdf`_
 
 .. note::

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -13,8 +13,8 @@ distribution of the source code and various resource file archives. See
 Current Release
 --------------------------------------------------------------------------------
 
-* **2021-09-01** `proj-8.1.1.tar.gz`_ (`md5`_)
-* **2021-07-01** `proj-data-1.7.tar.gz`_
+* **2021-09-01** `proj-8.2.0.tar.gz`_ (`md5`_)
+* **2021-07-01** `proj-data-1.8.tar.gz`_
 * **PDF Manual** `proj.pdf`_
 
 .. note::
@@ -28,6 +28,7 @@ Current Release
 Past Releases
 --------------------------------------------------------------------------------
 
+* **2021-09-01** `proj-8.1.1.tar.gz`_
 * **2021-07-01** `proj-8.1.0.tar.gz`_
 * **2021-05-05** `proj-8.0.1.tar.gz`_
 * **2021-03-01** `proj-8.0.0.tar.gz`_
@@ -82,8 +83,9 @@ Past Releases
 * **2018-03-01** `proj-datumgrid-oceania-1.1.zip`_
 * **2018-03-01** `proj-datumgrid-oceania-1.0.zip`_
 
+.. _`proj-8.2.0.tar.gz`: https://download.osgeo.org/proj/proj-8.2.0.tar.gz
+.. _`md5`: https://download.osgeo.org/proj/proj-8.2.0.tar.gz.md5
 .. _`proj-8.1.1.tar.gz`: https://download.osgeo.org/proj/proj-8.1.1.tar.gz
-.. _`md5`: https://download.osgeo.org/proj/proj-8.1.1.tar.gz.md5
 .. _`proj-8.1.0.tar.gz`: https://download.osgeo.org/proj/proj-8.1.0.tar.gz
 .. _`proj-8.0.1.tar.gz`: https://download.osgeo.org/proj/proj-8.0.1.tar.gz
 .. _`proj-8.0.0.tar.gz`: https://download.osgeo.org/proj/proj-8.0.0.tar.gz
@@ -109,6 +111,7 @@ Past Releases
 .. _`proj-4.9.2.tar.gz`: https://download.osgeo.org/proj/proj-4.9.2.tar.gz
 .. _`proj-4.9.3.tar.gz`: https://download.osgeo.org/proj/proj-4.9.3.tar.gz
 
+.. _`proj-data-1.8.tar.gz`: https://download.osgeo.org/proj/proj-data-1.8.tar.gz
 .. _`proj-data-1.7.tar.gz`: https://download.osgeo.org/proj/proj-data-1.7.tar.gz
 .. _`proj-data-1.6.tar.gz`: https://download.osgeo.org/proj/proj-data-1.6.tar.gz
 .. _`proj-data-1.5.tar.gz`: https://download.osgeo.org/proj/proj-data-1.5.tar.gz


### PR DESCRIPTION
Currently the website lists 8.1.1 as the current release under downloads: https://proj.org/download.html#current-release.

This is a cherry-pick of the download.rst part of 895f5e39535c797b02e0b5fe5f4b38211d9c64d5, which is on master but not on the 8.2 branch, which this PR targets.