### PR TITLE
Update SHA1SUM of https://github.com/google/googletest/archive/release-1.11.0.zip

### DIFF
--- a/test/googletest/CMakeLists.txt.in
+++ b/test/googletest/CMakeLists.txt.in
@@ -6,7 +6,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   URL https://github.com/google/googletest/archive/release-1.11.0.zip
-  URL_HASH SHA1=9ffb7b5923f4a8fcdabf2f42c6540cce299f44c0
+  URL_HASH SHA1=95fbeb07b95f0b0c740a2c6e2f6e60c4af06796a
   DOWNLOAD_NO_PROGRESS ON
   SOURCE_DIR        "${PROJ_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${PROJ_BINARY_DIR}/googletest-build"


### PR DESCRIPTION
The sha1sum of the .zip has changed overnight. Comparing a previous old
cached archive and a newly downloaded one, their content is identical once
unzipped. The .zip file sizes are identical but they differ on some
bytes in the 'header' of each zipped file. Probably github changed their
version of the zip utility ?
