### PR TITLE
Add .zenodo.json

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -18,3 +18,19 @@ jobs:
 
       - name: Run cppcheck test
         run: ./scripts/cppcheck.sh
+
+  other_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Requirements
+        run: |
+            sudo apt install python3-pip wget
+            sudo pip3 install jsonschema
+
+      - name: Check json files
+        run: |
+            wget https://raw.githubusercontent.com/rouault/zenodo_json_schema/master/zenodo-json-schema.json
+            jsonschema -i .zenodo.json zenodo-json-schema.json

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,7 +14,7 @@
             "name": "Evers, Kristian"
         },
         {
-            "affiliation": "SDFE.dk",
+            "affiliation": "Danish Agency for Data Supply and Efficiency",
             "name": "Knudsen, Thomas"
         },
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,7 @@
             "name": "Warmerdam, Frank"
         },
         {
-            "affiliation": "SDFE.dk",
+            "affiliation": "Danish Agency for Data Supply and Efficiency",
             "name": "Evers, Kristian"
         },
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,10 @@
 {
     "creators": [
         {
+            "affiliation": "United States Geological Survey",
+            "name": "Evenden, Gerald I."
+        },
+        {
             "affiliation": "Spatialys",
             "name": "Rouault, Even",
             "orcid": "0000-0002-5068-0476"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -44,7 +44,8 @@
         },
         {
             "affiliation": "North Road",
-            "name": "Dawson, Nyall"
+            "name": "Dawson, Nyall",
+            "orcid": "0000-0001-9812-7584"
         },
         {
             "affiliation": "Corteva",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -58,6 +58,9 @@
             "affiliation": "Corteva",
             "name": "Snow, Alan D.",
             "orcid": "0000-0002-7333-3100"
+        },
+        {
+            "name": "Jimenez Shaw, Javier"
         }
     ],
     "description": "PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. This includes cartographic projections as well as geodetic transformations.",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,7 +28,8 @@
         },
         {
             "affiliation": "GNS Science",
-            "name": "Taves, Mike"
+            "name": "Taves, Mike",
+            "orcid": "0000-0003-3657-7963"
         },
         {
             "affiliation": "Google Inc",
@@ -36,7 +37,8 @@
             "orcid": "0000-0002-5624-8190"
         },
         {
-            "name": "Sales de Andrade, Elliott"
+            "name": "Sales de Andrade, Elliott",
+            "orcid": "0000-0001-7310-8942"
         },
         {
             "affiliation": "SRI International",
@@ -53,7 +55,8 @@
         },
         {
             "affiliation": "Corteva",
-            "name": "Snow, Alan D."
+            "name": "Snow, Alan D.",
+            "orcid": "0000-0002-7333-3100"
         }
     ],
     "description": "PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. This includes cartographic projections as well as geodetic transformations.",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,7 +15,8 @@
         },
         {
             "affiliation": "Danish Agency for Data Supply and Efficiency",
-            "name": "Evers, Kristian"
+            "name": "Evers, Kristian",
+            "orcid": "0000-0002-1310-4576"
         },
         {
             "affiliation": "Danish Agency for Data Supply and Efficiency",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,67 @@
+{
+    "creators": [
+        {
+            "affiliation": "Spatialys",
+            "name": "Rouault, Even",
+            "orcid": "0000-0002-5068-0476"
+        },
+        {
+            "affiliation": "Planet Labs Inc",
+            "name": "Warmerdam, Frank"
+        },
+        {
+            "affiliation": "SDFE.dk",
+            "name": "Evers, Kristian"
+        },
+        {
+            "affiliation": "SDFE.dk",
+            "name": "Knudsen, Thomas"
+        },
+        {
+            "affiliation": "Hobu Inc",
+            "name": "Butler, Howard",
+            "orcid": "0000-0002-5340-1380"
+        },
+        {
+            "affiliation": "GNS Science",
+            "name": "Taves, Mike"
+        },
+        {
+            "affiliation": "Google Inc",
+            "name": "Schwehr, Kurt",
+            "orcid": "0000-0002-5624-8190"
+        },
+        {
+            "name": "Sales de Andrade, Elliott"
+        },
+        {
+            "affiliation": "SRI International",
+            "name": "Karney, Charles",
+            "orcid": "0000-0002-5006-5836"
+        },
+        {
+            "name": "Couwenberg, Sebastiaan"
+        },
+        {
+            "affiliation": "North Road",
+            "name": "Dawson, Nyall"
+        },
+        {
+            "affiliation": "Corteva",
+            "name": "Snow, Alan D."
+        }
+    ],
+    "description": "PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. This includes cartographic projections as well as geodetic transformations.",
+    "keywords": [
+        "PROJ",
+        "geodesy",
+        "cartography",
+        "coordinates",
+        "projections",
+        "conversion"
+    ],
+    "license": {
+        "id": "MIT"
+    },
+    "title": "PROJ"
+}


### PR DESCRIPTION
Add a .zenodo.json to prepare for automatic DOI generation when releasing PROJ.

I've given a try with a tag created on that branch in my fork with the sandbox.zenodo.org service: https://sandbox.zenodo.org/record/994082 / https://sandbox.zenodo.org/account/settings/github/repository/rouault/PROJ

See GDAL discussion thread: https://lists.osgeo.org/pipermail/gdal-dev/2022-January/thread.html#55228