### PR TITLE
Print deprecation warning for "find_package(PROJ4)"

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -7,6 +7,9 @@
 #  @PROJECT_VARIANT_NAME@_LIBRARY_DIRS = /usr/local/lib
 #  @PROJECT_VARIANT_NAME@_BINARY_DIRS = /usr/local/bin
 #  @PROJECT_VARIANT_NAME@_VERSION = 4.9.1 (for example)
+if(@PROJECT_VARIANT_NAME@ STREQUAL "PROJ4")
+  message(DEPRECATION "find_package(PROJ4) is deprecated and will be retired soon. Please use find_package(PROJ) instead.")
+endif()
 
 # Tell the user project where to find our headers and libraries
 get_filename_component (_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)

--- a/docs/source/development/cmake.rst
+++ b/docs/source/development/cmake.rst
@@ -10,7 +10,7 @@ the CMake configuration which comes with the library. Typical usage is:
 
 .. code::
 
-    find_package(PROJ CONFIG REQUIRED)
+    find_package(PROJ REQUIRED CONFIG)
 
     target_link_libraries(MyApp PRIVATE PROJ::proj)
 
@@ -25,14 +25,6 @@ particular, CMake will consult (and set) the cache variable
 ``PROJ_DIR``.
 
 The old CMake name for the PROJ project was "PROJ4" and the switch to
-the name "PROJ" was made with version 7.0.  So if you expect your
-package to work with pre-7.0 versions of PROJ, you will need to use
-
-.. code::
-
-    find_package(PROJ4)
-    target_link_libraries(MyApp PRIVATE ${PROJ4_LIBRARIES})
-    include_directories(${PROJ4_INCLUDE_DIRS})
-
-This will also find version 7.0.  This use of the PROJ4 name will be
-phased out at some point.
+the name "PROJ" was made with version 7.0.  As of PROJ 9.1, using
+``find_package(PROJ4)`` will show a CMake Deprecation Warning. The
+old project name PROJ4 name will be phased out after the PROJ 9.x series.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/OSGeo/PROJ/issues/3094
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API

I'm not familiar enough with the testing framework to know how to test this in CI. I can see the deprecation warning with a simple cmake project of just one file `app.cpp`:
```cpp
#include <proj.h>
#include <string>

int main() {
  const auto wgs84 = std::string("EPSG:4326");
  const auto pj = proj_create(nullptr, wgs84.c_str());
  proj_destroy(pj);
  return 0;
}
```
and `CMakeLists.txt`:
```cmake
find_package(PROJ4 REQUIRED CONFIG)
  
add_executable(app app.cpp)

target_link_libraries(app PRIVATE PROJ4::proj)
```

After a `cmake -B build`, I see 
```
CMake Deprecation Warning at /usr/local/lib/cmake/proj4/proj4-config.cmake:11 (message):
  find_package(PROJ4) is deprecated and will be retired soon.  Please use
  find_package(PROJ) instead.
```

Is this something that should be tested in CI?