### PR TITLE
CI: transition tests from autotools to cmake

### DIFF
--- a/.github/workflows/clang_linux.yml
+++ b/.github/workflows/clang_linux.yml
@@ -1,4 +1,4 @@
-name: CLang Linux
+name: Clang Linux
 
 on: [push, pull_request]
 

--- a/.github/workflows/clang_linux/start.sh
+++ b/.github/workflows/clang_linux/start.sh
@@ -8,6 +8,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sqlite3 libsqlite3-dev libtiff-dev libcurl4-openssl-dev jq python3-pip nlohmann-json3-dev
 
 python3 -m pip install --user jsonschema
+export PATH=$HOME/.local/bin:$PATH
 
 cd "$WORK_DIR"
 
@@ -16,16 +17,12 @@ if test -f "$WORK_DIR/ccache.tar.gz"; then
     (cd $HOME && tar xzf "$WORK_DIR/ccache.tar.gz")
 fi
 
-export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 ccache -M 500M
-ccache -s
 
 # -fno-use-cxa-atexit is needed to build with -coverage
-CC="ccache clang-10" CXX="ccache clang++-10" CFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" CXXFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" LDFLAGS="-fsanitize=address" ./travis/install.sh
-
-ccache -s
+CC="clang-10" CXX="clang++-10" CFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" CXXFLAGS="-Werror -fsanitize=address -fno-use-cxa-atexit" LDFLAGS="-fsanitize=address" ./travis/install.sh
 
 echo "Saving ccache..."
 rm -f "$WORK_DIR/ccache.tar.gz"

--- a/.github/workflows/linux_gcc_32bit/start.sh
+++ b/.github/workflows/linux_gcc_32bit/start.sh
@@ -21,18 +21,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  -o AP
 python3 -m pip install --user jsonschema
 export PATH=$HOME/.local/bin:$PATH
 
-export CXXFLAGS='-g -O2 -m32 -D_GLIBCXX_ASSERTIONS'
-export CFLAGS='-g -O2 -m32'
+export CXXFLAGS='-m32 -D_GLIBCXX_ASSERTIONS'
+export CFLAGS='-m32'
 export TIFF_CFLAGS=-I/usr/include/i386-linux-gnu
 export TIFF_LIBS="-L/usr/lib/i386-linux-gnu -ltiff"
 export SQLITE3_CFLAGS=-I/usr/include/i386-linux-gnu
 export SQLITE3_LIBS="-L/usr/lib/i386-linux-gnu -lsqlite3"
-export CC="ccache gcc"
-export CXX="ccache g++"
-
-NPROC=$(nproc)
-echo "NPROC=${NPROC}"
-export MAKEFLAGS="-j ${NPROC}"
 
 cd "$WORK_DIR"
 
@@ -41,15 +35,11 @@ if test -f "$WORK_DIR/ccache.tar.gz"; then
     (cd $HOME && tar xzf "$WORK_DIR/ccache.tar.gz")
 fi
 
-export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 ccache -M 500M
-ccache -s
 
-CFLAGS="-Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" ./travis/install.sh
-
-ccache -s
+CFLAGS="-Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" CMAKE_BUILD_TYPE=RelWithDebInfo ./travis/install.sh
 
 echo "Saving ccache..."
 rm -f "$WORK_DIR/ccache.tar.gz"

--- a/.github/workflows/linux_gcc_5_4/start.sh
+++ b/.github/workflows/linux_gcc_5_4/start.sh
@@ -23,13 +23,6 @@ python3 -m pip install --user cmake==3.9.6
 
 export PATH=$HOME/.local/bin:$PATH
 
-export CC="ccache gcc"
-export CXX="ccache g++"
-
-NPROC=$(nproc)
-echo "NPROC=${NPROC}"
-export MAKEFLAGS="-j ${NPROC}"
-
 cd "$WORK_DIR"
 
 if test -f "$WORK_DIR/ccache.tar.gz"; then
@@ -37,15 +30,11 @@ if test -f "$WORK_DIR/ccache.tar.gz"; then
     (cd $HOME && tar xzf "$WORK_DIR/ccache.tar.gz")
 fi
 
-export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 ccache -M 500M
-ccache -s
 
 CFLAGS="-Werror $CFLAGS" CXXFLAGS="-Werror $CXXFLAGS" ./travis/install.sh
-
-ccache -s
 
 echo "Saving ccache..."
 rm -f "$WORK_DIR/ccache.tar.gz"

--- a/.github/workflows/mac/install.sh
+++ b/.github/workflows/mac/install.sh
@@ -2,12 +2,8 @@
 
 set -e
 
-export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 ccache -M 200M
-ccache -s
 
-CC="ccache clang" CXX="ccache clang++" CFLAGS="-Werror -O2" CXXFLAGS="-Werror -O2" ./travis/install.sh
-
-ccache -s
+CC="clang" CXX="clang++" CFLAGS="-Werror" CXXFLAGS="-Werror" CMAKE_BUILD_TYPE=RelWithDebInfo ./travis/install.sh

--- a/.github/workflows/mingw_w64/start.sh
+++ b/.github/workflows/mingw_w64/start.sh
@@ -51,8 +51,8 @@ ccache -s
 MINGW_ARCH=x86_64-w64-mingw32
 MINGW_PREFIX=/usr/lib/gcc/$MINGW_ARCH/7.3-posix
 
-export CC="ccache $MINGW_ARCH-gcc"
-export CXX="ccache $MINGW_ARCH-g++"
+export CC="$MINGW_ARCH-gcc"
+export CXX="$MINGW_ARCH-g++"
 export LD=$MINGW_ARCH-ld
 
 UNAME="$(uname)" || UNAME=""

--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -10,12 +10,25 @@
 include(CheckLibraryExists)
 include(CheckFunctionExists)
 
+# if C flags have -Werror, temporarily remove these while running some checks
+string(FIND "${CMAKE_C_FLAGS}" "-Werror" FIND_WERROR)
+if(FIND_WERROR GREATER_EQUAL 0)
+  string(REPLACE "-Werror" "" _tmp_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+  set(_prev_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${_tmp_CMAKE_C_FLAGS}")
+endif()
+
 # check needed include file
 check_function_exists(localeconv HAVE_LOCALECONV)
 check_function_exists(strerror HAVE_STRERROR)
 if(NOT WIN32)
-    check_library_exists(dl dladdr "" HAVE_LIBDL)
-    check_library_exists(m exp "" HAVE_LIBM)
+  check_library_exists(dl dladdr "" HAVE_LIBDL)
+  check_library_exists(m exp "" HAVE_LIBM)
+endif()
+
+# restore CMAKE_C_FLAGS as before
+if(FIND_WERROR GREATER_EQUAL 0)
+  set(CMAKE_C_FLAGS "${_prev_CMAKE_C_FLAGS}")
 endif()
 
 set(PACKAGE "proj")

--- a/test/fuzzers/README.TXT
+++ b/test/fuzzers/README.TXT
@@ -10,7 +10,7 @@ https://bugs.chromium.org/p/oss-fuzz/issues/list?q=proj4
 
 - Build standard_fuzzer in a standalone mode:
 
-    $ g++ -g -std=c++11 standard_fuzzer.cpp -o standard_fuzzer -fvisibility=hidden -DSTANDALONE ../../src/.libs/libproj.a -lpthread -lsqlite3 -I../../src -I../../include
+    $ g++ -g -std=c++11 standard_fuzzer.cpp -o standard_fuzzer -fvisibility=hidden -DSTANDALONE ../../build/lib/libproj.a -lpthread -lsqlite3 -I../../src -I../../include
 
   Run it:
     $ PROJ_LIB=../../data ./standard_fuzzer {file_generated_by_oss_fuzz}

--- a/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
+++ b/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
@@ -37,7 +37,7 @@
 #include "proj.h"
 
 /* Standalone build:
-g++ -g -std=c++11 proj_crs_to_crs_fuzzer.cpp -o proj_crs_to_crs_fuzzer -fvisibility=hidden -DSTANDALONE ../../src/.libs/libproj.a -lpthread -lsqlite3 -I../../src -I../../include
+g++ -g -std=c++11 proj_crs_to_crs_fuzzer.cpp -o proj_crs_to_crs_fuzzer -fvisibility=hidden -DSTANDALONE ../../build/lib/libproj.a -lpthread -lsqlite3 -I../../src -I../../include
 */
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv);

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -106,8 +106,8 @@ test_projjson(){
   esac
   # cat out.json
   if [ $(jsonschema --version) = "3.2.0" ]; then
-    # workaround for this version, which does validate UTf-8
-    iconv -f UTF-8 -t ascii//TRANSLIT out.json > out.ascii
+    # workaround for this version, which does not validate UTF-8
+    tr -cd '\11\12\15\40-\176' < out.json > out.ascii
     mv out.ascii out.json
   fi
   jsonschema -i out.json /tmp/proj_shared_install_from_dist/share/proj/projjson.schema.json

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -16,113 +16,158 @@ fi
 echo "NPROC=${NPROC}"
 export MAKEFLAGS="-j ${NPROC}"
 
-# prepare build files
-./autogen.sh
+# Use ccache if it's available
+if command -v ccache &> /dev/null
+then
+    USE_CCACHE=ON
+    ccache -s
+else
+    USE_CCACHE=OFF
+fi
 
-# autoconf build
-mkdir build_autoconf
-cd build_autoconf
-../configure
-make dist-all >/dev/null
-# Check consistency of generated tarball
-TAR_FILENAME=`ls *.tar.gz`
-TAR_DIRECTORY=`basename $TAR_FILENAME .tar.gz`
-tar xvzf $TAR_FILENAME
-cd ..
+if test "x${CMAKE_BUILD_TYPE}" = "x"; then
+    CMAKE_BUILD_TYPE=Release
+fi
 
-# compare with CMake's dist
-mkdir build_cmake
-cd build_cmake
-cmake -DBUILD_TESTING=OFF ..
+echo "Make dist tarball, and check consistency"
+mkdir build_dist
+cd build_dist
+cmake -D BUILD_TESTING=OFF ..
 make dist
-tar xzf $TAR_FILENAME
-cd ..
-diff -qr build_autoconf/$TAR_DIRECTORY build_cmake/$TAR_DIRECTORY || true
 
-# continue build from autoconf
-cd build_autoconf/$TAR_DIRECTORY
+TAR_FILENAME=$(ls *.tar.gz)
+TAR_DIRECTORY=$(basename $TAR_FILENAME .tar.gz)
+mkdir ../build_from_dist
+cd ../build_from_dist
+tar xvzf ../build_dist/$TAR_FILENAME
 
 # There's a nasty #define CS in a Solaris system header. Avoid being caught about that again
 CXXFLAGS="-DCS=do_not_use_CS_for_solaris_compat $CXXFLAGS"
 
-# autoconf build from generated tarball
-mkdir build_autoconf
-cd build_autoconf
-../configure --prefix=/tmp/proj_autoconf_install_from_dist_all
+echo "Build shared ${CMAKE_BUILD_TYPE} configuration from generated tarball"
+cd $TAR_DIRECTORY
+mkdir shared_build
+cd shared_build
+cmake \
+  -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+  -D USE_CCACHE=${USE_CCACHE} \
+  -D BUILD_SHARED_LIBS=ON \
+  -D CMAKE_INSTALL_PREFIX=/tmp/proj_shared_install_from_dist \
+  ..
+make
 
-make >/dev/null
-
-if [ "$(uname)" == "Linux" -a -f src/.libs/libproj.so ]; then
-if objdump -TC "src/.libs/libproj.so" | grep "elf64-x86-64">/dev/null; then
+if [ "$(uname)" == "Linux" -a -f lib/libproj.so ]; then
+if objdump -TC "lib/libproj.so" | grep "elf64-x86-64">/dev/null; then
     echo "Checking exported symbols..."
     cat $TRAVIS_BUILD_DIR/scripts/reference_exported_symbols.txt | sort > /tmp/reference_exported_symbols.txt
-    $TRAVIS_BUILD_DIR/scripts/dump_exported_symbols.sh src/.libs/libproj.so | sort > /tmp/got_symbols.txt
-    diff -u /tmp/reference_exported_symbols.txt /tmp/got_symbols.txt || (echo "Difference(s) found in exported symbols. If intended, refresh scripts/reference_exported_symbols.txt with 'scripts/dump_exported_symbols.sh src/.libs/libproj.so > scripts/reference_exported_symbols.txt'"; exit 1)
+    $TRAVIS_BUILD_DIR/scripts/dump_exported_symbols.sh lib/libproj.so | sort > /tmp/got_symbols.txt
+    diff -u /tmp/reference_exported_symbols.txt /tmp/got_symbols.txt || (echo "Difference(s) found in exported symbols. If intended, refresh scripts/reference_exported_symbols.txt with 'scripts/dump_exported_symbols.sh lib/libproj.so > scripts/reference_exported_symbols.txt'"; exit 1)
 fi
 fi
 
-make check
+ctest
 make install
-find /tmp/proj_autoconf_install_from_dist_all
+# find /tmp/proj_shared_install_from_dist
+$TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_shared_install_from_dist shared
+$TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_shared_install_from_dist shared
+
+echo "Build static ${CMAKE_BUILD_TYPE} configuration from generated tarball"
+cd ..
+mkdir static_build
+cd static_build
+cmake \
+  -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+  -D USE_CCACHE=${USE_CCACHE} \
+  -D BUILD_SHARED_LIBS=OFF \
+  -D CMAKE_INSTALL_PREFIX=/tmp/proj_static_install_from_dist \
+  ..
+make
+
+ctest
+make install
+# find /tmp/proj_static_install_from_dist
+$TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist static
+$TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_static_install_from_dist static
+
+echo "Run PROJJSON tests only with shared configuration"
+
+test_projjson(){
+  printf "Testing PROJJSON output with $* ... "
+  case "$1" in
+    \+*)
+      /tmp/proj_shared_install_from_dist/bin/projinfo "$@" -o PROJJSON -q > out.json ;;
+    *)
+      /tmp/proj_shared_install_from_dist/bin/projinfo $* -o PROJJSON -q > out.json ;;
+  esac
+  # cat out.json
+  if [ $(jsonschema --version) = "3.2.0" ]; then
+    # workaround for this version, which does validate UTf-8
+    iconv -f UTF-8 -t ascii//TRANSLIT out.json > out.ascii
+    mv out.ascii out.json
+  fi
+  jsonschema -i out.json /tmp/proj_shared_install_from_dist/share/proj/projjson.schema.json
+  ret=$?
+  if [ $ret != 0 ]; then
+    return $ret
+  else
+    echo "Valid!"
+  fi
+  /tmp/proj_shared_install_from_dist/bin/projinfo @out.json -o PROJJSON -q > out2.json
+  diff -u out.json out2.json
+  ret=$?
+  rm -f out.json out2.json
+  return $ret
+}
+
+test_projjson EPSG:32631
+test_projjson EPSG:4326+3855
+test_projjson "+proj=longlat +ellps=GRS80 +nadgrids=@foo +type=crs"
+test_projjson -s EPSG:3111 -t GDA2020
+
+cd ..
+
+echo "Check that we can retrieve the resource directory in a relative way after renaming the installation prefix"
+
+mkdir /tmp/proj_shared_install_from_dist_renamed
+mkdir /tmp/proj_static_install_from_dist_renamed
+mv /tmp/proj_shared_install_from_dist /tmp/proj_shared_install_from_dist_renamed/subdir
+mv /tmp/proj_static_install_from_dist /tmp/proj_static_install_from_dist_renamed/subdir
+set +e
+/tmp/proj_shared_install_from_dist_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null 1>shared.out
+/tmp/proj_static_install_from_dist_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null 1>static.out
+set -e
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # on macOS /tmp is a symblink to /private/tmp only for the shared build
+    INST=/private/tmp
+else
+    INST=/tmp
+fi
+cat shared.out
+grep "Downloading from https://cdn.proj.org into $INST/proj_shared_install_from_dist_renamed/subdir/share/proj" shared.out
+cat static.out
+grep "Downloading from https://cdn.proj.org into /tmp/proj_static_install_from_dist_renamed/subdir/share/proj" static.out
+rm shared.out static.out
+
+sed -i'.bak' -e '1c\
+prefix='"$INST"'/proj_shared_install_from_dist_renamed/subdir' $INST/proj_shared_install_from_dist_renamed/subdir/lib/pkgconfig/proj.pc
+# cat $INST/proj_shared_install_from_dist_renamed/subdir/lib/pkgconfig/proj.pc
+
+sed -i'.bak' -e '1c\
+prefix=/tmp/proj_static_install_from_dist_renamed/subdir' /tmp/proj_static_install_from_dist_renamed/subdir/lib/pkgconfig/proj.pc
+# cat /tmp/proj_static_install_from_dist_renamed/subdir/lib/pkgconfig/proj.pc
+
 if [ $BUILD_NAME = "linux_gcc" ]; then
-    $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_autoconf_install_from_dist_all shared
-    $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_autoconf_install_from_dist_all static
-elif [ $BUILD_NAME = "osx" ]; then
-    # skip static builds, as macOS shows: ld: unknown option: -Bstatic
-    $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_autoconf_install_from_dist_all shared
+    $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_shared_install_from_dist_renamed/subdir shared
+    PROJ_LIB=/tmp/proj_static_install_from_dist_renamed/subdir/share/proj $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_static_install_from_dist_renamed/subdir static
 else
     echo "Skipping test_autotools.sh test for $BUILD_NAME"
 fi
 
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo EPSG:32631 -o PROJJSON -q > out.json
-cat out.json
-echo "Validating JSON"
-jsonschema -i out.json /tmp/proj_autoconf_install_from_dist_all/share/proj/projjson.schema.json && echo "Valid !"
-
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo EPSG:4326+3855 -o PROJJSON -q > out.json
-cat out.json
-echo "Validating JSON"
-jsonschema -i out.json /tmp/proj_autoconf_install_from_dist_all/share/proj/projjson.schema.json && echo "Valid !"
-
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo "+proj=longlat +ellps=GRS80 +nadgrids=@foo +type=crs" -o PROJJSON -q > out.json
-cat out.json
-echo "Validating JSON"
-jsonschema -i out.json /tmp/proj_autoconf_install_from_dist_all/share/proj/projjson.schema.json && echo "Valid !"
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo @out.json -o PROJJSON -q > out2.json
-diff -u out.json out2.json
-
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo -s EPSG:3111 -t GDA2020 -o PROJJSON -o PROJJSON -q > out.json
-cat out.json
-echo "Validating JSON"
-jsonschema -i out.json /tmp/proj_autoconf_install_from_dist_all/share/proj/projjson.schema.json && echo "Valid !"
-/tmp/proj_autoconf_install_from_dist_all/bin/projinfo @out.json -o PROJJSON -q > out2.json
-diff -u out.json out2.json
-
-# Test make clean target
-make clean > /dev/null
-
-cd ..
-
-if [ $TRAVIS_OS_NAME != "osx" ]; then
-    # Check that we can retrieve the resource directory in a relative way after renaming the installation prefix
-    mkdir /tmp/proj_autoconf_install_from_dist_all_renamed
-    mv /tmp/proj_autoconf_install_from_dist_all /tmp/proj_autoconf_install_from_dist_all_renamed/subdir
-    LD_LIBRARY_PATH=/tmp/proj_autoconf_install_from_dist_all_renamed/subdir/lib /tmp/proj_autoconf_install_from_dist_all_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory || /bin/true
-    LD_LIBRARY_PATH=/tmp/proj_autoconf_install_from_dist_all_renamed/subdir/lib /tmp/proj_autoconf_install_from_dist_all_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null | grep "Downloading from https://cdn.proj.org into /tmp/proj_autoconf_install_from_dist_all_renamed/subdir/share/proj"
-    sed -i '1cprefix=/tmp/proj_autoconf_install_from_dist_all_renamed/subdir' /tmp/proj_autoconf_install_from_dist_all_renamed/subdir/lib/pkgconfig/proj.pc
-    if [ $BUILD_NAME = "linux_gcc" ]; then
-        $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_autoconf_install_from_dist_all_renamed/subdir shared
-        PROJ_LIB=/tmp/proj_autoconf_install_from_dist_all_renamed/subdir/share/proj $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_autoconf_install_from_dist_all_renamed/subdir static
-    else
-        echo "Skipping test_autotools.sh test for $BUILD_NAME"
-    fi
-fi
+$TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_shared_install_from_dist_renamed/subdir shared
+PROJ_LIB=/tmp/proj_static_install_from_dist_renamed/subdir/share/proj $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist_renamed/subdir static
 
 if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
-
-    cmake --version
-
-    # Build PROJ as a subproject
+    echo "Build PROJ as a subproject"
     mkdir proj_as_subproject
     cd proj_as_subproject
     mkdir external
@@ -140,61 +185,41 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
 
     mkdir build_cmake
     cd build_cmake
-    cmake .. -DCMAKE_BUILD_TYPE=Debug
-    VERBOSE=1 make >/dev/null
-    cd ../..
-
-    # Use ccache if it's available
-    if command -v ccache &> /dev/null
-    then
-        USE_CCACHE=ON
-        ccache -s
-    else
-        USE_CCACHE=OFF
-    fi
-
-    # Regular build
-    mkdir build_cmake
-    cd build_cmake
-    cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj_cmake_install -DUSE_CCACHE=${USE_CCACHE}
-    make >/dev/null
-    if [ "${USE_CCACHE}" = "ON" ]; then
-        ccache -s
-    fi
-
-    make install >/dev/null
-    ctest
-    find /tmp/proj_cmake_install
-    if [ $BUILD_NAME = "linux_gcc" ] || [ $BUILD_NAME = "osx" ]; then
-        $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_cmake_install shared
-        $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_cmake_install shared
-    else
-        echo "Skipping test_cmake.sh and test_autotools.sh for $BUILD_NAME"
-    fi
-    cd ..
-
-    # Check that we can retrieve the resource directory in a relative way after renaming the installation prefix
-    mkdir /tmp/proj_cmake_install_renamed
-    mv /tmp/proj_cmake_install /tmp/proj_cmake_install_renamed/subdir
-    set +e
-    /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory
-    /tmp/proj_cmake_install_renamed/subdir/bin/projsync --source-id ? --dry-run --system-directory 2>/dev/null | grep "Downloading from https://cdn.proj.org into /tmp/proj_cmake_install_renamed/subdir/share/proj"
-    set -e
+    cmake -D USE_CCACHE=${USE_CCACHE} ..
+    make
 
     # return to root
-    cd ../..
+    cd ../../../..
 
+    echo "Build coverage as in-source build"
     # There's an issue with the clang on Travis + coverage + cpp code
     if [ "$BUILD_NAME" != "linux_clang" ]; then
-        # autoconf build with grids and coverage
+        # build with grids and coverage
         if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-            CFLAGS="--coverage" CXXFLAGS="--coverage" ./configure;
+            cmake \
+              -D CMAKE_BUILD_TYPE=Debug \
+              -D USE_CCACHE=${USE_CCACHE} \
+              -D CMAKE_C_FLAGS="--coverage" \
+              -D CMAKE_CXX_FLAGS="--coverage" \
+              . ;
         else
-            CFLAGS="$CFLAGS --coverage" CXXFLAGS="$CXXFLAGS --coverage" LDFLAGS="$LDFLAGS -lgcov" ./configure;
+            LDFLAGS="$LDFLAGS -lgcov" cmake \
+              -D CMAKE_BUILD_TYPE=Debug \
+              -D USE_CCACHE=${USE_CCACHE} \
+              -D CMAKE_C_FLAGS="$CFLAGS --coverage" \
+              -D CMAKE_CXX_FLAGS="$CXXFLAGS --coverage" \
+              . ;
         fi
     else
-        ./configure
+        cmake \
+          -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+          -D USE_CCACHE=${USE_CCACHE} \
+          . ;
     fi
-    make >/dev/null
-    make check
+    make
+    ctest
+fi
+
+if [ "${USE_CCACHE}" = "ON" ]; then
+    ccache -s
 fi

--- a/travis/linux_generic/install.sh
+++ b/travis/linux_generic/install.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-export CCACHE_CPP2=yes
 export PROJ_DB_CACHE_DIR="$HOME/.ccache"
 
 # -fno-use-cxa-atexit is needed to build with -coverage
-CC="ccache $CC" CXX="ccache $CXX" CFLAGS="-Werror" CXXFLAGS="-Werror" ./travis/install.sh
+CFLAGS="-Werror" CXXFLAGS="-Werror" ./travis/install.sh


### PR DESCRIPTION
This PR rewrites most of travis/install.sh to replace autotools with cmake. There is lots going on here, so here is a brief description of some of the changes:

- Build PROJ twice, for static and dynamic builds, each in their own build and install directories; most tests are run for each group
- `cmake/ProjConfig.cmake` was adjusted to temporarily remove `-Werror` C flag while running `check_library_exists(m exp "" HAVE_LIBM)`, as this raised an error with GCC 5.4
- Update PATH on Clang Linux to fix tests with jsonschema, which fixed one issue, but created a different issue that requires a workaround for jsonschema version 3.2.0 (error was `jsonschema: error: argument -i/--instance: invalid _json_file value: 'out.json'`)
- Install jsonschema for macOS, which fixed another issue, but created several different issues (1) that `/tmp` is a symblink to `/private/tmp` only for the shared version of the library in some contexts, and (2) `sed` behaves differently than on linux, requiring a backup suffix and use of command `c\` (not `c`)
- Coverage build with `lcov` seemed to need an in-source build (i.e. `cmake .`), so this remains the last step
- No need to (e.g.) use `CC="ccache gcc"`, as this should be handled by [`USE_CCACHE=ON`](https://github.com/OSGeo/PROJ/pull/2948); move all of the `ccache -s` into the main script
- Remove `export CCACHE_CPP2=yes` as this was required for older versions of ccache
- Update test/fuzzers paths to assume a cmake build path

A PR to drop autotools support will follow after this. The cache on macOS is not working, so that'll be another follow-up task to sort-out.