### PR TITLE
Fix datum names when importing from PROJ4 crs strings (affects some transformations using geoidgrids)

### DIFF
--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -9852,7 +9852,9 @@ TEST(io, projparse_merc_not_quite_google_mercator) {
     EXPECT_TRUE(wkt.find("METHOD[\"Popular Visualisation Pseudo "
                          "Mercator\",ID[\"EPSG\",1024]") != std::string::npos)
         << wkt;
-    EXPECT_TRUE(wkt.find("DATUM[\"unknown\",") != std::string::npos) << wkt;
+    EXPECT_TRUE(wkt.find("DATUM[\"unknown using nadgrids=@null\",") !=
+                std::string::npos)
+        << wkt;
 
     EXPECT_EQ(
         replaceAll(crs->exportToPROJString(PROJStringFormatter::create().get()),


### PR DESCRIPTION
When importing from a PROJ4 string with +towgs84, +nadgrids or
+geoidgrids terms, the datum name was just set to 'unknown'. So for
example the datums of '+proj=longlat +ellps=GRS80 +towgs84=1,2,3' and
'+proj=longlat +ellps=GRS80 +towgs84=4,5,6' were considered identical,
because they had the same name 'unknown' and used the same ellipsoid.
This affected the transformation of such CRS when they had an
additional +geoidgrids term, which resulted in an erroneous +proj=push
+v_1 +v_2 step to be added to preserve the horizontal coordinates.
