### PR TITLE
Increase MAX_ITER so Mollweide forward projection works near the poles.

### DIFF
--- a/src/projections/moll.cpp
+++ b/src/projections/moll.cpp
@@ -10,7 +10,7 @@ PROJ_HEAD(moll, "Mollweide") "\n\tPCyl, Sph";
 PROJ_HEAD(wag4, "Wagner IV") "\n\tPCyl, Sph";
 PROJ_HEAD(wag5, "Wagner V") "\n\tPCyl, Sph";
 
-#define MAX_ITER    10
+#define MAX_ITER    30
 #define LOOP_TOL    1e-7
 
 namespace { // anonymous namespace

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -3599,6 +3599,18 @@ roundtrip 1
 accept  -2 -1
 expect  -201113.698641813 -124066.283433860
 roundtrip 1
+accept  0.0 89.99
+expect  0.00 9050917.562466157600
+roundtrip 1
+accept  0.0 90.0
+expect  0.00 9050966.799011318013
+roundtrip 1
+accept  0.0 -89.99
+expect  0.0 -9050917.562466157600
+roundtrip 1
+accept  0.0 -90.0
+expect  0.00 -9050966.799011318013
+roundtrip 1
 
 direction inverse
 accept  200 100

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -3602,14 +3602,14 @@ roundtrip 1
 accept  0.0 89.99
 expect  0.00 9050917.562466157600
 roundtrip 1
-accept  0.0 90.0
-expect  0.00 9050966.799011318013
+accept  0.0 89.999
+expect  0.00 9050964.513822982088
 roundtrip 1
 accept  0.0 -89.99
 expect  0.0 -9050917.562466157600
 roundtrip 1
-accept  0.0 -90.0
-expect  0.00 -9050966.799011318013
+accept  0.0 -89.999
+expect  0.00 -9050964.513822982088
 roundtrip 1
 
 direction inverse


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API

As has been reported on `cartopy` [here](https://github.com/SciTools/cartopy/issues/1604), and [here](https://github.com/SciTools/cartopy/issues/1333), the `PROJ` implementation of the Mollweide projection fails near the poles.  In particular, with all versions up to and including 9.0.0, you can see that all declinations north of ~89.15 map to the same x/y point:
```
$ echo 0.0 89.1 | proj +proj=moll +ellps=GRS80
0.00	9000253.15
$ echo 0.0 89.2 | proj +proj=moll +ellps=GRS80
0.00	9020047.85
$ echo 0.0 89.3 | proj +proj=moll +ellps=GRS80
0.00	9020047.85
$ echo 0.0 89.4 | proj +proj=moll +ellps=GRS80
0.00	9020047.85
```
It turns out the problem is simply that the `MAX_ITER` value is too low.  Setting `MAX_ITER = 30` as in this PR allows the projection to work properly up to (at least) 89.99999.  There should be no penalty for performance at other declinations since the convergence tolerance has not been changed.

With this PR:
```
$ echo 0.0 89.1 | proj +proj=moll +ellps=GRS80
0.00	9000253.15
$ echo 0.0 89.2 | proj +proj=moll +ellps=GRS80
0.00	9003130.48
$ echo 0.0 89.3 | proj +proj=moll +ellps=GRS80
0.00	9005889.97
$ echo 0.0 89.4 | proj +proj=moll +ellps=GRS80
0.00	9008520.64
$ echo 0.0 89.999 | proj +proj=moll +ellps=GRS80
0.00	9020045.57
$ echo 0.0 89.9999 | proj +proj=moll +ellps=GRS80 
0.00	9020047.74
$ echo 0.0 89.99999 | proj +proj=moll +ellps=GRS80
0.00	9020047.84
```

For further information, setting `MAX_ITER = 20` works up to 89.999.