### PR TITLE
update "Edit on GitHub" button branch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -206,7 +206,7 @@ html_context = {
     'github_user': 'OSGeo',
     'github_repo': 'PROJ',
     # TODO: edit when switching active branch
-    'github_version': '/8.0/docs/source/',
+    'github_version': '8.2/docs/source/',
 }
 
 # Add any extra paths that contain custom files (such as robots.txt or


### PR DESCRIPTION
I also removed the leading slash, since I noticed the links contained a double slash. That worked fine, but still.

(cherry picked from commit 80e32d55d076fa48f753d5014cf828d85a0d1bce)

This is the master PR companion of the second commit in #2989.