### PR TITLE
unitconvert: round to nearest date when converting to yyyymmdd.

### DIFF
--- a/docs/source/operations/conversions/unitconvert.rst
+++ b/docs/source/operations/conversions/unitconvert.rst
@@ -158,6 +158,16 @@ Time units
 
 In the table below all time units supported by PROJ are listed.
 
+    .. note::
+
+        When converting time units from a date-only format (`yyyymmdd`), PROJ
+        assumes a time value of 00:00 midnight.  When converting time units
+        to a date-only format, PROJ rounds to the *nearest* date at 00:00
+        midnight.  That is, any time values less than 12:00 noon will round to
+        00:00 on the same day.  Time values greater than or equal to 12:00 noon
+        will round to 00:00 on the following day.
+
+
 +--------------+-----------------------------+
 | Label        | Name                        |
 +==============+=============================+

--- a/src/conversions/unitconvert.cpp
+++ b/src/conversions/unitconvert.cpp
@@ -254,20 +254,20 @@ static double mjd_to_yyyymmdd(double mjd) {
 /************************************************************************
     Date returned in YYYY-MM-DD format.
 ************************************************************************/
-    unsigned int mjd_iter = 14 + 31;
+    unsigned int date_iter = 14 + 31;
     unsigned int year = 1859, month = 0, day = 0;
     unsigned int date = (int) lround(mjd);
 
-    for (; date >= mjd_iter; year++) {
-        mjd_iter += days_in_year(year);
+    for (; date >= date_iter; year++) {
+        date_iter += days_in_year(year);
     }
     year--;
-    mjd_iter -= days_in_year(year);
+    date_iter -= days_in_year(year);
 
-    for (month=1; mjd_iter + days_in_month(year, month) <= date; month++)
-        mjd_iter += days_in_month(year, month);
+    for (month=1; date_iter + days_in_month(year, month) <= date; month++)
+        date_iter += days_in_month(year, month);
 
-    day = date - mjd_iter + 1;
+    day = date - date_iter + 1;
 
     return year*10000.0 + month*100.0 + day;
 }

--- a/src/conversions/unitconvert.cpp
+++ b/src/conversions/unitconvert.cpp
@@ -252,21 +252,22 @@ static double yyyymmdd_to_mjd(double yyyymmdd) {
 /***********************************************************************/
 static double mjd_to_yyyymmdd(double mjd) {
 /************************************************************************
-    Date given in YYYY-MM-DD format.
+    Date returned in YYYY-MM-DD format.
 ************************************************************************/
-    double mjd_iter = 14 + 31;
-    int year = 1859, month=0, day=0;
+    unsigned int mjd_iter = 14 + 31;
+    unsigned int year = 1859, month = 0, day = 0;
+    unsigned int date = (int) lround(mjd);
 
-    for (; mjd >= mjd_iter; year++) {
+    for (; date >= mjd_iter; year++) {
         mjd_iter += days_in_year(year);
     }
     year--;
     mjd_iter -= days_in_year(year);
 
-    for (month=1; mjd_iter + days_in_month(year, month) <= mjd; month++)
+    for (month=1; mjd_iter + days_in_month(year, month) <= date; month++)
         mjd_iter += days_in_month(year, month);
 
-    day = (int)(mjd - mjd_iter + 1);
+    day = date - mjd_iter + 1;
 
     return year*10000.0 + month*100.0 + day;
 }

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -618,7 +618,6 @@ static void test_time(const char *args, double tol, double t_in, double t_exp) {
 // ---------------------------------------------------------------------------
 
 TEST(gie, unitconvert_selftest) {
-
     char args1[] = "+proj=unitconvert +t_in=decimalyear +t_out=decimalyear";
     double in1 = 2004.25;
 
@@ -639,6 +638,36 @@ TEST(gie, unitconvert_selftest) {
     test_time(args3, 1e-6, in3, in3);
     test_time(args4, 1e-6, in4, exp4);
     test_time(args5, 1e-6, in5, in5);
+}
+
+static void test_date(const char *args, double tol, double t_in, double t_exp) {
+    PJ_COORD in, out;
+    PJ *P = proj_create(PJ_DEFAULT_CTX, args);
+
+    ASSERT_TRUE(P != 0);
+
+    in = proj_coord(0.0, 0.0, 0.0, t_in);
+
+    out = proj_trans(P, PJ_FWD, in);
+    EXPECT_NEAR(out.xyzt.t, t_exp, tol);
+
+    proj_destroy(P);
+
+    proj_log_level(NULL, PJ_LOG_NONE);
+}
+
+TEST(gie, unitconvert_selftest_date) {
+    char args[] = "+proj=unitconvert +t_in=decimalyear +t_out=yyyymmdd";
+    test_date(args, 1e-6, 2022.0027, 20220102);
+    test_date(args, 1e-6, 1990.0, 19900101);
+    test_date(args, 1e-6, 2004.1612, 20040229);
+    test_date(args, 1e-6, 1899.999, 19000101);
+
+    strcpy(&args[18], "+t_in=yyyymmdd +t_out=decimalyear");
+    test_date(args, 1e-6, 20220102, 2022.0027397);
+    test_date(args, 1e-6, 19900101, 1990.0);
+    test_date(args, 1e-6, 20040229, 2004.1612022);
+    test_date(args, 1e-6, 18991231, 1899.9972603);
 }
 
 static const char tc32_utm32[] = {


### PR DESCRIPTION
This resolves an issue where converting from a low-precision decimalyear
to yyyymmdd gave a surprising result, due to mjd_to_yyyymmdd() truncating
away the fractional time component.

This commit changes the behaviour of mjd_to_yyyymmdd() to round to the
nearest date, instead of truncating.

Refs #1483

If this PR is accepted, then it supercedes pull #3074.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1483 
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API