### PR TITLE
Change order of horizontal and vertical operations when dealing with WKT1 / PROJ4 compound CRS

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1056,8 +1056,9 @@ class PROJ_GCC_DLL BoundCRS final : public CRS,
     PROJ_INTERNAL BoundCRSNNPtr shallowCloneAsBoundCRS() const;
     PROJ_INTERNAL bool isTOWGS84Compatible() const;
     PROJ_INTERNAL std::string getHDatumPROJ4GRIDS() const;
-    PROJ_INTERNAL std::string getVDatumPROJ4GRIDS(
-        const crs::GeographicCRS *geogCRSOfCompoundCRS = nullptr) const;
+    PROJ_INTERNAL std::string
+    getVDatumPROJ4GRIDS(const crs::GeographicCRS *geogCRSOfCompoundCRS,
+                        const char **outGeoidCRSValue) const;
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;

--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1056,7 +1056,8 @@ class PROJ_GCC_DLL BoundCRS final : public CRS,
     PROJ_INTERNAL BoundCRSNNPtr shallowCloneAsBoundCRS() const;
     PROJ_INTERNAL bool isTOWGS84Compatible() const;
     PROJ_INTERNAL std::string getHDatumPROJ4GRIDS() const;
-    PROJ_INTERNAL std::string getVDatumPROJ4GRIDS() const;
+    PROJ_INTERNAL std::string getVDatumPROJ4GRIDS(
+        const crs::GeographicCRS *geogCRSOfCompoundCRS = nullptr) const;
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -444,8 +444,10 @@ class PROJ_GCC_DLL PROJStringFormatter {
     PROJ_INTERNAL void setTOWGS84Parameters(const std::vector<double> &params);
     PROJ_INTERNAL const std::vector<double> &getTOWGS84Parameters() const;
 
-    PROJ_INTERNAL void setVDatumExtension(const std::string &filename);
+    PROJ_INTERNAL void setVDatumExtension(const std::string &filename,
+                                          const std::string &geoidCRSValue);
     PROJ_INTERNAL const std::string &getVDatumExtension() const;
+    PROJ_INTERNAL const std::string &getGeoidCRSValue() const;
 
     PROJ_INTERNAL void setHDatumExtension(const std::string &filename);
     PROJ_INTERNAL const std::string &getHDatumExtension() const;

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -311,6 +311,10 @@ class PROJ_GCC_DLL WKTFormatter {
     PROJ_INTERNAL void setHDatumExtension(const std::string &filename);
     PROJ_INTERNAL const std::string &getHDatumExtension() const;
 
+    PROJ_INTERNAL void
+    setGeogCRSOfCompoundCRS(const crs::GeographicCRSPtr &crs);
+    PROJ_INTERNAL const crs::GeographicCRSPtr &getGeogCRSOfCompoundCRS() const;
+
     PROJ_INTERNAL static std::string morphNameToESRI(const std::string &name);
 
 #ifdef unused
@@ -445,6 +449,10 @@ class PROJ_GCC_DLL PROJStringFormatter {
 
     PROJ_INTERNAL void setHDatumExtension(const std::string &filename);
     PROJ_INTERNAL const std::string &getHDatumExtension() const;
+
+    PROJ_INTERNAL void
+    setGeogCRSOfCompoundCRS(const crs::GeographicCRSPtr &crs);
+    PROJ_INTERNAL const crs::GeographicCRSPtr &getGeogCRSOfCompoundCRS() const;
 
     PROJ_INTERNAL void setOmitProjLongLatIfPossible(bool omit);
     PROJ_INTERNAL bool omitProjLongLatIfPossible() const;

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -5133,9 +5133,14 @@ void CompoundCRS::_exportToWKT(io::WKTFormatter *formatter) const {
                                     : io::WKTConstants::COMPD_CS,
                              !identifiers().empty());
         formatter->addQuotedString(nameStr());
+        if (!l_components.empty()) {
+            formatter->setGeogCRSOfCompoundCRS(
+                l_components[0]->extractGeographicCRS());
+        }
         for (const auto &crs : l_components) {
             crs->_exportToWKT(formatter);
         }
+        formatter->setGeogCRSOfCompoundCRS(nullptr);
         ObjectUsage::baseExportToWKT(formatter);
         formatter->endNode();
     }
@@ -5177,13 +5182,19 @@ void CompoundCRS::_exportToJSON(
 void CompoundCRS::_exportToPROJString(
     io::PROJStringFormatter *formatter) const // throw(io::FormattingException)
 {
-    for (const auto &crs : componentReferenceSystems()) {
+    const auto &l_components = componentReferenceSystems();
+    if (!l_components.empty()) {
+        formatter->setGeogCRSOfCompoundCRS(
+            l_components[0]->extractGeographicCRS());
+    }
+    for (const auto &crs : l_components) {
         auto crs_exportable =
             dynamic_cast<const IPROJStringExportable *>(crs.get());
         if (crs_exportable) {
             crs_exportable->_exportToPROJString(formatter);
         }
     }
+    formatter->setGeogCRSOfCompoundCRS(nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -5687,9 +5698,17 @@ std::string BoundCRS::getHDatumPROJ4GRIDS() const {
 
 // ---------------------------------------------------------------------------
 
-std::string BoundCRS::getVDatumPROJ4GRIDS() const {
+std::string BoundCRS::getVDatumPROJ4GRIDS(
+    const crs::GeographicCRS *geogCRSOfCompoundCRS) const {
+    // When importing from WKT1 PROJ4_GRIDS extension, we used to hardcode
+    // "WGS 84" as the hub CRS, so let's test that for backward compatibility.
     if (dynamic_cast<VerticalCRS *>(d->baseCRS().get()) &&
         ci_equal(d->hubCRS()->nameStr(), "WGS 84")) {
+        return d->transformation()->getHeightToGeographic3DFilename();
+    } else if (geogCRSOfCompoundCRS &&
+               dynamic_cast<VerticalCRS *>(d->baseCRS().get()) &&
+               ci_equal(d->hubCRS()->nameStr(),
+                        geogCRSOfCompoundCRS->nameStr())) {
         return d->transformation()->getHeightToGeographic3DFilename();
     }
     return std::string();
@@ -5715,7 +5734,8 @@ void BoundCRS::_exportToWKT(io::WKTFormatter *formatter) const {
         formatter->endNode();
     } else {
 
-        auto vdatumProj4GridName = getVDatumPROJ4GRIDS();
+        auto vdatumProj4GridName =
+            getVDatumPROJ4GRIDS(formatter->getGeogCRSOfCompoundCRS().get());
         if (!vdatumProj4GridName.empty()) {
             formatter->setVDatumExtension(vdatumProj4GridName);
             d->baseCRS()->_exportToWKT(formatter);
@@ -5789,7 +5809,8 @@ void BoundCRS::_exportToPROJString(
             "baseCRS of BoundCRS cannot be exported as a PROJ string");
     }
 
-    auto vdatumProj4GridName = getVDatumPROJ4GRIDS();
+    auto vdatumProj4GridName =
+        getVDatumPROJ4GRIDS(formatter->getGeogCRSOfCompoundCRS().get());
     if (!vdatumProj4GridName.empty()) {
         formatter->setVDatumExtension(vdatumProj4GridName);
         crs_exportable->_exportToPROJString(formatter);

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -5597,6 +5597,54 @@ void CoordinateOperationFactory::Private::createOperationsBoundToCompound(
         authFactory ? authFactory->databaseContext().as_nullable() : nullptr;
 
     const auto &componentsDst = compoundDst->componentReferenceSystems();
+
+    // Case of BOUND[NAD83_3D,TOWGS84] to
+    // COMPOUND[BOUND[NAD83_2D,TOWGS84],BOUND[VERT[NAVD88],HUB=NAD83_3D,GRID]]
+    // ==> We can ignore the TOWGS84 BOUND aspect and just ask for
+    // NAD83_3D to COMPOUND[NAD83_2D,BOUND[VERT[NAVD88],HUB=NAD83_3D,GRID]]
+    if (componentsDst.size() >= 2) {
+        auto srcGeogCRS = boundSrc->baseCRS()->extractGeodeticCRS();
+        auto compDst0BoundCrs =
+            util::nn_dynamic_pointer_cast<crs::BoundCRS>(componentsDst[0]);
+        auto compDst1BoundCrs =
+            dynamic_cast<crs::BoundCRS *>(componentsDst[1].get());
+        if (srcGeogCRS && compDst0BoundCrs && compDst1BoundCrs) {
+            auto compDst0Geog = compDst0BoundCrs->extractGeographicCRS();
+            auto compDst1Vert = dynamic_cast<const crs::VerticalCRS *>(
+                compDst1BoundCrs->baseCRS().get());
+            auto compDst1BoundCrsHubCrsGeog =
+                dynamic_cast<const crs::GeographicCRS *>(
+                    compDst1BoundCrs->hubCRS().get());
+            if (compDst1BoundCrsHubCrsGeog) {
+                auto hubDst1Datum =
+                    compDst1BoundCrsHubCrsGeog->datumNonNull(dbContext);
+                if (compDst0Geog && compDst1Vert &&
+                    srcGeogCRS->datumNonNull(dbContext)->isEquivalentTo(
+                        hubDst1Datum.get(),
+                        util::IComparable::Criterion::EQUIVALENT) &&
+                    compDst0Geog->datumNonNull(dbContext)->isEquivalentTo(
+                        hubDst1Datum.get(),
+                        util::IComparable::Criterion::EQUIVALENT)) {
+                    auto srcNew = boundSrc->baseCRS();
+                    auto properties = util::PropertyMap().set(
+                        common::IdentifiedObject::NAME_KEY,
+                        compDst0BoundCrs->nameStr() + " + " +
+                            componentsDst[1]->nameStr());
+                    auto dstNew = crs::CompoundCRS::create(
+                        properties,
+                        {NN_NO_CHECK(compDst0BoundCrs), componentsDst[1]});
+                    auto tmpRes = createOperations(srcNew, dstNew, context);
+                    for (const auto &op : tmpRes) {
+                        auto opClone = op->shallowClone();
+                        setCRSs(opClone.get(), sourceCRS, targetCRS);
+                        res.emplace_back(opClone);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
     if (!componentsDst.empty()) {
         auto compDst0BoundCrs =
             dynamic_cast<crs::BoundCRS *>(componentsDst[0].get());

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4965,7 +4965,6 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToGeog(
             authFactory ? authFactory->databaseContext().as_nullable()
                         : nullptr;
 
-
         // Deal with "+proj=something +geoidgrids +nadgrids/+towgs84" to
         // another CRS whose datum is not the same as the horizontal datum
         // of the source
@@ -4987,7 +4986,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToGeog(
                     dstGeog->datumNonNull(dbContext).get(),
                     util::IComparable::Criterion::EQUIVALENT)) {
 
-                const auto& op1Dest = comp1Bound->hubCRS();
+                const auto &op1Dest = comp1Bound->hubCRS();
                 const auto ops1 = createOperations(
                     crs::CompoundCRS::create(
                         util::PropertyMap().set(

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -4845,6 +4845,7 @@ TEST_F(CApi, proj_crs_create_bound_vertical_crs) {
     ASSERT_NE(proj_4, nullptr);
     EXPECT_EQ(std::string(proj_4),
               "+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=foo.gtx "
+              "+geoid_crs=WGS84 "
               "+vunits=m +no_defs +type=crs");
 }
 

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -5128,7 +5128,8 @@ TEST(crs, WKT1_VERT_DATUM_EXTENSION_to_PROJ_string) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+geoidgrids=egm08_25.gtx +vunits=m +no_defs +type=crs");
+              "+geoidgrids=egm08_25.gtx +geoid_crs=WGS84 +vunits=m +no_defs "
+              "+type=crs");
 }
 
 // ---------------------------------------------------------------------------
@@ -6194,7 +6195,7 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
         EXPECT_EQ(compoundCRS->exportToPROJString(
                       PROJStringFormatter::create().get()),
                   "+proj=longlat +datum=WGS84 +geoidgrids=us_nga_egm08_25.tif "
-                  "+vunits=m +no_defs +type=crs");
+                  "+geoid_crs=WGS84 +vunits=m +no_defs +type=crs");
     }
 #ifdef disabled_since_epsg_10_035
     // There are now too many transformations from NGF-IGN69 height to WGS 84

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -5099,7 +5099,7 @@ TEST(crs, WKT1_VERT_DATUM_EXTENSION_to_WKT2) {
         "                    ORDER[3],\n"
         "                    LENGTHUNIT[\"metre\",1]],\n"
         "            ID[\"EPSG\",4979]]],\n"
-        "    ABRIDGEDTRANSFORMATION[\"EGM2008 geoid height to WGS84 "
+        "    ABRIDGEDTRANSFORMATION[\"EGM2008 geoid height to WGS 84 "
         "ellipsoidal height\",\n"
         "        METHOD[\"GravityRelatedHeight to Geographic3D\"],\n"
         "        PARAMETERFILE[\"Geoid (height correction) model "

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -9237,10 +9237,8 @@ TEST(io, projparse_longlat_geoidgrids) {
     crs->exportToWKT(f.get());
 
     auto wkt = f->toString();
-    EXPECT_TRUE(
-        wkt.find(
-            "ABRIDGEDTRANSFORMATION[\"unknown to WGS84 ellipsoidal height\"") !=
-        std::string::npos)
+    EXPECT_TRUE(wkt.find("ABRIDGEDTRANSFORMATION[\"unknown to WGS 84 "
+                         "ellipsoidal height\"") != std::string::npos)
         << wkt;
     EXPECT_TRUE(wkt.find("PARAMETERFILE[\"Geoid (height correction) model "
                          "file\",\"foo.gtx\"]") != std::string::npos)
@@ -9250,7 +9248,8 @@ TEST(io, projparse_longlat_geoidgrids) {
         crs->exportToPROJString(
             PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
                 .get()),
-        "+proj=longlat +ellps=GRS80 +geoidgrids=foo.gtx +vunits=m +no_defs "
+        "+proj=longlat +ellps=GRS80 +geoidgrids=foo.gtx +geoid_crs=WGS84 "
+        "+vunits=m +no_defs "
         "+type=crs");
 }
 

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -4431,7 +4431,7 @@ TEST(wkt_parse, WKT1_VERT_DATUM_EXTENSION) {
               crs->hubCRS()->nameStr());
 
     EXPECT_EQ(crs->transformation()->nameStr(),
-              "EGM2008 geoid height to WGS84 ellipsoidal height");
+              "EGM2008 geoid height to WGS 84 ellipsoidal height");
     EXPECT_EQ(crs->transformation()->method()->nameStr(),
               "GravityRelatedHeight to Geographic3D");
     ASSERT_EQ(crs->transformation()->parameterValues().size(), 1U);
@@ -4466,13 +4466,54 @@ TEST(wkt_parse, WKT1_VERT_DATUM_EXTENSION_units_ftUS) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->transformation()->nameStr(),
-              "NAVD88 height to WGS84 ellipsoidal height"); // no (ftUS)
+              "NAVD88 height to WGS 84 ellipsoidal height"); // no (ftUS)
     auto sourceTransformationCRS = crs->transformation()->sourceCRS();
     auto sourceTransformationVertCRS =
         nn_dynamic_pointer_cast<VerticalCRS>(sourceTransformationCRS);
     EXPECT_EQ(
         sourceTransformationVertCRS->coordinateSystem()->axisList()[0]->unit(),
         UnitOfMeasure::METRE);
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(wkt_parse, WKT1_COMPD_CS_VERT_DATUM_EXTENSION) {
+    auto wkt =
+        "COMPD_CS[\"NAD83 + NAVD88 height\",\n"
+        "    GEOGCS[\"NAD83\",\n"
+        "        DATUM[\"North_American_Datum_1983\",\n"
+        "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n"
+        "                AUTHORITY[\"EPSG\",\"7019\"]],\n"
+        "            AUTHORITY[\"EPSG\",\"6269\"]],\n"
+        "        PRIMEM[\"Greenwich\",0,\n"
+        "            AUTHORITY[\"EPSG\",\"8901\"]],\n"
+        "        UNIT[\"degree\",0.0174532925199433,\n"
+        "            AUTHORITY[\"EPSG\",\"9122\"]],\n"
+        "        AUTHORITY[\"EPSG\",\"4269\"]],\n"
+        "    VERT_CS[\"NAVD88 height\",\n"
+        "        VERT_DATUM[\"North American Vertical Datum 1988\",2005,\n"
+        "            EXTENSION[\"PROJ4_GRIDS\",\"@foo.gtx\"],\n"
+        "            AUTHORITY[\"EPSG\",\"5103\"]],\n"
+        "        UNIT[\"metre\",1,\n"
+        "            AUTHORITY[\"EPSG\",\"9001\"]],\n"
+        "        AXIS[\"Gravity-related height\",UP],\n"
+        "        AUTHORITY[\"EPSG\",\"5703\"]]]";
+
+    auto obj = WKTParser().createFromWKT(wkt);
+    auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+    ASSERT_TRUE(crs != nullptr);
+
+    auto boundVertCRS =
+        nn_dynamic_pointer_cast<BoundCRS>(crs->componentReferenceSystems()[1]);
+    ASSERT_TRUE(boundVertCRS != nullptr);
+
+    EXPECT_EQ(boundVertCRS->transformation()->nameStr(),
+              "NAVD88 height to NAD83 ellipsoidal height");
+
+    EXPECT_EQ(
+        crs->exportToWKT(
+            WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL).get()),
+        wkt);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -3710,9 +3710,9 @@ TEST(operation,
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -3789,9 +3789,9 @@ TEST(
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -3867,9 +3867,9 @@ TEST(
               "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=rad +z_in=m "
-              "+xy_out=deg +z_out=us-ft");
+              "+xy_out=deg +z_out=us-ft "
+              "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------
@@ -6279,13 +6279,11 @@ TEST(operation,
     auto op_proj =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
     EXPECT_EQ(op_proj, "+proj=pipeline "
-                       "+step +proj=push +v_1 +v_2 "
                        "+step +proj=axisswap +order=2,1 "
                        "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                        "+step +proj=vgridshift +grids=HT2_0.gtx +multiplier=1 "
                        "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
-                       "+step +proj=axisswap +order=2,1 "
-                       "+step +proj=pop +v_1 +v_2");
+                       "+step +proj=axisswap +order=2,1");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -2933,10 +2933,10 @@ TEST(operation, ETRS89_3D_to_proj_string_with_geoidgrids_nadgrids) {
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=axisswap +order=2,1 "
-              "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
+              "+step +proj=unitconvert +xy_in=deg +z_in=m +xy_out=rad +z_out=m "
+              "+step +inv +proj=hgridshift +grids=rdtrans2008.gsb "
               "+step +inv +proj=vgridshift +grids=naptrans2008.gtx "
               "+multiplier=1 "
-              "+step +inv +proj=hgridshift +grids=rdtrans2008.gsb "
               "+step +proj=sterea +lat_0=52.1561605555556 "
               "+lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 "
               "+y_0=463000 +ellps=bessel");
@@ -3085,11 +3085,6 @@ TEST(operation, WGS84_G1762_to_compoundCRS_with_bound_vertCRS) {
     auto list = CoordinateOperationFactory::create()->createOperations(
         src, NN_NO_CHECK(dst), ctxt);
     ASSERT_GE(list.size(), 53U);
-    EXPECT_EQ(list[0]->nameStr(),
-              "Inverse of WGS 84 to WGS 84 (G1762) + "
-              "Inverse of unknown to WGS84 ellipsoidal height + "
-              "Inverse of NAD83 to WGS 84 (1) + "
-              "axis order change (2D)");
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=axisswap +order=2,1 "
@@ -3551,8 +3546,6 @@ TEST(operation,
     auto op = CoordinateOperationFactory::create()->createOperation(
         NN_NO_CHECK(src), GeographicCRS::EPSG_4979);
     ASSERT_TRUE(op != nullptr);
-    EXPECT_EQ(op->nameStr(), "axis order change (2D) + "
-                             "unknown to WGS84 ellipsoidal height");
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
@@ -3574,9 +3567,6 @@ TEST(operation,
     auto op = CoordinateOperationFactory::create()->createOperation(
         NN_NO_CHECK(src), GeographicCRS::EPSG_4979);
     ASSERT_TRUE(op != nullptr);
-    EXPECT_EQ(op->nameStr(), "axis order change (2D) + "
-                             "Conversion from unknown to unknown + "
-                             "unknown to WGS84 ellipsoidal height");
     EXPECT_EQ(
         op->exportToPROJString(PROJStringFormatter::create().get()),
         "+proj=pipeline "
@@ -4047,10 +4037,11 @@ TEST(operation, geocent_to_compoundCRS) {
         NN_CHECK_ASSERT(src), NN_CHECK_ASSERT(dst));
     ASSERT_TRUE(op != nullptr);
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +inv +proj=cart +ellps=WGS84 +step +inv "
-              "+proj=vgridshift +grids=@foo.gtx +multiplier=1 +step +inv "
-              "+proj=hgridshift +grids=@foo.gsb +step +proj=unitconvert "
-              "+xy_in=rad +xy_out=deg");
+              "+proj=pipeline "
+              "+step +inv +proj=cart +ellps=WGS84 "
+              "+step +inv +proj=hgridshift +grids=@foo.gsb "
+              "+step +inv +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
+              "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
 // ---------------------------------------------------------------------------
@@ -4070,10 +4061,11 @@ TEST(operation, geocent_to_compoundCRS_context) {
         src, NN_CHECK_ASSERT(dst), ctxt);
     ASSERT_EQ(list.size(), 1U);
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +inv +proj=cart +ellps=WGS84 +step +inv "
-              "+proj=vgridshift +grids=@foo.gtx +multiplier=1 +step +inv "
-              "+proj=hgridshift +grids=@foo.gsb +step +proj=unitconvert "
-              "+xy_in=rad +xy_out=deg");
+              "+proj=pipeline "
+              "+step +inv +proj=cart +ellps=WGS84 "
+              "+step +inv +proj=hgridshift +grids=@foo.gsb "
+              "+step +inv +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
+              "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
 // ---------------------------------------------------------------------------
@@ -4184,10 +4176,10 @@ TEST(operation, compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert) {
     ASSERT_TRUE(op != nullptr);
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
-              "+step +proj=hgridshift +grids=@foo.gsb "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
+              "+step +proj=hgridshift +grids=@foo.gsb "
               "+step +inv +proj=hgridshift +grids=@bar.gsb "
+              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
@@ -4212,8 +4204,10 @@ TEST(
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
+              "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=hgridshift +grids=@foo.gsb "
               "+step +inv +proj=hgridshift +grids=@bar.gsb "
+              "+step +inv +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
@@ -4238,10 +4232,12 @@ TEST(
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
+              "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=hgridshift +grids=@foo.gsb "
-              "+step +proj=unitconvert +z_in=m +z_out=us-ft "
               "+step +inv +proj=hgridshift +grids=@bar.gsb "
-              "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
+              "+step +inv +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
+              "+step +proj=unitconvert +xy_in=rad +z_in=m "
+              "+xy_out=deg +z_out=us-ft");
 }
 
 // ---------------------------------------------------------------------------
@@ -4287,10 +4283,10 @@ TEST(
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
-              "+step +proj=push +v_3 "
+              "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=cart +ellps=GRS67 "
               "+step +inv +proj=cart +ellps=GRS80 "
-              "+step +proj=pop +v_3 "
+              "+step +inv +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
@@ -4326,18 +4322,11 @@ TEST(
     EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
-              "+step +proj=push +v_3 "
-              "+step +proj=cart +ellps=GRS80 "
-              "+step +proj=helmert +x=1 +y=2 +z=3 "
-              "+step +inv +proj=cart +ellps=WGS84 "
-              "+step +proj=pop +v_3 "
               "+step +proj=vgridshift +grids=@foo.gtx +multiplier=1 "
-              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
-              "+step +proj=push +v_3 "
-              "+step +proj=cart +ellps=WGS84 "
-              "+step +proj=helmert +x=-4 +y=-5 +z=-6 "
+              "+step +proj=cart +ellps=GRS80 "
+              "+step +proj=helmert +x=-3 +y=-3 +z=-3 "
               "+step +inv +proj=cart +ellps=GRS80 "
-              "+step +proj=pop +v_3 "
+              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 }
 
@@ -4431,14 +4420,6 @@ TEST(
     auto list = CoordinateOperationFactory::create()->createOperations(
         NN_CHECK_ASSERT(src), NN_CHECK_ASSERT(dst), ctxt);
     ASSERT_EQ(list.size(), 1U);
-    EXPECT_EQ(list[0]->nameStr(),
-              "Inverse of unnamed + "
-              "Transformation from NAD83 to WGS84 + "
-              "Conversion from NAVD88 height to NAVD88 height (ftUS) + "
-              "Inverse of Transformation from NAD83 to WGS84 + "
-              "unnamed");
-    auto grids = list[0]->gridsNeeded(dbContext, false);
-    EXPECT_TRUE(grids.empty());
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +inv +proj=tmerc +lat_0=30 +lon_0=-87.5 +k=0.999933333 "
@@ -6504,8 +6485,8 @@ TEST(operation, boundCRS_to_compoundCRS) {
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +proj=hgridshift +grids=@foo.gsb "
-              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
               "+step +inv +proj=hgridshift +grids=@bar.gsb "
+              "+step +inv +proj=vgridshift +grids=@bar.gtx +multiplier=1 "
               "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
 
     auto opInverse = CoordinateOperationFactory::create()->createOperation(

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -2922,7 +2922,8 @@ TEST(operation, ETRS89_3D_to_proj_string_with_geoidgrids_nadgrids) {
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 "
         "+k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel "
-        "+nadgrids=rdtrans2008.gsb +geoidgrids=naptrans2008.gtx +units=m "
+        "+nadgrids=rdtrans2008.gsb +geoidgrids=naptrans2008.gtx "
+        "+geoid_crs=horizontal_crs +units=m "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4030,6 +4031,7 @@ TEST(operation, geocent_to_compoundCRS) {
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4053,6 +4055,7 @@ TEST(operation, geocent_to_compoundCRS_context) {
     auto src = authFactory->createCoordinateReferenceSystem("4978");
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4163,11 +4166,13 @@ TEST(operation, compoundCRS_to_compoundCRS_with_vertical_transform) {
 TEST(operation, compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +nadgrids=@bar.gsb +geoidgrids=@bar.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4190,11 +4195,13 @@ TEST(
     compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert_same_geoidgrids) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +nadgrids=@bar.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4218,11 +4225,13 @@ TEST(
     compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert_same_geoidgrids_different_vunits) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +nadgrids=@bar.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+vunits=us-ft +type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4247,11 +4256,13 @@ TEST(
     compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert_same_nadgrids_same_geoidgrids) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +nadgrids=@foo.gsb +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4269,11 +4280,13 @@ TEST(
     compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert_same_towgs84_same_geoidgrids) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS67 +towgs84=0,0,0 +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +towgs84=0,0,0 +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -4297,11 +4310,13 @@ TEST(
     compoundCRS_to_compoundCRS_with_bound_crs_in_horiz_and_vert_same_ellsp_but_different_towgs84_different_geoidgrids) {
     auto objSrc = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +towgs84=1,2,3 +geoidgrids=@foo.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto src = nn_dynamic_pointer_cast<CRS>(objSrc);
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +towgs84=4,5,6 +geoidgrids=@bar.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);
@@ -6474,6 +6489,7 @@ TEST(operation, boundCRS_to_compoundCRS) {
     ASSERT_TRUE(src != nullptr);
     auto objDst = PROJStringParser().createFromPROJString(
         "+proj=longlat +ellps=GRS80 +nadgrids=@bar.gsb +geoidgrids=@bar.gtx "
+        "+geoid_crs=horizontal_crs "
         "+type=crs");
     auto dst = nn_dynamic_pointer_cast<CRS>(objDst);
     ASSERT_TRUE(dst != nullptr);


### PR DESCRIPTION
This PR builds on top of https://github.com/OSGeo/PROJ/pull/3125 and https://github.com/OSGeo/PROJ/pull/3126, and specifically adds the following commit:
-  Change hub CRS semantics when importing from a PROJ.4 string with +geoidgrids, and modify order of horizontal and vertical steps
    Previously when importing "+proj=something +datum/+towgs84/+nadgrids +geoidgrids",
    the geoid transformation was referenced to WGS 84, instead of the
    horizontal datum, which was a breakage with respect to PROJ < 6
    behaviour.
    Modify also the createOperations() logic in such situation to apply
    first the vertical transformation and then the horizontal one when going
    from the compound CRS to the final or intermediate geographic 3D CRS.

With all those changes, PROJ should behave very close to the PROJ < 6 era when doing transformations between CRS created from WKT1 and PROJ.4 and that have both horizontal & vertical transformations.  The main effect is that the vertical grid is assumed to be registered against the geographic datum of the horizontal CRS, and no longer WGS 84 as was hardcoded in PROJ >= 6 and < 9.1. So a transformation doing "+nadgrids=nad_src +geoidgrids=geoid_src" to "+nadgrids=naddst +geoidgrids=geoid_dst" will now do "+proj=vgridshift +grids=geoid_src" -> "+proj=hgridshift +grids=nad_src" -> "+proj=hgridshift +grids=nad_dst" -> "+proj=vgridshift +grids=geoid_dst"  (with appropriate direction of the transformation omitted here...)

@kbevers  / @hobu : not sure if the above makes sense to you... Beyond being compatible with the legacy behaviour, it seems also more logical, although that can be argued and people could certainly have use cases where the vertical grid is referenced to the datum after the horizontal transformation (but if using WKT2 with explicit hub CRS for the vertical transformation, that should be correctly taken into account). The main question is "it appropriate at that time to bring back PROJ < 6 behaviour ?"

CC @Jochem-L as it might impact Dutch transformations using rdtrans and naptrans (but I believe there are considered legacy compared to a more modern approach mixing Helmert based and grid based transformation), as can been seen in the change of the expected result of one of the unit test. We had a discussion on the mailing list some time ago regarding the order of operations