### PR TITLE
Steps with omit_inv are not considered when checking if inverse pipeline operation is possible

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -550,7 +550,7 @@ PJ *OPERATION(pipeline,0) {
     /* determine if an inverse operation is possible */
     for( auto& step: pipeline->steps) {
         PJ *Q = step.pj;
-        if ( pj_has_inverse(Q) ) {
+        if ( step.omit_inv || pj_has_inverse(Q) ) {
             continue;
         } else {
             P->inv   = nullptr;

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -879,4 +879,30 @@ expect      5.875      55.375      0
 -------------------------------------------------------------------------------
 
 
+
+-------------------------------------------------------------------------------
+# Test inverse pipeline with noninvertible affine transformation. We define an
+# affine transformation that's not invertible and omit the inverse path. We
+# also define a step that handles the inverse and omits the forward path.
+#
+# Because the first affine matrix is not invertible, we specify omit_inv to
+# disable executing in reverse.
+#
+# Now we need another affine to actually make the inverse operation.
+#
+# The second affine has omit_fwd and inv. We don't execute this when running
+# forwards. When doing inverse, we call the inverse of the inverted affine which
+# means that we actually do the forward of the specified affine. As it happens,
+# the forward of this affine actually undoes what the first affine did in forward
+# path.
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+operation   proj=pipeline step proj=affine omit_inv s11=2 s22=0 s33=0 step proj=affine omit_fwd inv s11=0.5 s22=0 s33=0
+-------------------------------------------------------------------------------
+
+accept      10 0 0
+expect      20 0 0
+roundtrip
+
 </gie-strict>

--- a/test/gie/more_builtins.gie
+++ b/test/gie/more_builtins.gie
@@ -878,31 +878,147 @@ accept      4.5        52.5        0
 expect      5.875      55.375      0
 -------------------------------------------------------------------------------
 
-
-
--------------------------------------------------------------------------------
-# Test inverse pipeline with noninvertible affine transformation. We define an
-# affine transformation that's not invertible and omit the inverse path. We
-# also define a step that handles the inverse and omits the forward path.
+===============================================================================
+# Tests for testing that +omit_fwd, +omit_inv and +inv work together like they
+# should.
 #
-# Because the first affine matrix is not invertible, we specify omit_inv to
-# disable executing in reverse.
+# +omit_fwd specifies that a step should be omitted when running forwards.
 #
-# Now we need another affine to actually make the inverse operation.
+# +omit_inv specifies that a step should be omitted when running backwards.
 #
-# The second affine has omit_fwd and inv. We don't execute this when running
-# forwards. When doing inverse, we call the inverse of the inverted affine which
-# means that we actually do the forward of the specified affine. As it happens,
-# the forward of this affine actually undoes what the first affine did in forward
-# path.
--------------------------------------------------------------------------------
+# +inv specifies that a step should be inverted. The forward path would do
+# inverse operation and inverse path would do forward operation.
+#
+# |                |       invertible step       |     non-invertible step     |
+# | flags          | forward path | inverse path | forward path | inverse path |
+# | -------------- | ------------ | ------------ | ------------ | ------------ |
+# | +omit_fwd      | omit         | inv          | omit         | undefined    |
+# | +omit_fwd +inv | omit         | fwd          | omit         | fwd          |
+# | +omit_inv      | fwd          | omit         | fwd          | omit         |
+# | +omit_inv +inv | inv          | omit         | undefined    | omit         |
+#
+# From the table we can see that invertible steps should work pretty much all
+# the time. Non-invertible steps on the other hand make either the forward path
+# or inverse path undefined depending on which flags the step has.
+#
+# A non-invertible step is for example an affine transformation where we cannot
+# calculate the inverse of the matrix.
+===============================================================================
 
 -------------------------------------------------------------------------------
-operation   proj=pipeline step proj=affine omit_inv s11=2 s22=0 s33=0 step proj=affine omit_fwd inv s11=0.5 s22=0 s33=0
+# Test that +omit_fwd, +omit_inv and +inv work correctly with an invertible step.
 -------------------------------------------------------------------------------
 
-accept      10 0 0
-expect      20 0 0
-roundtrip
+# Test that forward path does nothing and inverse path does inverse transformation
+
+operation   proj=pipeline step proj=affine s11=2 omit_fwd
+
+direction forward
+accept 1 2 3
+expect 1 2 3
+
+direction inverse
+accept 1 2 3
+expect 0.5 2 3
+
+# Test that forward path does nothing and inverse path does forward transformation
+
+operation   proj=pipeline step proj=affine s11=2 omit_fwd inv
+
+direction forward
+accept 1 2 3
+expect 1 2 3
+
+direction inverse
+accept 1 2 3
+expect 2 2 3
+
+# Test that forward path does forward transformation and inverse path does nothing
+
+operation   proj=pipeline step proj=affine s11=2 omit_inv
+
+direction forward
+accept 1 2 3
+expect 2 2 3
+
+direction inverse
+accept 1 2 3
+expect 1 2 3
+
+# Test that forward path does inverse transformation and inverse path does nothing
+
+operation   proj=pipeline step proj=affine s11=2 omit_inv inv
+
+direction forward
+accept 1 2 3
+expect 0.5 2 3
+
+direction inverse
+accept 1 2 3
+expect 1 2 3
+
+-------------------------------------------------------------------------------
+# Test that +omit_fwd, +omit_inv and +inv work correctly with a non-invertible step.
+-------------------------------------------------------------------------------
+
+# Test that forward path does nothing and inverse path is not defined.
+#
+# The affine transformation is not invertible so this pipeline cannot be executed in
+# reverse.
+
+operation proj=pipeline step proj=affine s11=1 s12=1 s13=1 s22=0 s33=0 omit_fwd
+
+direction forward
+accept 1 2 3
+expect 1 2 3
+
+direction inverse
+accept 1 2 3
+expect failure errno no_inverse_op
+
+# Test that forward path does nothing and inverse path does forward transformation.
+#
+# The affine transformation does not have an inverse, but inv specifies that the
+# step should be done in inverse order relative to our pipeline direction. When
+# we execute the pipeline in reverse, we should call the forward transformation of
+# the step which is defined so the pipeline should be valid in reverse.
+
+operation proj=pipeline step proj=affine s11=1 s12=1 s13=1 s22=0 s33=0 omit_fwd inv
+
+direction forward
+accept 1 2 3
+expect 1 2 3
+
+direction inverse
+accept 1 2 3
+expect 6 0 0
+
+# Test that the forward path does forward transformation and inverse path does nothing.
+
+operation proj=pipeline step proj=affine s11=1 s12=1 s13=1 s22=0 s33=0 omit_inv
+
+direction forward
+accept 1 2 3
+expect 6 0 0
+
+direction inverse
+accept 1 2 3
+expect 1 2 3
+
+# Test that the forward path is not defined and inverse path does nothing.
+#
+# When going through the forward path, inv specifies that we should execute the
+# step in reverse. Because the affine transformation does not have an inverse,
+# this means that the forward path does not exist.
+
+operation proj=pipeline step proj=affine s11=1 s12=1 s13=1 s22=0 s33=0 omit_inv inv
+
+direction forward
+accept 1 2 3
+expect failure errno no_inverse_op
+
+direction inverse
+accept 1 2 3
+expect 1 2 3
 
 </gie-strict>


### PR DESCRIPTION
Hello!

While testing if we could move from our internal coordinate transformation library to using pure PROJ, I came upon one case where it would be beneficial to be able to make PROJ proceed if affine transformation is not invertible but the inverse is not going to be used.

I'm was a bit suprised that this didn't work. You would think that it's okay that an affine transformation cannot be run in reverse if it's explicitly specified that the step should be skipped when doing inverse operation.

I'm not sure if this is a good idea or not. I would like some feedback. If this is a good idea, would this need documenting?

 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API
