### PR TITLE
DOCS: add missing functions from filemanager.cpp

### DIFF
--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -880,7 +880,13 @@ Setting custom I/O functions
 .. doxygenfunction:: proj_context_set_sqlite3_vfs_name
    :project: doxygen_api
 
+.. doxygenfunction:: proj_context_set_file_finder
+   :project: doxygen_api
+
 .. doxygenfunction:: proj_context_set_search_paths
+   :project: doxygen_api
+
+.. doxygenfunction:: proj_context_set_ca_bundle_path
    :project: doxygen_api
 
 

--- a/src/proj.h
+++ b/src/proj.h
@@ -379,12 +379,12 @@ PJ_CONTEXT PROJ_DLL *proj_context_clone (PJ_CONTEXT *ctx);
 
 /** Callback to resolve a filename to a full path */
 typedef const char* (*proj_file_finder) (PJ_CONTEXT *ctx, const char*, void* user_data);
+/*! @endcond */
 
 void PROJ_DLL proj_context_set_file_finder(PJ_CONTEXT *ctx, proj_file_finder finder, void* user_data);
-/*! @endcond */
 void PROJ_DLL proj_context_set_search_paths(PJ_CONTEXT *ctx, int count_paths, const char* const* paths);
-/*! @cond Doxygen_Suppress */
 void PROJ_DLL proj_context_set_ca_bundle_path(PJ_CONTEXT *ctx, const char *path);
+/*! @cond Doxygen_Suppress */
 void PROJ_DLL proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable);
 int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx, int from_legacy_code_path);
 


### PR DESCRIPTION
Add doxygen entries for:

- proj_context_set_file_finder
- proj_context_set_ca_bundle_path

Fixes #2540

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2540
 - [x] Added clear title that can be used to generate release notes
