### PR TITLE
Set more precise error code for parsing errors in proj_create().

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -572,6 +572,11 @@ PJ *proj_create(PJ_CONTEXT *ctx, const char *text) {
         if (identifiedObject) {
             return pj_obj_create(ctx, NN_NO_CHECK(identifiedObject));
         }
+    } catch (const io::ParsingException &e) {
+        if (proj_context_errno(ctx) == 0) {
+            proj_context_errno_set(ctx, PROJ_ERR_INVALID_OP_WRONG_SYNTAX);
+        }
+        proj_log_error(ctx, __FUNCTION__, e.what());
     } catch (const std::exception &e) {
         proj_log_error(ctx, __FUNCTION__, e.what());
     }

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -533,11 +533,11 @@ expect      0 0 1
 roundtrip   1
 
 -------------------------------------------------------------------------------
-# Check that proj_create() returns a generic error when an exception is caught
+# Check that proj_create() returns a syntax error when an exception is caught
 # in the creation of a PJ object.
 -------------------------------------------------------------------------------
-operation   this is a bogus CRS meant to trigger a generic error in proj_create()
-expect      failure   errno other
+operation   this is a bogus CRS meant to trigger a syntax error in proj_create()
+expect      failure   errno invalid_op_wrong_syntax
 
 -------------------------------------------------------------------------------
 # Test proj=set


### PR DESCRIPTION
If proj_create() catches a ParsingException, and the error code hasn't
otherwise been set internally, set the error code to
PROJ_ERR_INVALID_OP_WRONG_SYNTAX instead of allowing it to default to
the generic PROJ_ERR_OTHER.

Ref #2529

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #xxxx
 - [x] Tests added (modified existing test)
 - [x] Added clear title that can be used to generate release notes
