### PR TITLE
Fix build issue for ARM64 when using MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     /wd4706  # Suppress warning about assignment within conditional expression
     /wd4996  # Suppress warning about sprintf, etc., being unsafe
   )
+  if("$ENV{VSCMD_ARG_TGT_ARCH}" STREQUAL "arm64")
+    # Suppress an inaccurate warning when compiling for an MSVC/ARM64 platform
+    # It incorrectly assumes a division by zero is possible despite a check
+    set(PROJ_C_WARN_FLAGS ${PROJ_C_WARN_FLAGS} /wd4723)
+  endif()
   set(PROJ_CXX_WARN_FLAGS /EHsc ${PROJ_C_WARN_FLAGS})
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
   if(MSVC)


### PR DESCRIPTION
When compiling with MSVC for an ARM64 platform using the same configuration options as used in the github workflow, an inaccurate warning is treated as an error due to the "/Wx" option.

This disables the warning for the ARM64 target in the CMake files.

Tested with the CMake options:
* `MAKE_BUILD_TYPE="RELEASE"`
* `BUILD_SHARED_LIBS="ON"`

Using the VS2022 x64 -> ARM64 cross-compilation environment via `vcvarsamd64_arm64`.