### PR TITLE
Fix build with Intel C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,13 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
   endif()
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  # Intel CXX compiler based on clang defaults to -ffast-math, which
+  # breaks std::isinf(), std::isnan(), etc.
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -fno-fast-math)
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -fno-fast-math)
+endif ()
+
 set(PROJ_C_WARN_FLAGS "${PROJ_C_WARN_FLAGS}"
   CACHE STRING "C flags used to compile PROJ targets")
 set(PROJ_CXX_WARN_FLAGS "${PROJ_CXX_WARN_FLAGS}"


### PR DESCRIPTION
icx --version: Intel(R) oneAPI DPC++/C++ Compiler 2022.0.0 (2022.0.0.20211123)

Disable fast maths to:
- Fix warnings about std::isnan(), etc. being evaluated to false, due to
  -ffast-math being enabled
- Fix failures in regression test suite

How to reproduce:
docker pull intel/oneapi-basekit
docker run --rm -it -v $HOME:$HOME intel/oneapi-basekit
apt update
apt install sqlite3 libsqlite3-dev libcurl4-gnutls-dev libtiff-dev
CC=icx CXX=icx cmake .. -DCMAKE_EXE_LINKER_FLAGS=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
