### PR TITLE
Database: add OGC:CRS84h (WGS 84 longitude-latitude-height)

### DIFF
--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -33,6 +33,19 @@ INSERT INTO "usage" VALUES(
     'EPSG','1024'  -- unknown
 );
 
+-- Defined in http://www.opengis.net/def/crs/OGC/0/CRS84h . Same as EPSG:4979 except axis order
+INSERT INTO "geodetic_crs" VALUES('OGC','CRS84h','WGS 84 longitude-latitude-height',NULL,'geographic 3D','EPSG','6426','EPSG','6326',NULL,0);
+INSERT INTO "scope" VALUES('PROJ','OGC_CRS84h','3D system frequently used in GIS, Web APIs and Web applications',0);
+INSERT INTO "usage" VALUES(
+    'PROJ',
+    'OGC_CRS84h_USAGE',
+    'geodetic_crs',
+    'OGC',
+    'CRS84h',
+    'EPSG','1262', -- extent ('World')
+    'PROJ','OGC_CRS84h'  -- scope
+);
+
 INSERT INTO "geodetic_crs" VALUES('OGC','CRS27','NAD27 (CRS27)',NULL,'geographic 2D','EPSG','6424','EPSG','6267',NULL,0);
 INSERT INTO "usage" VALUES(
     'PROJ',

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -319,12 +319,12 @@ echo 'Checks that ED50 to ETRS89 (12) is in the output (superseded transformatio
 $EXE -s EPSG:23030 -t EPSG:25830 --bbox -6,40,-5,41 --grid-check known_available --hide-ballpark --summary >>${OUT} 2>&1
 echo "" >>${OUT}
 
-echo 'Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort' >> ${OUT}
-$EXE --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort >> ${OUT}
+echo 'Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC"' >> ${OUT}
+$EXE --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" >> ${OUT}
 echo "" >>${OUT}
 
-echo 'Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort' >> ${OUT}
-$EXE --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort >> ${OUT}
+echo 'Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC"' >> ${OUT}
+$EXE --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" >> ${OUT}
 echo "" >>${OUT}
 
 echo 'Testing --list-crs | grep deprecated | sort' >> ${OUT}

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1622,18 +1622,20 @@ Candidate operations found: 2
 unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (12) + UTM zone 30N, 0.2 m, Spain - mainland, Balearic Islands, Ceuta and Melila - onshore.
 unknown id, Inverse of UTM zone 30N + ED50 to ETRS89 (7) + UTM zone 30N, 1.5 m, Spain - onshore mainland except northwest (north of 41°30'N and west of 4°30'W).
 
-Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC" | sort
+Testing --list-crs | grep "EPSG:32632\|ESRI:103668\|OGC"
 EPSG:32632 "WGS 84 / UTM zone 32N"
 ESRI:103668 "NAD_1983_HARN_Adj_MN_Ramsey_Meters"
 OGC:CRS27 "NAD27 (CRS27)"
 OGC:CRS83 "NAD83 (CRS83)"
 OGC:CRS84 "WGS 84 (CRS84)"
+OGC:CRS84h "WGS 84 longitude-latitude-height"
 
-Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC" | sort
-EPSG:4326 "WGS 84"
+Testing --list-crs --authority OGC,EPSG | grep "EPSG:4326\|OGC"
 OGC:CRS27 "NAD27 (CRS27)"
 OGC:CRS83 "NAD83 (CRS83)"
 OGC:CRS84 "WGS 84 (CRS84)"
+OGC:CRS84h "WGS 84 longitude-latitude-height"
+EPSG:4326 "WGS 84"
 
 Testing --list-crs | grep deprecated | sort
 


### PR DESCRIPTION
This is used by recent OGC specs, such as
"OGC API - Features - Part 2: Coordinate Reference Systems by Reference"
(https://docs.ogc.org/is/18-058/18-058.html)
