### PR TITLE
Fix nullptr dereference in utilities when argv[0] == NULL

### DIFF
--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -346,6 +346,10 @@ int main(int argc, char **argv) {
     int have_to_flag = 0, inverse = 0;
     int use_env_locale = 0;
 
+    if( argc == 0 ) {
+        exit(1);
+    }
+
     /* This is just to check that pj_init() is locale-safe */
     /* Used by nad/testvarious */
     if (getenv("PROJ_USE_ENV_LOCALE") != nullptr)

--- a/src/apps/geod.cpp
+++ b/src/apps/geod.cpp
@@ -136,6 +136,10 @@ int main(int argc, char **argv) {
 	FILE *fid;
 	static int eargc = 0, c;
 
+	if( argc == 0 ) {
+		exit(1);
+	}
+
 	if ((emess_dat.Prog_name = strrchr(*argv,'/')) != nullptr) ++emess_dat.Prog_name;
 	else emess_dat.Prog_name = *argv;
 	inverse = strncmp(emess_dat.Prog_name, "inv", 3) == 0 ||

--- a/src/apps/optargpm.h
+++ b/src/apps/optargpm.h
@@ -415,6 +415,9 @@ OPTARGS *opt_parse (int argc, char **argv, const char *flags, const char *keys, 
     int free_format;
     OPTARGS *o;
 
+    if( argc == 0 )
+        return nullptr;
+
     o = (OPTARGS *) calloc (1, sizeof(OPTARGS));
     if (nullptr==o)
         return nullptr;

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -300,6 +300,10 @@ int main(int argc, char **argv) {
     FILE *fid;
     int eargc = 0, mon = 0;
 
+    if( argc == 0 ) {
+        exit(1);
+    }
+
     if ( (emess_dat.Prog_name = strrchr(*argv,DIR_CHAR)) != nullptr)
         ++emess_dat.Prog_name;
     else emess_dat.Prog_name = *argv;


### PR DESCRIPTION
https://lwn.net/Articles/?offset=50 was an entertaining reading where we
learn that the fact that argv[0] contains the name of the binary is
purely a convention, normally taken by the shell that launches the
process, but not guaranteed by the execve() system call that does the
job.

The following test program tested against cct, cs2cs, geod, gie and proj
make them cause a null pointer dereference

```
 #include <unistd.h>
 #include <stdio.h>
extern char **environ;

int main()
{
    char* argv[] = { NULL };
    printf("%d\n", execve("/path/to/some/proj/binary", argv, environ));
    return 0;
}
```
CC @busstoptaktik @cffk  I'm sure you'll find that amusing :-)