### PR TITLE
Document in the tagline dat lat_0 is required for labrd

### DIFF
--- a/docs/source/operations/projections/labrd.rst
+++ b/docs/source/operations/projections/labrd.rst
@@ -34,9 +34,10 @@ Parameters
 Required
 --------------------------------------------------------------------------------
 
-.. include:: ../options/lon_0.rst
+.. option:: +lat_0=<value>
 
-.. include:: ../options/lat_0.rst
+    Latitude of projection center. Must not be zero.
+
 
 Optional
 --------------------------------------------------------------------------------
@@ -46,6 +47,8 @@ Optional
     Azimuth of the central line.
 
     *Defaults to 0.0*
+
+.. include:: ../options/lon_0.rst
 
 .. include:: ../options/R.rst
 

--- a/src/projections/labrd.cpp
+++ b/src/projections/labrd.cpp
@@ -6,7 +6,7 @@
 #include "proj.h"
 #include "proj_internal.h"
 
-PROJ_HEAD(labrd, "Laborde") "\n\tCyl, Sph\n\tSpecial for Madagascar";
+PROJ_HEAD(labrd, "Laborde") "\n\tCyl, Sph\n\tlat_0= Special for Madagascar";
 #define EPS 1.e-10
 
 namespace { // anonymous namespace

--- a/src/projections/labrd.cpp
+++ b/src/projections/labrd.cpp
@@ -6,7 +6,7 @@
 #include "proj.h"
 #include "proj_internal.h"
 
-PROJ_HEAD(labrd, "Laborde") "\n\tCyl, Sph\n\tlat_0= Special for Madagascar";
+PROJ_HEAD(labrd, "Laborde") "\n\tCyl, Sph\n\tSpecial for Madagascar\n\tlat_0=";
 #define EPS 1.e-10
 
 namespace { // anonymous namespace


### PR DESCRIPTION
Add 'lat_0=' to the labrd info lines to document that the 'lat_0' argument is needed for a minimal test on this projection.

All other projections list their required arguments on this line with only this exception. (Makes this easier to test for in the SharpProj unittests, where I now have an hardcoded exception)