### PR TITLE
Docker: update base image to ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # OSGeo/PROJ
 
-FROM ubuntu:18.04 as builder
+FROM ubuntu:20.04 as builder
 
 MAINTAINER Howard Butler <howard@hobu.co>
 
@@ -9,10 +9,10 @@ ARG DESTDIR="/build"
 
 # Setup build env
 RUN apt-get update -y \
-    && apt-get install -y --fix-missing --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
             software-properties-common build-essential ca-certificates \
-            make cmake wget unzip libtool automake \
-            zlib1g-dev libsqlite3-dev pkg-config sqlite3 libcurl4-gnutls-dev \
+            cmake wget unzip \
+            zlib1g-dev libsqlite3-dev sqlite3 libcurl4-gnutls-dev \
             libtiff5-dev
 
 COPY . /PROJ
@@ -27,7 +27,7 @@ RUN cd /PROJ \
 
 
 
-FROM ubuntu:18.04 as runner
+FROM ubuntu:20.04 as runner
 
 RUN date
 

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-dev python3-pip g++ doxygen dvipng latexmk \


### PR DESCRIPTION
Upgrade the Ubuntu-based docker images to the latest Ubuntu LTS, with end of standard support in April 2025 and EOL 2030.

Specific motivation for docs/docbuild/Dockerfile is to upgrade beyond Python 3.6, which is no longer supported upstream and by many packages in use. Ubuntu 20.04 includes support for Python 3.8.

Images and docs (pdf and html) were built locally, and look fine.