### PR TITLE
Specify CMAKE_INSTALL_RPATH for macOS; use -rpath LDFLAGS for tests

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -37,7 +37,6 @@ jobs:
         working-directory: ./docs/plot
         run: |
             export PATH=/opt/proj/bin:$PATH
-            export LD_LIBRARY_PATH=/opt/proj/lib
             export PROJ_LIB=/opt/proj/share/proj
             ./plot.py plotdefs.json images/
 

--- a/.github/workflows/mac/before_install.sh
+++ b/.github/workflows/mac/before_install.sh
@@ -3,11 +3,9 @@
 set -e
 
 
-conda update -n base -c defaults conda
-conda install compilers -y
+conda update --yes --quiet -n base -c defaults conda
+conda install --yes --quiet compilers
 
 conda config --set channel_priority strict
-conda install --yes --quiet python=3.8 autoconf automake libtool ccache -y
-conda install --yes --quiet proj=7.1.1=h45baca5_3 --only-deps -y
-
-./travis/before_install_pip.sh
+conda install --yes --quiet python=3.8 autoconf automake libtool ccache jsonschema
+conda install --yes --quiet --only-deps proj=7.1.1=h45baca5_3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,17 +23,14 @@ option(BUILD_PROJSYNC
 
 if(NOT MSVC)
 
-  if(NOT APPLE)
-    # Use relative path so that package is relocatable
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${LIBDIR}")
-  else()
+  # Use relative path so that package is relocatable
+  if(APPLE)
     set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${LIBDIR}")
-    # TO DO: cmake 2.8.12 introduces a way to make the install tree
-    # relocatable with OSX via
-    # (1) set(CMAKE_MACOSX_RPATH ON) and
-    # (2) setting the INSTALL_RPATH property on the executables to
-    # "@loader_path/../${LIBDIR}"
+    set(CMAKE_INSTALL_RPATH "@loader_path/../${LIBDIR}")
+  else()
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${LIBDIR}")
   endif()
+  # Other apps can link to libproj using e.g. LDFLAGS -Wl,-rpath,${prefix}/lib
 
 else()
 

--- a/test/postinstall/README.md
+++ b/test/postinstall/README.md
@@ -34,7 +34,7 @@ Two build modes are tested with each configure method:
 
 All configure methods share the same suite of tests for `c_app` and `cpp_app`:
 
-- `test_ldd` - examines the shared object dependencies to see if "libproj" is found with the correct path (for `shared` build mode), or not listed as a dependency for builds with static libproj.
+- `test_libpath` - examines the shared object dependencies to see if "libproj" is found with the correct path (for `shared` build mode), or not listed as a dependency for builds with static libproj.
 - `test_transform` - example coordinate transform to ensure basic functions work as expected.
 - `test_searchpath` - compares `searchpath` (from `proj_info()`) to either `datadir` via pkg-config or relative path `PROJ_DIR/../../../share/proj` via CMake.
 - `test_version` - compares PROJ version components from `proj_info()` to the version from pkg-config or CMake.

--- a/test/postinstall/c_app/CMakeLists.txt
+++ b/test/postinstall/c_app/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/..)
 include(common)
-add_test_ldd(c_app proj)
+add_test_libpath(c_app proj)
 add_test_transform(c_app)
 add_test_searchpath(c_app)
 add_test_version(c_app)

--- a/test/postinstall/c_app/Makefile.am
+++ b/test/postinstall/c_app/Makefile.am
@@ -3,7 +3,7 @@ c_app_SOURCES = c_app.c
 c_app_CFLAGS = $(PROJ_CFLAGS)
 c_app_LDADD = $(PROJ_LIBS)
 TESTS = \
-  test_ldd.sh \
+  test_libpath.sh \
   test_transform.sh \
   test_searchpath.sh \
   test_version.sh

--- a/test/postinstall/c_app/makefile.mak
+++ b/test/postinstall/c_app/makefile.mak
@@ -1,7 +1,7 @@
 PROGRAM = c_app
 OBJECTS = $(addsuffix .o,$(PROGRAM))
 TESTS = \
-  test_ldd.sh \
+  test_libpath.sh \
   test_transform.sh \
   test_searchpath.sh \
   test_version.sh

--- a/test/postinstall/c_app/test_ldd.sh
+++ b/test/postinstall/c_app/test_ldd.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-. ../common.sh
-
-test_ldd c_app libproj

--- a/test/postinstall/c_app/test_libpath.sh
+++ b/test/postinstall/c_app/test_libpath.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+. ../common.sh
+
+EXPECTED_LIBPATH="$(pkg-config proj --variable=libdir)"
+
+test_libpath c_app "${EXPECTED_LIBPATH}" libproj

--- a/test/postinstall/cpp_app/CMakeLists.txt
+++ b/test/postinstall/cpp_app/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(cpp_app PRIVATE ${USE_PROJ_NAME}::proj)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/..)
 include(common)
-add_test_ldd(cpp_app)
+add_test_libpath(cpp_app)
 add_test_transform(cpp_app)
 add_test_searchpath(cpp_app)
 add_test_version(cpp_app)

--- a/test/postinstall/cpp_app/Makefile.am
+++ b/test/postinstall/cpp_app/Makefile.am
@@ -3,7 +3,7 @@ cpp_app_SOURCES = cpp_app.cpp
 cpp_app_CXXFLAGS = $(PROJ_CFLAGS)
 cpp_app_LDADD = $(PROJ_LIBS)
 TESTS = \
-  test_ldd.sh \
+  test_libpath.sh \
   test_transform.sh \
   test_searchpath.sh \
   test_version.sh

--- a/test/postinstall/cpp_app/makefile.mak
+++ b/test/postinstall/cpp_app/makefile.mak
@@ -1,7 +1,7 @@
 PROGRAM = cpp_app
 OBJECTS = $(addsuffix .o,$(PROGRAM))
 TESTS = \
-  test_ldd.sh \
+  test_libpath.sh \
   test_transform.sh \
   test_searchpath.sh \
   test_version.sh

--- a/test/postinstall/cpp_app/test_ldd.sh
+++ b/test/postinstall/cpp_app/test_ldd.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-. ../common.sh
-
-test_ldd cpp_app libproj

--- a/test/postinstall/cpp_app/test_libpath.sh
+++ b/test/postinstall/cpp_app/test_libpath.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+. ../common.sh
+
+EXPECTED_LIBPATH="$(pkg-config proj --variable=libdir)"
+
+test_libpath cpp_app "${EXPECTED_LIBPATH}" libproj

--- a/test/postinstall/test_autotools.sh
+++ b/test/postinstall/test_autotools.sh
@@ -3,8 +3,7 @@
 # Post-install tests with autotools/pkg-config
 #
 # First required argument is the installed prefix, which
-# is used to set PKG_CONFIG_PATH and
-# LD_LIBRARY_PATH/DYLD_LIBRARY_PATH for shared builds
+# is used to set PKG_CONFIG_PATH and rpath for shared.
 # Second argument is either shared (default) or static
 cd $(dirname $0)
 . ./common.sh
@@ -19,7 +18,12 @@ else
   export PKG_CONFIG="pkg-config --static"
   ENABLE_STATIC_PROJ=yes
 fi
+
 export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+
+if [ ${BUILD_MODE} = shared ]; then
+  export LDFLAGS="${LDFLAGS} -Wl,-rpath,$(pkg-config proj --variable=libdir)"
+fi
 
 autogen_configure_check_clean(){
   set -e

--- a/test/postinstall/test_cmake.bat
+++ b/test/postinstall/test_cmake.bat
@@ -72,7 +72,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ^
   -DUSE_PROJ_NAME=%1 .. || Exit /B 1
 
 cmake --build . --config Release || Exit /B 1
-ctest --output-on-failure -V -C Release || Exit /B 1
+ctest --output-on-failure -C Release || Exit /B 1
 
 Cd ..
 Rd /s /q build

--- a/test/postinstall/test_cmake.sh
+++ b/test/postinstall/test_cmake.sh
@@ -3,14 +3,14 @@
 # Post-install tests with CMake
 #
 # First required argument is the installed prefix, which
-# is used to set CMAKE_PREFIX_PATH and
-# LD_LIBRARY_PATH/DYLD_LIBRARY_PATH for shared builds
+# is used to set CMAKE_PREFIX_PATH
 # Second argument is either shared (default) or static
 cd $(dirname $0)
 . ./common.sh
 main_setup $1 $2
 
 echo "Running post-install tests with CMake (${BUILD_MODE})"
+
 
 cmake_make_ctest(){
   rm -rf build
@@ -19,7 +19,7 @@ cmake_make_ctest(){
 
   cmake -DCMAKE_PREFIX_PATH=${prefix} -DUSE_PROJ_NAME=$1 ..
   VERBOSE=1 make
-  ctest --output-on-failure -V
+  ctest --output-on-failure
 
   cd ..
   rm -rf build

--- a/test/postinstall/test_pkg-config.sh
+++ b/test/postinstall/test_pkg-config.sh
@@ -3,8 +3,7 @@
 # Post-install tests with pkg-config and a Makefile
 #
 # First required argument is the installed prefix, which
-# is used to set PKG_CONFIG_PATH and
-# LD_LIBRARY_PATH/DYLD_LIBRARY_PATH for shared builds
+# is used to set PKG_CONFIG_PATH and rpath for shared.
 # Second argument is either shared (default) or static
 cd $(dirname $0)
 . ./common.sh
@@ -13,6 +12,10 @@ main_setup $1 $2
 echo "Running post-install tests with pkg-config (${BUILD_MODE})"
 
 export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+
+if [ ${BUILD_MODE} = shared ]; then
+  export LDFLAGS="${LDFLAGS} -Wl,-rpath,$(pkg-config proj --variable=libdir)"
+fi
 
 make_all_test_clean(){
   set -e

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -169,17 +169,17 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
         $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_cmake_install shared
         $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_cmake_install shared
     else
-        echo "Skipping test_autotools.sh test for $BUILD_NAME"
+        echo "Skipping test_cmake.sh and test_autotools.sh for $BUILD_NAME"
     fi
     cd ..
 
-    if [ $TRAVIS_OS_NAME != "osx" ]; then
-        # Check that we can retrieve the resource directory in a relative way after renaming the installation prefix
-        mkdir /tmp/proj_cmake_install_renamed
-        mv /tmp/proj_cmake_install /tmp/proj_cmake_install_renamed/subdir
-        /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory || /bin/true
-        /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null | grep "Downloading from https://cdn.proj.org into /tmp/proj_cmake_install_renamed/subdir/share/proj"
-    fi
+    # Check that we can retrieve the resource directory in a relative way after renaming the installation prefix
+    mkdir /tmp/proj_cmake_install_renamed
+    mv /tmp/proj_cmake_install /tmp/proj_cmake_install_renamed/subdir
+    set +e
+    /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory
+    /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null | grep "Downloading from https://cdn.proj.org into /tmp/proj_cmake_install_renamed/subdir/share/proj"
+    set -e
 
     # return to root
     cd ../..


### PR DESCRIPTION
The primary change in this PR applies to macOS users, which allows the library and utilities to be relocatable, using a relative path to the library via `../lib`. There was a "TO DO: cmake 2.8.12" note in src/CMakeLists.txt that provided accurate guidance on this. Before this change, a user might see (e.g.):
```
$ /tmp/proj_cmake_install_renamed/subdir/bin/projsync
dyld: Library not loaded: @rpath/libproj.22.dylib
  Referenced from: /tmp/proj_cmake_install_renamed/subdir/bin/projsync
  Reason: image not found
```
the RPATH setting in CMake was already used for Linux so that the library and utilities are relocatable.

Other changes:
- Don't use LD_LIBRARY_PATH or DYLD_LIBRARY_PATH variables
- Quieter conda install messages, and install jsonschema required for testing

Other changes within test/postinstall:
- Rename `test_ldd` to `test_libpath` to be more generic
- For macOS, use `otool -l` to look for a matching LC_RPATH entry
- When necessary, use `export LDFLAGS="${LDFLAGS} -Wl,-rpath,$(pkg-config proj --variable=libdir)"` to "bake" the correct RPATH into objects (not needed for test_cmake or static builds)