### PR TITLE
Add invertible Horner polynomials

### DIFF
--- a/docs/source/operations/transformations/horner.rst
+++ b/docs/source/operations/transformations/horner.rst
@@ -5,7 +5,7 @@ Horner polynomial evaluation
 ================================================================================
 
 .. versionadded:: 5.0.0
-.. versionchanged:: 9.1.0 Iterative real polynormal inversion
+.. versionchanged:: 9.1.0 Iterative polynormal inversion
 
 +-----------------+-------------------------------------------------------------------+
 | **Alias**       | horner                                                            |
@@ -126,7 +126,7 @@ Evaluation of the complex polynomials are defined by the following equations:
 
 Where :math:`n` is the degree of the polynomial. :math:`U` and :math:`V` are
 defined as in :eq:`UV` and the resulting coordinates are again determined
-by :eq:`xy_out`.
+by :eq:`xy_out`. Complex polynomials can be solved iteratively similar to real polynomials.
 
 Examples
 ################################################################################
@@ -185,10 +185,6 @@ describing real and complex polynomials can't be mixed.
 
     Coordinate of origin for the forward mapping
 
-.. option:: +inv_origin=<northing,easting>
-
-    Coordinate of origin for the inverse mapping. Not required for iterative inversion.
-
 Real polynomials
 ..............................................................................
 
@@ -228,13 +224,16 @@ of the polynomial:
     Coefficients for the complex forward transformation
     as described in :eq:`complex_poly`.
 
-.. option:: +inv_c=<c_1,c_2,...,c_N>
-
-    Coefficients for the complex inverse transformation
-    as described in :eq:`complex_poly`.
-
 Optional
 -------------------------------------------------------------------------------
+
+.. option:: +inv_origin=<northing,easting>
+
+    .. versionchanged:: 9.1.0
+
+    Coordinate of origin for the inverse mapping.
+    Without this option iterative polynomial evaluation is used for
+    the inverse tranformation.
 
 .. option:: +inv_u=<u_11,u_12,...,u_ij,..,u_mn>
 
@@ -242,7 +241,7 @@ Optional
 
     Coefficients for the inverse transformation i.e. latitude to northing
     as described in :eq:`real_poly`. Only applies for real polynomials.
-    Without this option iterative real polynomial evaluation is used for
+    Without this option iterative polynomial evaluation is used for
     the inverse tranformation.
 
 .. option:: +inv_v=<v_11,v_12,...,v_ij,..,v_mn>
@@ -251,7 +250,16 @@ Optional
 
     Coefficients for the inverse transformation i.e. longitude to easting
     as described in :eq:`real_poly`. Only applies for real polynomials.
-    Without this option iterative real polynomial evaluation is used for
+    Without this option iterative polynomial evaluation is used for
+    the inverse tranformation.
+
+.. option:: +inv_c=<c_1,c_2,...,c_N>
+
+    .. versionchanged:: 9.1.0
+
+    Coefficients for the complex inverse transformation
+    as described in :eq:`complex_poly`. Only applies for complex polynomials.
+    Without this option iterative polynomial evaluation is used for
     the inverse tranformation.
 
 .. option:: +range=<value>
@@ -270,7 +278,7 @@ Optional
 
     .. versionadded:: 9.1.0
 
-    Only applies to real polynomials and iterative inversion.
+    Only applies to cases of iterative inversion.
     The procedure converges to the correct results with each step.
     Iteration stops when the result differs from the previous calculated
     result by less than <value>.

--- a/docs/source/operations/transformations/horner.rst
+++ b/docs/source/operations/transformations/horner.rst
@@ -5,7 +5,7 @@ Horner polynomial evaluation
 ================================================================================
 
 .. versionadded:: 5.0.0
-.. versionadded:: 9.1.0 Iterative real polynormal inversion
+.. versionchanged:: 9.1.0 Iterative real polynormal inversion
 
 +-----------------+-------------------------------------------------------------------+
 | **Alias**       | horner                                                            |
@@ -66,9 +66,6 @@ coefficients. If only the forward set of coefficients and origin is known the in
 be done by iteratively solving a system of equations. By writing :eq:`real_poly` as:
 
 .. math::
-    :label: real_poly_iterative_inversion
-
-    \begin{align}
         \begin{bmatrix}
             \Delta X \\
             \Delta Y \\
@@ -84,6 +81,12 @@ be done by iteratively solving a system of equations. By writing :eq:`real_poly`
         \begin{bmatrix}
             U \\
             V \\
+        \end{bmatrix} \\
+
+.. math::
+        \begin{bmatrix}
+            \Delta X \\
+            \Delta Y \\
         \end{bmatrix} =
         \begin{bmatrix}
             u_{0,0} \\
@@ -96,10 +99,9 @@ be done by iteratively solving a system of equations. By writing :eq:`real_poly`
         \begin{bmatrix}
             U \\
             V \\
-        \end{bmatrix}
-    \end{align}
+        \end{bmatrix} \\
 
-    \begin{align}
+.. math::
         \begin{bmatrix}
             U \\
             V \\
@@ -107,12 +109,11 @@ be done by iteratively solving a system of equations. By writing :eq:`real_poly`
         \begin{bmatrix}
              MA & MB \\
              MC & MD \\
-        \end{bmatrix}^-1
+        \end{bmatrix}^{-1}
         \begin{bmatrix}
             \Delta X - u_{0,0} \\
             \Delta Y - v_{0,0} \\
         \end{bmatrix}
-    \end{align}
 
 We can iteratively solve with initial values of :math:`U = 0` and :math:`V = 0` and find :math:`U` and :math:`V`.
 
@@ -210,18 +211,6 @@ of the polynomial:
     Coefficients for the forward transformation i.e. longitude to easting
     as described in :eq:`real_poly`.
 
-.. option:: +inv_u=<u_11,u_12,...,u_ij,..,u_mn>
-
-    Coefficients for the inverse transformation i.e. latitude to northing
-    as described in :eq:`real_poly`. Not required for iterative inversion.
-
-.. option:: +inv_v=<v_11,v_12,...,v_ij,..,v_mn>
-
-    Coefficients for the inverse transformation i.e. longitude to easting
-    as described in :eq:`real_poly`. Not required for iterative inversion.
-
-
-
 Complex polynomials
 ..............................................................................
 
@@ -247,6 +236,24 @@ of the polynomial:
 Optional
 -------------------------------------------------------------------------------
 
+.. option:: +inv_u=<u_11,u_12,...,u_ij,..,u_mn>
+
+    .. versionchanged:: 9.1.0
+
+    Coefficients for the inverse transformation i.e. latitude to northing
+    as described in :eq:`real_poly`. Only applies for real polynomials.
+    Without this option iterative real polynomial evaluation is used for
+    the inverse tranformation.
+
+.. option:: +inv_v=<v_11,v_12,...,v_ij,..,v_mn>
+
+    .. versionchanged:: 9.1.0
+
+    Coefficients for the inverse transformation i.e. longitude to easting
+    as described in :eq:`real_poly`. Only applies for real polynomials.
+    Without this option iterative real polynomial evaluation is used for
+    the inverse tranformation.
+
 .. option:: +range=<value>
 
     Radius of the region of validity.
@@ -261,12 +268,15 @@ Optional
 
 .. option:: +inv_tolerance=<value>
 
+    .. versionadded:: 9.1.0
+
     Only applies to real polynomials and iterative inversion.
     The procedure converges to the correct results with each step.
     Iteration stops when the result differs from the previous calculated
     result by less than <value>.
     <value> should be the same units as :math:`U` and :math:`V` of :eq:`UV`
-    Defaults to 0.001 meters.
+
+    *Defaults to 0.001.*
 
 Further reading
 ################################################################################

--- a/docs/source/operations/transformations/horner.rst
+++ b/docs/source/operations/transformations/horner.rst
@@ -5,6 +5,7 @@ Horner polynomial evaluation
 ================================================================================
 
 .. versionadded:: 5.0.0
+.. versionadded:: 9.1.0 Iterative real polynormal inversion
 
 +-----------------+-------------------------------------------------------------------+
 | **Alias**       | horner                                                            |
@@ -61,7 +62,59 @@ The final coordinates are determined as
     Y_{out} = Y_{in} + \Delta Y
 
 The inverse transform is the same as the above but requires a different set of
-coefficients.
+coefficients. If only the forward set of coefficients and origin is known the inverse transform can
+be done by iteratively solving a system of equations. By writing :eq:`real_poly` as:
+
+.. math::
+    :label: real_poly_iterative_inversion
+
+    \begin{align}
+        \begin{bmatrix}
+            \Delta X \\
+            \Delta Y \\
+        \end{bmatrix} =
+        \begin{bmatrix}
+            u_{0,0} \\
+            v_{0,0} \\
+        \end{bmatrix} +
+        \begin{bmatrix}
+             u_{0,1} + u_{0,2} U + ... & u_{1,0} + u_{1,1} U + u_{2,0} V + ... \\
+             v_{1,0} + v_{1,1} V + v_{2,0} U + ... & v_{0,1} + v_{0,2} V \\
+        \end{bmatrix}
+        \begin{bmatrix}
+            U \\
+            V \\
+        \end{bmatrix} =
+        \begin{bmatrix}
+            u_{0,0} \\
+            v_{0,0} \\
+        \end{bmatrix} +
+        \begin{bmatrix}
+             MA & MB \\
+             MC & MD \\
+        \end{bmatrix}
+        \begin{bmatrix}
+            U \\
+            V \\
+        \end{bmatrix}
+    \end{align}
+
+    \begin{align}
+        \begin{bmatrix}
+            U \\
+            V \\
+        \end{bmatrix} =
+        \begin{bmatrix}
+             MA & MB \\
+             MC & MD \\
+        \end{bmatrix}^-1
+        \begin{bmatrix}
+            \Delta X - u_{0,0} \\
+            \Delta Y - v_{0,0} \\
+        \end{bmatrix}
+    \end{align}
+
+We can iteratively solve with initial values of :math:`U = 0` and :math:`V = 0` and find :math:`U` and :math:`V`.
 
 Evaluation of the complex polynomials are defined by the following equations:
 
@@ -133,7 +186,7 @@ describing real and complex polynomials can't be mixed.
 
 .. option:: +inv_origin=<northing,easting>
 
-    Coordinate of origin for the inverse mapping
+    Coordinate of origin for the inverse mapping. Not required for iterative inversion.
 
 Real polynomials
 ..............................................................................
@@ -160,12 +213,12 @@ of the polynomial:
 .. option:: +inv_u=<u_11,u_12,...,u_ij,..,u_mn>
 
     Coefficients for the inverse transformation i.e. latitude to northing
-    as described in :eq:`real_poly`.
+    as described in :eq:`real_poly`. Not required for iterative inversion.
 
 .. option:: +inv_v=<v_11,v_12,...,v_ij,..,v_mn>
 
     Coefficients for the inverse transformation i.e. longitude to easting
-    as described in :eq:`real_poly`.
+    as described in :eq:`real_poly`. Not required for iterative inversion.
 
 
 
@@ -206,6 +259,14 @@ Optional
 
     Express longitude as westing. Only applies for complex polynomials.
 
+.. option:: +inv_tolerance=<value>
+
+    Only applies to real polynomials and iterative inversion.
+    The procedure converges to the correct results with each step.
+    Iteration stops when the result differs from the previous calculated
+    result by less than <value>.
+    <value> should be the same units as :math:`U` and :math:`V` of :eq:`UV`
+    Defaults to 0.001 meters.
 
 Further reading
 ################################################################################

--- a/docs/source/operations/transformations/horner.rst
+++ b/docs/source/operations/transformations/horner.rst
@@ -117,6 +117,9 @@ be done by iteratively solving a system of equations. By writing :eq:`real_poly`
 
 We can iteratively solve with initial values of :math:`U = 0` and :math:`V = 0` and find :math:`U` and :math:`V`.
 
+.. note::
+    This iterative inverse transformation is a more general solution to *reversible polynormials of degree n* as presented in :cite:`IOGP2019`. These can provide a satisfactory solution in a single step when certain conditions are met.
+
 Evaluation of the complex polynomials are defined by the following equations:
 
 .. math::

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -169,6 +169,17 @@
   Url                      = {https://www.iogp.org/bookstore/product/coordinate-conversions-and-transformation-including-formulas/}
 }
 
+@TechReport{IOGP2019,
+  Title                    = {Geomatics Guidance Note 7, part 2: Coordinate Conversions \& Transformations including Formulas},
+  Author                   = {IOGP},
+  Institution              = {International Association For Oil And Gas Producers},
+  Year                     = {2019},
+  Number                   = {373-7-2},
+  Type                     = {IOGP Publication},
+
+  Url                      = {https://www.iogp.org/wp-content/uploads/2019/09/373-07-02.pdf}
+}
+
 @TechReport{ISO19111,
   Title                    = {{Geographic information -- Referencing by coordinates}},
   Author                   = {ISO},

--- a/src/transformations/horner.cpp
+++ b/src/transformations/horner.cpp
@@ -100,8 +100,9 @@ struct horner {
     int    order;    /* maximum degree of polynomium */
     int    coefs;    /* number of coefficients for each polynomium  */
     double range;    /* radius of the region of validity */
-    int    has_only_fwd; /* inv parameters are not specified, inverse is done by gauss-newton iteration */
-    double inverse_tolerance; /* in the units of the destination coords, specifies when to stop iterating if has_only_fwd and direction is reverse */
+    bool has_inv;  /* inv parameters are specified */
+    double inverse_tolerance; /* in the units of the destination coords,
+                                 specifies when to stop iterating if !has_inv and direction is reverse */
 
     double *fwd_u;   /* coefficients for the forward transformations */
     double *fwd_v;   /* i.e. latitude/longitude to northing/easting  */
@@ -180,8 +181,65 @@ static HORNER *horner_alloc (size_t order, int complex_polynomia) {
     return nullptr;
 }
 
+inline static PJ_UV double_real_horner_eval(int order, const double *cx, const double *cy, PJ_UV en, int order_offset = 0)
+{
+    /* 
+       The melody of this block is straight out of the great Engsager/Poder songbook.
+       For numerical stability, the summation is carried out backwards,
+       summing the tiny high order elements first.
+       Double Horner's scheme: N = n*Cy*e -> yout, E = e*Cx*n -> xout
+     */
+    const double n = en.v;
+    const double e = en.u;
+    const int sz =  horner_number_of_coefficients(order); /* Number of coefficients per polynomial */
+    cx += sz;
+    cy += sz;
+    double N = *--cy;
+    double E = *--cx;
+    for (int r = order; r > order_offset; r--) {
+        double u = *--cy;
+        double v = *--cx;
+        for (int c = order; c >= r; c--) {
+            u = n*u + *--cy;
+            v = e*v + *--cx;
+        }
+        N = e*N + u;
+        E = n*E + v;
+    }
+    return { E, N };
+}
 
+inline static double single_real_horner_eval(int order, const double *cx, double x, int order_offset = 0)
+{
+    const int sz = order + 1; /* Number of coefficients per polynomial */
+    cx += sz;
+    double u = *--cx;
+    for (int r = order; r > order_offset; r--) {
+        u = x*u + *--cx;
+    }
+    return u;
+}
 
+inline static PJ_UV complex_horner_eval(int order, const double *c, PJ_UV en, int order_offset = 0)
+{
+    // the coefficients are ordered like this:
+    // (Cn0+i*Ce0, Cn1+i*Ce1, ...)
+    const int sz =  2*order + 2; // number of coefficients
+    const double e = en.u;
+    const double n = en.v;
+    const double *cbeg = c + order_offset*2;
+    c += sz;
+
+    double E = *--c;
+    double N = *--c;
+    double w;
+    while (c > cbeg) {
+        w = n*E + e*N + *--c;
+        N = n*N - e*E + *--c;
+        E = w;
+    }
+    return { E, N };
+}
 
 /**********************************************************************/
 static PJ_UV horner_func (PJ* P, const HORNER *transformation, PJ_DIRECTION direction, PJ_UV position) {
@@ -216,13 +274,9 @@ P = sum (i = [0 : order])
         sum (j = [0 : order - i])
             pow(par_1, i) * pow(par_2, j) * coef(index(order, i, j))
 
-For numerical stability, the summation is carried out backwards,
-summing the tiny high order elements first.
-
 ***********************************************************************/
 
     /* These variable names follow the Engsager/Poder  implementation */
-    int     sz;              /* Number of coefficients per polynomial */
     double  range; /* Equivalent to the gen_pol's FLOATLIMIT constant */
     double  n, e;
     PJ_UV uv_error;
@@ -243,10 +297,9 @@ summing the tiny high order elements first.
     }
 
     /* Prepare for double Horner */
-    sz    =  horner_number_of_coefficients(transformation->order);
     range =  transformation->range;
 
-    const bool iterative_inverse = direction == PJ_INV && transformation->has_only_fwd;
+    const bool iterative_inverse = direction == PJ_INV && !transformation->has_inv;
 
     if (direction==PJ_FWD) {                              /* forward */
         e   = position.u - transformation->fwd_origin->u;
@@ -290,23 +343,17 @@ summing the tiny high order elements first.
             double Mb = 0.0;
             double Mc = 0.0;
             double Md = 0.0;
-            /* Coefficient pointers */
-            double *tcx = transformation->fwd_u;
-            double *tcy = transformation->fwd_v;
-            for (int i = 0; i <= order; ++i) {
-                for (int j = 0; j <= (order-i); ++j) {
-                    if (i == 0 && j == 0) {
-                        // do nothing
-                    } else if (i == 0) {
-                        Ma += (*tcx) * pow(x0, j-1);
-                        Md += (*tcy) * pow(y0, j-1);
-                    } else {
-                        Mb += (*tcx) * pow(y0, i-1) * pow(x0, j);
-                        Mc += (*tcy) * pow(x0, i-1) * pow(y0, j);
-                    }
-                    tcx++;
-                    tcy++;
-                }
+            {
+                const double *tcx = transformation->fwd_u;
+                const double *tcy = transformation->fwd_v;
+                PJ_UV x0y0 = { x0, y0 };
+                // sum the i > 0 coefficients
+                PJ_UV Mbc = double_real_horner_eval(order, tcx, tcy, x0y0, 1);
+                Mb = Mbc.u;
+                Mc = Mbc.v;
+                // sum the i = 0, j > 0 coefficients
+                Ma = single_real_horner_eval(order, tcx, x0, 1);
+                Md = single_real_horner_eval(order, tcy, y0, 1);
             }
             double idet = 1.0 / (Ma*Md - Mb*Mc);
             double x = idet * (Md*de - Mb*dn);
@@ -325,31 +372,11 @@ summing the tiny high order elements first.
             position.v = y0 + transformation->fwd_origin->v;
         }
     }
-    /* The melody of this block is straight out of the great Engsager/Poder songbook */
     else {
-        int g =  transformation->order;
-        int r = g, c;
-        double u, v, N, E;
-        /* Coefficient pointers */
-        double *tcx = direction == PJ_FWD ? (transformation->fwd_u + sz) : (transformation->inv_u + sz);
-        double *tcy = direction == PJ_FWD ? (transformation->fwd_v + sz) : (transformation->inv_v + sz);
-
-        /* Double Horner's scheme: N = n*Cy*e -> yout, E = e*Cx*n -> xout */
-        N = *--tcy;
-        E = *--tcx;
-        for (;    r > 0;    r--) {
-            u = *--tcy;
-            v = *--tcx;
-            for (c = g;    c >= r;    c--) {
-                u = n*u + *--tcy;
-                v = e*v + *--tcx;
-            }
-            N = e*N + u;
-            E = n*E + v;
-        }
-
-        position.u = E;
-        position.v = N;
+        const double *tcx = direction == PJ_FWD ? transformation->fwd_u : transformation->inv_u;
+        const double *tcy = direction == PJ_FWD ? transformation->fwd_v : transformation->inv_v;
+        PJ_UV en = { e, n };
+        position = double_real_horner_eval(transformation->order, tcx, tcy, en);
     }
 
     return position;
@@ -384,7 +411,6 @@ polynomial evaluation engine.
 ***********************************************************************/
 
     /* These variable names follow the Engsager/Poder  implementation */
-    int     sz;                             /* Number of coefficients */
     double  range; /* Equivalent to the gen_pol's FLOATLIMIT constant */
     double  n, e;
     PJ_UV uv_error;
@@ -405,10 +431,9 @@ polynomial evaluation engine.
     }
 
     /* Prepare for double Horner */
-    sz    =  2*transformation->order + 2;
     range =  transformation->range;
 
-    const bool iterative_inverse = direction == PJ_INV && transformation->has_only_fwd;
+    const bool iterative_inverse = direction == PJ_INV && !transformation->has_inv;
 
     if (direction==PJ_FWD) {                              /* forward */
         e  =  position.u - transformation->fwd_origin->u;
@@ -438,24 +463,18 @@ polynomial evaluation engine.
     }
 
     if (iterative_inverse) {
+        // complex real part corresponds to Northing, imag part to Easting
         const double tol = transformation->inverse_tolerance;
         const std::complex<double> dZ(n-transformation->fwd_c[0], e-transformation->fwd_c[1]);
-        std::complex<double> w0(0.0, 0.0);
+        std::complex<double> w0(0.0, 0.0); 
         int loops = 32; // usually converges really fast (1-2 loops)
         bool converged = false;
         while (loops-- > 0 && !converged) {
-            // coefficient pointers from back to front until the first complex pair (fwd_c0+i*fwd_c1)
-            double *cb = transformation->fwd_c;
-            double *c = cb + sz;
-            cb += 2;
-            double E = *--c;
-            double N = *--c;
-            while (c > cb) {
-                double w = w0.real()*E + w0.imag()*N + *--c;
-                       N = w0.real()*N - w0.imag()*E + *--c;
-                       E = w;
-            }
-            std::complex<double> det(N, E);
+            // sum coefficient pointers from back to front until the first complex pair (fwd_c0+i*fwd_c1)
+            const double *c = transformation->fwd_c;
+            PJ_UV en = { w0.imag(), w0.real() };
+            en = complex_horner_eval(transformation->order, c, en, 1);
+            std::complex<double> det(en.v, en.u);
             std::complex<double> w1 = dZ / det;
             converged = (fabs(w1.real()-w0.real()) < tol) && (fabs(w1.imag()-w0.imag()) < tol);
             w0 = w1;
@@ -480,19 +499,8 @@ polynomial evaluation engine.
 
     // coefficient pointers
     double *cb = direction == PJ_FWD ? transformation->fwd_c : transformation->inv_c;
-    double *c = cb + sz;
-
-    /* Everything's set up properly - now do the actual polynomium evaluation */
-    double E = *--c;
-    double N = *--c;
-    double w;
-    while (c > cb) {
-        w = n*E + e*N + *--c;
-        N = n*N - e*E + *--c;
-        E = w;
-    }
-    position.u = E;
-    position.v = N;
+    PJ_UV en = { e, n };
+    position = complex_horner_eval(transformation->order, cb, en);
     return position;
 }
 
@@ -557,7 +565,7 @@ static int parse_coefs (PJ *P, double *coefs, const char *param, int ncoefs) {
 PJ *PROJECTION(horner) {
 /*********************************************************************/
     int   degree = 0, n, complex_polynomia = 0;
-    int has_only_fwd = 0;
+    bool has_inv = false;
     HORNER *Q;
     P->fwd4d  = horner_forward_4d;
     P->inv4d  = horner_reverse_4d;
@@ -590,16 +598,16 @@ PJ *PROJECTION(horner) {
     P->opaque = Q;
 
     if (!complex_polynomia) {
-        has_only_fwd =
-            !pj_param_exists(P->params, "inv_u") &&
-            !pj_param_exists(P->params, "inv_v") &&
-            !pj_param_exists(P->params, "inv_origin");
+        has_inv =
+            pj_param_exists(P->params, "inv_u") ||
+            pj_param_exists(P->params, "inv_v") ||
+            pj_param_exists(P->params, "inv_origin");
     } else {
-        has_only_fwd =
-            !pj_param_exists(P->params, "inv_c") &&
-            !pj_param_exists(P->params, "inv_origin");
+        has_inv =
+            pj_param_exists(P->params, "inv_c") ||
+            pj_param_exists(P->params, "inv_origin");
     }
-    Q->has_only_fwd = has_only_fwd;
+    Q->has_inv = has_inv;
 
     if (complex_polynomia) {
         /* Westings and/or southings? */
@@ -612,7 +620,7 @@ PJ *PROJECTION(horner) {
             proj_log_error (P, _("missing fwd_c"));
             return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
         }
-        if (!has_only_fwd && 0==parse_coefs (P, Q->inv_c, "inv_c", n))
+        if (has_inv && 0==parse_coefs (P, Q->inv_c, "inv_c", n))
         {
             proj_log_error (P, _("missing inv_c"));
             return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
@@ -633,12 +641,12 @@ PJ *PROJECTION(horner) {
             proj_log_error (P, _("missing fwd_v"));
             return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
         }
-        if (!has_only_fwd && 0==parse_coefs (P, Q->inv_u, "inv_u", n))
+        if (has_inv && 0==parse_coefs (P, Q->inv_u, "inv_u", n))
         {
             proj_log_error (P, _("missing inv_u"));
             return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
         }
-        if (!has_only_fwd && 0==parse_coefs (P, Q->inv_v, "inv_v", n))
+        if (has_inv && 0==parse_coefs (P, Q->inv_v, "inv_v", n))
         {
             proj_log_error (P, _("missing inv_v"));
             return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
@@ -650,7 +658,7 @@ PJ *PROJECTION(horner) {
         proj_log_error (P, _("missing fwd_origin"));
         return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);
     }
-    if (!has_only_fwd && 0==parse_coefs (P, (double *)(Q->inv_origin), "inv_origin", 2))
+    if (has_inv && 0==parse_coefs (P, (double *)(Q->inv_origin), "inv_origin", 2))
     {
         proj_log_error (P, _("missing inv_origin"));
         return horner_freeup (P, PROJ_ERR_INVALID_OP_MISSING_ARG);

--- a/src/transformations/horner.cpp
+++ b/src/transformations/horner.cpp
@@ -222,7 +222,6 @@ summing the tiny high order elements first.
 
     /* These variable names follow the Engsager/Poder  implementation */
     int     sz;              /* Number of coefficients per polynomial */
-    double *tcx, *tcy;                        /* Coefficient pointers */
     double  range; /* Equivalent to the gen_pol's FLOATLIMIT constant */
     double  n, e;
     PJ_UV uv_error;
@@ -249,14 +248,10 @@ summing the tiny high order elements first.
     const bool iterative_inverse = direction == PJ_INV && transformation->has_only_real_fwd;
 
     if (direction==PJ_FWD) {                              /* forward */
-        tcx = transformation->fwd_u + sz;
-        tcy = transformation->fwd_v + sz;
         e   = position.u - transformation->fwd_origin->u;
         n   = position.v - transformation->fwd_origin->v;
     } else {                                              /* inverse */
         if (!iterative_inverse) {
-            tcx = transformation->inv_u + sz;
-            tcy = transformation->inv_v + sz;
             e   = position.u - transformation->inv_origin->u;
             n   = position.v - transformation->inv_origin->v;
         } else {
@@ -283,8 +278,8 @@ summing the tiny high order elements first.
          */
         const int order = transformation->order;
         const double tol = transformation->inverse_tolerance;
-        double de = e - transformation->fwd_u[0];
-        double dn = n - transformation->fwd_v[0];
+        const double de = e - transformation->fwd_u[0];
+        const double dn = n - transformation->fwd_v[0];
         double x0 = 0.0;
         double y0 = 0.0;
         int loops = 32; // usually converges really fast (1-2 loops)
@@ -293,8 +288,9 @@ summing the tiny high order elements first.
             double Mb = 0.0;
             double Mc = 0.0;
             double Md = 0.0;
-            tcx = transformation->fwd_u;
-            tcy = transformation->fwd_v;
+            /* Coefficient pointers */
+            double *tcx = transformation->fwd_u;
+            double *tcy = transformation->fwd_v;
             for (int i = 0; i <= order; ++i) {
                 for (int j = 0; j <= (order-i); ++j) {
                     if (i == 0 && j == 0) {
@@ -326,6 +322,9 @@ summing the tiny high order elements first.
         int g =  transformation->order;
         int r = g, c;
         double u, v, N, E;
+        /* Coefficient pointers */
+        double *tcx = direction == PJ_FWD ? (transformation->fwd_u + sz) : (transformation->inv_u + sz);
+        double *tcy = direction == PJ_FWD ? (transformation->fwd_v + sz) : (transformation->inv_v + sz);
 
         /* Double Horner's scheme: N = n*Cy*e -> yout, E = e*Cx*n -> xout */
         N = *--tcy;

--- a/src/transformations/horner.cpp
+++ b/src/transformations/horner.cpp
@@ -445,8 +445,9 @@ polynomial evaluation engine.
         bool converged = false;
         while (loops-- > 0 && !converged) {
             // coefficient pointers from back to front until the first complex pair (fwd_c0+i*fwd_c1)
-            double *cb = transformation->fwd_c + 2;
+            double *cb = transformation->fwd_c;
             double *c = cb + sz;
+            cb += 2;
             double E = *--c;
             double N = *--c;
             while (c > cb) {

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -871,6 +871,8 @@ TEST(gie, horner_only_fwd_selftest) {
         /* Check roundtrip precision for 1 iteration each way */
         dist = proj_roundtrip(P, PJ_FWD, 1, &a);
         EXPECT_LE(dist, 0.01);
+
+        proj_destroy(P);
     }
 }
 

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -778,6 +778,16 @@ static const char tc32_utm32_fwd_only[] = {
     "1.9107771273e-18,3.3615590093e-10,2.4380247154e-14,-2.0241230315e-18,1."
     "2429019719e-15,5.3886155968e-19,-1.0167505000e-18" };
 
+static const char sb_utm32_fwd_only[] = {
+    " +proj=horner"
+    " +ellps=intl"
+    " +range=10000000"
+    " +fwd_origin=4.94690026817276e+05,6.13342113183056e+06"
+    " +deg=3"
+    " +fwd_c=6.13258562111350e+06,6.19480105709997e+05,9.99378966275206e-01,-2."
+    "82153291753490e-02,-2.27089979140026e-10,-1.77019590701470e-09,1."
+    "08522286274070e-14,2.11430298751604e-15" };
+
 static const char hatt_to_ggrs[] = {
     " +proj=horner"
     " +ellps=bessel"
@@ -834,6 +844,33 @@ TEST(gie, horner_only_fwd_selftest) {
         EXPECT_LE(dist, 0.01);
 
         proj_destroy(P);
+    }
+
+    {
+        PJ *P = proj_create(PJ_DEFAULT_CTX, sb_utm32_fwd_only);
+        ASSERT_TRUE(P != nullptr);
+
+        PJ_COORD a = proj_coord(0, 0, 0, 0);
+        PJ_COORD b = proj_coord(0, 0, 0, 0);
+        PJ_COORD c = proj_coord(0, 0, 0, 0);
+        a.uv.v = 6130821.2945;
+        a.uv.u = 495136.8544;
+        c.uv.v = 6130000.0000;
+        c.uv.u = 620000.0000;
+
+        /* Forward projection */
+        b = proj_trans(P, PJ_FWD, a);
+        double dist = proj_xy_dist(b, c);
+        EXPECT_LE(dist, 0.001);
+
+        /* Inverse projection */
+        b = proj_trans(P, PJ_INV, c);
+        dist = proj_xy_dist(b, a);
+        EXPECT_LE(dist, 0.001);
+
+        /* Check roundtrip precision for 1 iteration each way */
+        dist = proj_roundtrip(P, PJ_FWD, 1, &a);
+        EXPECT_LE(dist, 0.01);
     }
 }
 


### PR DESCRIPTION
This enables the user to create horner polynomial transformations
in the real number space without the need to supply "inv" parameters:
"+inv_origin", "+inv_u" and "+inv_v". We can get the inverse
transformation by only using the "fwd" parameters and solving
a system of equations iteratively. The system is usually solved in a
very small number of iterations.

A new optional parameter "+inv_tolerance" is added that can make the
iterative process stop earlier if a certain coordinate accuracy is
met. For example "+inv_tolerance=0.1" will make the iterative
process stop when the calculated coordinates differ less than
0.1 meters, if the units of the transformation destination is meters.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API