### PR TITLE
CI: use `ctest --output-on-failure` option

### DIFF
--- a/.github/workflows/mingw_w64/start.sh
+++ b/.github/workflows/mingw_w64/start.sh
@@ -113,7 +113,7 @@ cmake -G "Unix Makefiles" \
     ..
 make
 # Run a subset of tests that should pass
-ctest -R "proj_test_cpp_api|geodesic-test|proj_errno_string_test|proj_angular_io_test|proj_context_test|pj_phi2_test|gie_self_tests|test_network|test_defmodel|test_tinshift|test_misc|test_fork"
+ctest --output-on-failure -R "proj_test_cpp_api|geodesic-test|proj_errno_string_test|proj_angular_io_test|proj_context_test|pj_phi2_test|gie_self_tests|test_network|test_defmodel|test_tinshift|test_misc|test_fork"
 # TODO: fix failing tests with .gie files; see #2168 and run
 # PROJ_LIB=./data/for_tests wine64 ./bin/gie.exe ../test/gie/more_builtins.gie
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
             set PROJ_DIR=%GITHUB_WORKSPACE%\proj_dir
             set PROJ_BUILD=%GITHUB_WORKSPACE%\build
             cd %PROJ_BUILD%
-            ctest -V -C "${{ env.BUILD_TYPE }}"
+            ctest --output-on-failure -C "${{ env.BUILD_TYPE }}"
             set PATH=%PROJ_DIR%\bin;%PATH%
             set BUILD_MODE=shared
             if "${{ env.BUILD_SHARED_LIBS }}"=="OFF" (set BUILD_MODE=static)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ test_script:
   - echo test_script
   - set PROJ_LIB=%PROJ_DIR%\share\proj
   - cd %PROJ_BUILD%
-  - ctest -V -C Release
+  - ctest --output-on-failure -C Release
   - set PATH=%PROJ_DIR%\bin;%PATH%
   - set BUILD_MODE=shared
   - if BUILD_SHARED_LIBS==OFF (set BUILD_MODE=static)

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -70,7 +70,7 @@ if objdump -TC "lib/libproj.so" | grep "elf64-x86-64">/dev/null; then
 fi
 fi
 
-ctest
+ctest --output-on-failure
 make install
 # find /tmp/proj_shared_install_from_dist
 $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_shared_install_from_dist shared
@@ -88,7 +88,7 @@ cmake \
   ..
 make
 
-ctest
+ctest --output-on-failure
 make install
 # find /tmp/proj_static_install_from_dist
 $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist static
@@ -225,7 +225,7 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
           . ;
     fi
     make
-    ctest
+    ctest --output-on-failure
 fi
 
 if [ "${USE_CCACHE}" = "ON" ]; then


### PR DESCRIPTION
Use [ctest](https://cmake.org/cmake/help/v3.9/manual/ctest.1.html) option `--output-on-failure`. It's usually preferred over the verbose `-V` option, as it only shows verbose output on failure.