### PR TITLE
lookForGridInfo(): make it work properly when passed the old PROJ name

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -3272,7 +3272,9 @@ bool DatabaseContext::lookForGridInfo(
                "grid_alternatives.open_license, "
                "grid_packages.open_license AS package_open_license, "
                "grid_alternatives.direct_download, "
-               "grid_packages.direct_download AS package_direct_download "
+               "grid_packages.direct_download AS package_direct_download, "
+               "grid_alternatives.proj_grid_name, "
+               "grid_alternatives.old_proj_grid_name "
                "FROM grid_alternatives "
                "LEFT JOIN grid_packages ON "
                "grid_alternatives.package_name = grid_packages.package_name "
@@ -3285,6 +3287,28 @@ bool DatabaseContext::lookForGridInfo(
         url = row[1].empty() ? std::move(row[2]) : std::move(row[1]);
         openLicense = (row[3].empty() ? row[4] : row[3]) == "1";
         directDownload = (row[5].empty() ? row[6] : row[5]) == "1";
+
+        const auto &proj_grid_name = row[7];
+        const auto &old_proj_grid_name = row[8];
+        if (proj_grid_name != old_proj_grid_name &&
+            old_proj_grid_name == projFilename) {
+            std::string fullFilenameNewName;
+            fullFilenameNewName.resize(2048);
+            if (d->pjCtxt() == nullptr) {
+                d->setPjCtxt(pj_get_default_ctx());
+            }
+            int errno_before = proj_context_errno(d->pjCtxt());
+            bool gridAvailableWithNewName =
+                pj_find_file(d->pjCtxt(), proj_grid_name.c_str(),
+                             &fullFilenameNewName[0],
+                             fullFilenameNewName.size() - 1) != 0;
+            proj_context_errno_set(d->pjCtxt(), errno_before);
+            fullFilenameNewName.resize(strlen(fullFilenameNewName.c_str()));
+            if (gridAvailableWithNewName) {
+                gridAvailable = true;
+                fullFilename = fullFilenameNewName;
+            }
+        }
 
         if (considerKnownGridsAsAvailable &&
             (!packageName.empty() || (!url.empty() && openLicense))) {

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -2763,6 +2763,47 @@ TEST_F(FactoryWithTmpDatabase, lookForGridInfo) {
 
 // ---------------------------------------------------------------------------
 
+TEST_F(FactoryWithTmpDatabase,
+       lookForGridInfo_from_old_name_with_new_grid_available) {
+    createStructure();
+
+    ASSERT_TRUE(execute("INSERT INTO grid_alternatives(original_grid_name,"
+                        "proj_grid_name, "
+                        "old_proj_grid_name, "
+                        "proj_grid_format, "
+                        "proj_method, "
+                        "inverse_direction, "
+                        "package_name, "
+                        "url, direct_download, open_license, directory) "
+                        "VALUES ("
+                        "'NOT-YET-IN-GRID-TRANSFORMATION-original_grid_name', "
+                        "'tests/egm96_15_uncompressed_truncated.tif', "
+                        "'old_name.gtx', "
+                        "'NTv2', "
+                        "'hgridshift', "
+                        "0, "
+                        "NULL, "
+                        "'url', 1, 1, NULL);"))
+        << last_error();
+
+    std::string fullFilename;
+    std::string packageName;
+    std::string url;
+    bool directDownload = false;
+    bool openLicense = false;
+    bool gridAvailable = false;
+    EXPECT_TRUE(DatabaseContext::create(m_ctxt)->lookForGridInfo(
+        "old_name.gtx", false, fullFilename, packageName, url, directDownload,
+        openLicense, gridAvailable));
+    EXPECT_TRUE(
+        fullFilename.find("tests/egm96_15_uncompressed_truncated.tif") !=
+        std::string::npos)
+        << fullFilename;
+    EXPECT_EQ(gridAvailable, true);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST_F(FactoryWithTmpDatabase, custom_geodetic_crs) {
     createStructure();
     populateWithFakeEPSG();


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/45470

That is, if the file for the old PROJ name is not found, but the file
for the new PROJ name is found, then use the later for fullFilename and
gridAvailable.