### PR TITLE
Allow PROJ_LIB paths wrapped with double quotes

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1420,6 +1420,21 @@ static void *pj_open_lib_internal(
         if (out_full_filename != nullptr && out_full_filename_size > 0)
             out_full_filename[0] = '\0';
 
+        auto open_lib_from_paths = [&ctx, open_file, &name, &fname, &sysname, &mode](const std::string & projLib) {
+            void *fid = nullptr;
+            auto paths = NS_PROJ::internal::split(projLib, dirSeparator);
+            for (const auto& path : paths) {
+                fname = NS_PROJ::internal::stripQuotes(path);;
+                fname += DIR_CHAR;
+                fname += name;
+                sysname = fname.c_str();
+                fid = open_file(ctx, sysname, mode);
+                if (fid)
+                    break;
+            }
+            return fid;
+        };
+
         /* check if ~/name */
         if (is_tilde_slash(name))
             if ((sysname = getenv("HOME")) != nullptr) {
@@ -1487,16 +1502,7 @@ static void *pj_open_lib_internal(
         else if (!gbPROJ_LIB_ENV_VAR_TRIED_LAST &&
                  !(projLib = NS_PROJ::FileManager::getProjLibEnvVar(ctx))
                       .empty()) {
-            auto paths = NS_PROJ::internal::split(projLib, dirSeparator);
-            for (const auto &path : paths) {
-                fname = path;
-                fname += DIR_CHAR;
-                fname += name;
-                sysname = fname.c_str();
-                fid = open_file(ctx, sysname, mode);
-                if (fid)
-                    break;
-            }
+            fid = open_lib_from_paths(projLib);
         }
 
         else if ((sysname = get_path_from_relative_share_proj(
@@ -1519,16 +1525,7 @@ static void *pj_open_lib_internal(
         else if (gbPROJ_LIB_ENV_VAR_TRIED_LAST &&
                  !(projLib = NS_PROJ::FileManager::getProjLibEnvVar(ctx))
                       .empty()) {
-            auto paths = NS_PROJ::internal::split(projLib, dirSeparator);
-            for (const auto &path : paths) {
-                fname = path;
-                fname += DIR_CHAR;
-                fname += name;
-                sysname = fname.c_str();
-                fid = open_file(ctx, sysname, mode);
-                if (fid)
-                    break;
-            }
+            fid = open_lib_from_paths(projLib);
         }
 
         else {

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1421,18 +1421,18 @@ static void *pj_open_lib_internal(
             out_full_filename[0] = '\0';
 
         auto open_lib_from_paths = [&ctx, open_file, &name, &fname, &sysname, &mode](const std::string & projLibPaths) {
-            void *fid = nullptr;
+            void *lib_fid = nullptr;
             auto paths = NS_PROJ::internal::split(projLibPaths, dirSeparator);
             for (const auto& path : paths) {
                 fname = NS_PROJ::internal::stripQuotes(path);
                 fname += DIR_CHAR;
                 fname += name;
                 sysname = fname.c_str();
-                fid = open_file(ctx, sysname, mode);
-                if (fid)
+                lib_fid = open_file(ctx, sysname, mode);
+                if (lib_fid)
                     break;
             }
-            return fid;
+            return lib_fid;
         };
 
         /* check if ~/name */

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1420,9 +1420,9 @@ static void *pj_open_lib_internal(
         if (out_full_filename != nullptr && out_full_filename_size > 0)
             out_full_filename[0] = '\0';
 
-        auto open_lib_from_paths = [&ctx, open_file, &name, &fname, &sysname, &mode](const std::string & projLib) {
+        auto open_lib_from_paths = [&ctx, open_file, &name, &fname, &sysname, &mode](const std::string & projLibPaths) {
             void *fid = nullptr;
-            auto paths = NS_PROJ::internal::split(projLib, dirSeparator);
+            auto paths = NS_PROJ::internal::split(projLibPaths, dirSeparator);
             for (const auto& path : paths) {
                 fname = NS_PROJ::internal::stripQuotes(path);;
                 fname += DIR_CHAR;

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1424,7 +1424,7 @@ static void *pj_open_lib_internal(
             void *fid = nullptr;
             auto paths = NS_PROJ::internal::split(projLibPaths, dirSeparator);
             for (const auto& path : paths) {
-                fname = NS_PROJ::internal::stripQuotes(path);;
+                fname = NS_PROJ::internal::stripQuotes(path);
                 fname += DIR_CHAR;
                 fname += name;
                 sysname = fname.c_str();


### PR DESCRIPTION
This improvement is mostly useful on Windows, where users
are used to wrapping paths with whitespaces with double quotes.

For example, these should now be allowed (correctly concatenated):

```
PROJ_LIB="C:\Program Files\PROJ";C:\Users\mloskot\PROJ
```

------
By the way, as per https://github.com/OSGeo/PROJ/pull/1230#issuecomment-455826744 paths with spaces are supported:

> > Can folders with spaces in them also be added to `PROJ_LIB`?
>
> yes. The only restriction is that they don't have ':' in them on Unix or ';' on Windows as those are used as separator to delineate directories

------
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Added clear title that can be used to generate release notes
