### PR TITLE
Change hub CRS semantics when importing a WKT1 COMPD_CS with a EXTENSION PROJ4_GRIDS

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1056,7 +1056,8 @@ class PROJ_GCC_DLL BoundCRS final : public CRS,
     PROJ_INTERNAL BoundCRSNNPtr shallowCloneAsBoundCRS() const;
     PROJ_INTERNAL bool isTOWGS84Compatible() const;
     PROJ_INTERNAL std::string getHDatumPROJ4GRIDS() const;
-    PROJ_INTERNAL std::string getVDatumPROJ4GRIDS() const;
+    PROJ_INTERNAL std::string getVDatumPROJ4GRIDS(
+        const crs::GeographicCRS *geogCRSOfCompoundCRS = nullptr) const;
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -311,6 +311,10 @@ class PROJ_GCC_DLL WKTFormatter {
     PROJ_INTERNAL void setHDatumExtension(const std::string &filename);
     PROJ_INTERNAL const std::string &getHDatumExtension() const;
 
+    PROJ_INTERNAL void
+    setGeogCRSOfCompoundCRS(const crs::GeographicCRSPtr &crs);
+    PROJ_INTERNAL const crs::GeographicCRSPtr &getGeogCRSOfCompoundCRS() const;
+
     PROJ_INTERNAL static std::string morphNameToESRI(const std::string &name);
 
 #ifdef unused
@@ -445,6 +449,10 @@ class PROJ_GCC_DLL PROJStringFormatter {
 
     PROJ_INTERNAL void setHDatumExtension(const std::string &filename);
     PROJ_INTERNAL const std::string &getHDatumExtension() const;
+
+    PROJ_INTERNAL void
+    setGeogCRSOfCompoundCRS(const crs::GeographicCRSPtr &crs);
+    PROJ_INTERNAL const crs::GeographicCRSPtr &getGeogCRSOfCompoundCRS() const;
 
     PROJ_INTERNAL void setOmitProjLongLatIfPossible(bool omit);
     PROJ_INTERNAL bool omitProjLongLatIfPossible() const;

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -5092,9 +5092,14 @@ void CompoundCRS::_exportToWKT(io::WKTFormatter *formatter) const {
                                     : io::WKTConstants::COMPD_CS,
                              !identifiers().empty());
         formatter->addQuotedString(nameStr());
+        if (!l_components.empty()) {
+            formatter->setGeogCRSOfCompoundCRS(
+                l_components[0]->extractGeographicCRS());
+        }
         for (const auto &crs : l_components) {
             crs->_exportToWKT(formatter);
         }
+        formatter->setGeogCRSOfCompoundCRS(nullptr);
         ObjectUsage::baseExportToWKT(formatter);
         formatter->endNode();
     }
@@ -5136,13 +5141,19 @@ void CompoundCRS::_exportToJSON(
 void CompoundCRS::_exportToPROJString(
     io::PROJStringFormatter *formatter) const // throw(io::FormattingException)
 {
-    for (const auto &crs : componentReferenceSystems()) {
+    const auto &l_components = componentReferenceSystems();
+    if (!l_components.empty()) {
+        formatter->setGeogCRSOfCompoundCRS(
+            l_components[0]->extractGeographicCRS());
+    }
+    for (const auto &crs : l_components) {
         auto crs_exportable =
             dynamic_cast<const IPROJStringExportable *>(crs.get());
         if (crs_exportable) {
             crs_exportable->_exportToPROJString(formatter);
         }
     }
+    formatter->setGeogCRSOfCompoundCRS(nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -5646,9 +5657,17 @@ std::string BoundCRS::getHDatumPROJ4GRIDS() const {
 
 // ---------------------------------------------------------------------------
 
-std::string BoundCRS::getVDatumPROJ4GRIDS() const {
+std::string BoundCRS::getVDatumPROJ4GRIDS(
+    const crs::GeographicCRS *geogCRSOfCompoundCRS) const {
+    // When importing from WKT1 PROJ4_GRIDS extension, we used to hardcode
+    // "WGS 84" as the hub CRS, so let's test that for backward compatibility.
     if (dynamic_cast<VerticalCRS *>(d->baseCRS().get()) &&
         ci_equal(d->hubCRS()->nameStr(), "WGS 84")) {
+        return d->transformation()->getHeightToGeographic3DFilename();
+    } else if (geogCRSOfCompoundCRS &&
+               dynamic_cast<VerticalCRS *>(d->baseCRS().get()) &&
+               ci_equal(d->hubCRS()->nameStr(),
+                        geogCRSOfCompoundCRS->nameStr())) {
         return d->transformation()->getHeightToGeographic3DFilename();
     }
     return std::string();
@@ -5674,7 +5693,8 @@ void BoundCRS::_exportToWKT(io::WKTFormatter *formatter) const {
         formatter->endNode();
     } else {
 
-        auto vdatumProj4GridName = getVDatumPROJ4GRIDS();
+        auto vdatumProj4GridName =
+            getVDatumPROJ4GRIDS(formatter->getGeogCRSOfCompoundCRS().get());
         if (!vdatumProj4GridName.empty()) {
             formatter->setVDatumExtension(vdatumProj4GridName);
             d->baseCRS()->_exportToWKT(formatter);
@@ -5748,7 +5768,8 @@ void BoundCRS::_exportToPROJString(
             "baseCRS of BoundCRS cannot be exported as a PROJ string");
     }
 
-    auto vdatumProj4GridName = getVDatumPROJ4GRIDS();
+    auto vdatumProj4GridName =
+        getVDatumPROJ4GRIDS(formatter->getGeogCRSOfCompoundCRS().get());
     if (!vdatumProj4GridName.empty()) {
         formatter->setVDatumExtension(vdatumProj4GridName);
         crs_exportable->_exportToPROJString(formatter);

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -171,6 +171,7 @@ struct WKTFormatter::Private {
     std::vector<double> toWGS84Parameters_{};
     std::string hDatumExtension_{};
     std::string vDatumExtension_{};
+    crs::GeographicCRSPtr geogCRSOfCompoundCRS_{};
     std::vector<bool> inversionStack_{false};
     std::string result_{};
 
@@ -804,6 +805,18 @@ const std::string &WKTFormatter::getHDatumExtension() const {
 
 // ---------------------------------------------------------------------------
 
+void WKTFormatter::setGeogCRSOfCompoundCRS(const crs::GeographicCRSPtr &crs) {
+    d->geogCRSOfCompoundCRS_ = crs;
+}
+
+// ---------------------------------------------------------------------------
+
+const crs::GeographicCRSPtr &WKTFormatter::getGeogCRSOfCompoundCRS() const {
+    return d->geogCRSOfCompoundCRS_;
+}
+
+// ---------------------------------------------------------------------------
+
 std::string WKTFormatter::morphNameToESRI(const std::string &name) {
 
     for (const auto *suffix : {"(m)", "(ftUS)", "(E-N)", "(N-E)"}) {
@@ -1240,6 +1253,7 @@ struct WKTParser::Private {
     bool esriStyle_ = false;
     bool maybeEsriStyle_ = false;
     DatabaseContextPtr dbContext_{};
+    crs::GeographicCRSPtr geogCRSOfCompoundCRS_{};
 
     static constexpr int MAX_PROPERTY_SIZE = 1024;
     PropertyMap **properties_{};
@@ -4584,21 +4598,31 @@ CRSNNPtr WKTParser::Private::buildVerticalCRS(const WKTNodeNNPtr &node) {
                     gridName != "g2012a_conus.gtx,g2012a_alaska.gtx,"
                                 "g2012a_guam.gtx,g2012a_hawaii.gtx,"
                                 "g2012a_puertorico.gtx,g2012a_samoa.gtx") {
+                    auto geogCRS =
+                        geogCRSOfCompoundCRS_ &&
+                                geogCRSOfCompoundCRS_->primeMeridian()
+                                        ->longitude()
+                                        .getSIValue() == 0 &&
+                                geogCRSOfCompoundCRS_->coordinateSystem()
+                                        ->axisList()[0]
+                                        ->unit() == UnitOfMeasure::DEGREE
+                            ? geogCRSOfCompoundCRS_->promoteTo3D(std::string(),
+                                                                 dbContext_)
+                            : GeographicCRS::EPSG_4979;
+
                     auto sourceTransformationCRS =
                         createBoundCRSSourceTransformationCRS(
-                            crs.as_nullable(),
-                            GeographicCRS::EPSG_4979.as_nullable());
+                            crs.as_nullable(), geogCRS.as_nullable());
                     auto transformation = Transformation::
                         createGravityRelatedHeightToGeographic3D(
                             PropertyMap().set(
                                 IdentifiedObject::NAME_KEY,
-                                sourceTransformationCRS->nameStr() +
-                                    " to WGS84 ellipsoidal height"),
-                            sourceTransformationCRS, GeographicCRS::EPSG_4979,
-                            nullptr, gridName,
+                                sourceTransformationCRS->nameStr() + " to " +
+                                    geogCRS->nameStr() + " ellipsoidal height"),
+                            sourceTransformationCRS, geogCRS, nullptr, gridName,
                             std::vector<PositionalAccuracyNNPtr>());
-                    return nn_static_pointer_cast<CRS>(BoundCRS::create(
-                        crs, GeographicCRS::EPSG_4979, transformation));
+                    return nn_static_pointer_cast<CRS>(
+                        BoundCRS::create(crs, geogCRS, transformation));
                 }
             }
         }
@@ -4648,9 +4672,14 @@ WKTParser::Private::buildDerivedVerticalCRS(const WKTNodeNNPtr &node) {
 
 CRSNNPtr WKTParser::Private::buildCompoundCRS(const WKTNodeNNPtr &node) {
     std::vector<CRSNNPtr> components;
+    bool bFirstNode = true;
     for (const auto &child : node->GP()->children()) {
         auto crs = buildCRS(child);
         if (crs) {
+            if (bFirstNode) {
+                geogCRSOfCompoundCRS_ = crs->extractGeographicCRS();
+                bFirstNode = false;
+            }
             components.push_back(NN_NO_CHECK(crs));
         }
     }
@@ -7483,6 +7512,7 @@ struct PROJStringFormatter::Private {
     std::vector<double> toWGS84Parameters_{};
     std::string vDatumExtension_{};
     std::string hDatumExtension_{};
+    crs::GeographicCRSPtr geogCRSOfCompoundCRS_{};
 
     std::list<Step> steps_{};
     std::vector<Step::KeyValue> globalParamValues_{};
@@ -8674,6 +8704,20 @@ void PROJStringFormatter::setHDatumExtension(const std::string &filename) {
 
 const std::string &PROJStringFormatter::getHDatumExtension() const {
     return d->hDatumExtension_;
+}
+
+// ---------------------------------------------------------------------------
+
+void PROJStringFormatter::setGeogCRSOfCompoundCRS(
+    const crs::GeographicCRSPtr &crs) {
+    d->geogCRSOfCompoundCRS_ = crs;
+}
+
+// ---------------------------------------------------------------------------
+
+const crs::GeographicCRSPtr &
+PROJStringFormatter::getGeogCRSOfCompoundCRS() const {
+    return d->geogCRSOfCompoundCRS_;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -5099,7 +5099,7 @@ TEST(crs, WKT1_VERT_DATUM_EXTENSION_to_WKT2) {
         "                    ORDER[3],\n"
         "                    LENGTHUNIT[\"metre\",1]],\n"
         "            ID[\"EPSG\",4979]]],\n"
-        "    ABRIDGEDTRANSFORMATION[\"EGM2008 geoid height to WGS84 "
+        "    ABRIDGEDTRANSFORMATION[\"EGM2008 geoid height to WGS 84 "
         "ellipsoidal height\",\n"
         "        METHOD[\"GravityRelatedHeight to Geographic3D\"],\n"
         "        PARAMETERFILE[\"Geoid (height correction) model "

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -4268,7 +4268,7 @@ TEST(wkt_parse, WKT1_VERT_DATUM_EXTENSION) {
               crs->hubCRS()->nameStr());
 
     EXPECT_EQ(crs->transformation()->nameStr(),
-              "EGM2008 geoid height to WGS84 ellipsoidal height");
+              "EGM2008 geoid height to WGS 84 ellipsoidal height");
     EXPECT_EQ(crs->transformation()->method()->nameStr(),
               "GravityRelatedHeight to Geographic3D");
     ASSERT_EQ(crs->transformation()->parameterValues().size(), 1U);
@@ -4303,13 +4303,54 @@ TEST(wkt_parse, WKT1_VERT_DATUM_EXTENSION_units_ftUS) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->transformation()->nameStr(),
-              "NAVD88 height to WGS84 ellipsoidal height"); // no (ftUS)
+              "NAVD88 height to WGS 84 ellipsoidal height"); // no (ftUS)
     auto sourceTransformationCRS = crs->transformation()->sourceCRS();
     auto sourceTransformationVertCRS =
         nn_dynamic_pointer_cast<VerticalCRS>(sourceTransformationCRS);
     EXPECT_EQ(
         sourceTransformationVertCRS->coordinateSystem()->axisList()[0]->unit(),
         UnitOfMeasure::METRE);
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(wkt_parse, WKT1_COMPD_CS_VERT_DATUM_EXTENSION) {
+    auto wkt =
+        "COMPD_CS[\"NAD83 + NAVD88 height\",\n"
+        "    GEOGCS[\"NAD83\",\n"
+        "        DATUM[\"North_American_Datum_1983\",\n"
+        "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n"
+        "                AUTHORITY[\"EPSG\",\"7019\"]],\n"
+        "            AUTHORITY[\"EPSG\",\"6269\"]],\n"
+        "        PRIMEM[\"Greenwich\",0,\n"
+        "            AUTHORITY[\"EPSG\",\"8901\"]],\n"
+        "        UNIT[\"degree\",0.0174532925199433,\n"
+        "            AUTHORITY[\"EPSG\",\"9122\"]],\n"
+        "        AUTHORITY[\"EPSG\",\"4269\"]],\n"
+        "    VERT_CS[\"NAVD88 height\",\n"
+        "        VERT_DATUM[\"North American Vertical Datum 1988\",2005,\n"
+        "            EXTENSION[\"PROJ4_GRIDS\",\"@foo.gtx\"],\n"
+        "            AUTHORITY[\"EPSG\",\"5103\"]],\n"
+        "        UNIT[\"metre\",1,\n"
+        "            AUTHORITY[\"EPSG\",\"9001\"]],\n"
+        "        AXIS[\"Gravity-related height\",UP],\n"
+        "        AUTHORITY[\"EPSG\",\"5703\"]]]";
+
+    auto obj = WKTParser().createFromWKT(wkt);
+    auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+    ASSERT_TRUE(crs != nullptr);
+
+    auto boundVertCRS =
+        nn_dynamic_pointer_cast<BoundCRS>(crs->componentReferenceSystems()[1]);
+    ASSERT_TRUE(boundVertCRS != nullptr);
+
+    EXPECT_EQ(boundVertCRS->transformation()->nameStr(),
+              "NAVD88 height to NAD83 ellipsoidal height");
+
+    EXPECT_EQ(
+        crs->exportToWKT(
+            WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL).get()),
+        wkt);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -3710,9 +3710,9 @@ TEST(operation,
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -3789,9 +3789,9 @@ TEST(
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -3867,9 +3867,9 @@ TEST(
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -6013,13 +6013,11 @@ TEST(operation,
     auto op_proj =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
     EXPECT_EQ(op_proj, "+proj=pipeline "
-                       "+step +proj=push +v_1 +v_2 "
                        "+step +proj=axisswap +order=2,1 "
                        "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                        "+step +proj=vgridshift +grids=HT2_0.gtx +multiplier=1 "
                        "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
-                       "+step +proj=axisswap +order=2,1 "
-                       "+step +proj=pop +v_1 +v_2");
+                       "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Previously, when importing a WKT1 like
```
COMPD_CS["NAD83 + NAVD88 height",
    GEOGCS["NAD83",
        DATUM["North_American_Datum_1983",
            SPHEROID["GRS 1980",6378137,298.257222101,
                AUTHORITY["EPSG","7019"]],
            AUTHORITY["EPSG","6269"]],
        PRIMEM["Greenwich",0,
            AUTHORITY["EPSG","8901"]],
        UNIT["degree",0.0174532925199433,
            AUTHORITY["EPSG","9122"]],
        AUTHORITY["EPSG","4269"]],
    VERT_CS["NAVD88 height",
        VERT_DATUM["North American Vertical Datum 1988",2005,
            EXTENSION["PROJ4_GRIDS","@foo.gtx"],
            AUTHORITY["EPSG","5103"]],
        UNIT["metre",1.0,
            AUTHORITY["EPSG","9001"]],
        AXIS["Gravity-related height",UP],
        AUTHORITY["EPSG","5703"]]]
```

we modeled the vertical part as a BoundCRS of a vertical CRS with a hub
CRS being EPSG:4979 and a transformation from the vertical CRS to
EPSG:4979 using the specified grid.

This is quite questionable, and doesn't follow the semantics of the
GDAL <= 2.4 / PROJ < 6 era, where the grid was referenced to the
horizontal datum, rather than WGS 84.

So change this to use the promoted-to-3D geographic CRS of the compound CRS
as the hub CRS / geographic 3D of the vertical transformation.

Said otherwise, the WKT2 export of the above WKT is now:
```
COMPOUNDCRS["NAD83 + NAVD88 height",
    GEOGCRS["NAD83",
        DATUM["North American Datum 1983",
            ELLIPSOID["GRS 1980",6378137,298.257222101,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]],
        CS[ellipsoidal,2],
            AXIS["geodetic latitude (Lat)",north,
                ORDER[1],
                ANGLEUNIT["degree",0.0174532925199433]],
            AXIS["geodetic longitude (Lon)",east,
                ORDER[2],
                ANGLEUNIT["degree",0.0174532925199433]],
        ID["EPSG",4269]],
    BOUNDCRS[
        SOURCECRS[
            VERTCRS["NAVD88 height",
                VDATUM["North American Vertical Datum 1988"],
                CS[vertical,1],
                    AXIS["gravity-related height",up,
                        LENGTHUNIT["metre",1]],
                ID["EPSG",5703]]],
        TARGETCRS[
            GEOGCRS["NAD83",
                DATUM["North American Datum 1983",
                    ELLIPSOID["GRS 1980",6378137,298.257222101,
                        LENGTHUNIT["metre",1]],
                    ID["EPSG",6269]],
                PRIMEM["Greenwich",0,
                    ANGLEUNIT["degree",0.0174532925199433],
                    ID["EPSG",8901]],
                CS[ellipsoidal,3],
                    AXIS["geodetic latitude (Lat)",north,
                        ORDER[1],
                        ANGLEUNIT["degree",0.0174532925199433,
                            ID["EPSG",9122]]],
                    AXIS["geodetic longitude (Lon)",east,
                        ORDER[2],
                        ANGLEUNIT["degree",0.0174532925199433,
                            ID["EPSG",9122]]],
                    AXIS["ellipsoidal height (h)",up,
                        ORDER[3],
                        LENGTHUNIT["metre",1,
                            ID["EPSG",9001]]],
                REMARK["Promoted to 3D from EPSG:4269"]]],
        ABRIDGEDTRANSFORMATION["NAVD88 height to NAD83 ellipsoidal height",
            METHOD["GravityRelatedHeight to Geographic3D"],
            PARAMETERFILE["Geoid (height correction) model file","@foo.gtx",
                ID["EPSG",8666]]]]]
```