### PR TITLE
Fix cmake CURL dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,11 +26,9 @@ build_script:
   - set VCPKG_ROOT=C:\Tools\vcpkg
   - set VCPKG_INSTALLED=%VCPKG_ROOT%\installed\%platform%-windows
   # If cached directory does not exist, update vcpkg and install dependencies
-  # The checkout of a precise sha1 for VS2015 is a workaround for https://github.com/microsoft/vcpkg/issues/11666
   - if not exist %VCPKG_INSTALLED%\bin (
       cd "%VCPKG_ROOT%" &
       git pull > nul &
-      (if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (git checkout a64dc07690bc8806e717e190f62eb58e198b599c)) &
       .\bootstrap-vcpkg.bat -disableMetrics &
       vcpkg install sqlite3[core,tool]:"%platform%"-windows &
       vcpkg install tiff:"%platform%"-windows &

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -463,10 +463,10 @@ endif()
 
 if(CURL_ENABLED)
   target_compile_definitions(proj PRIVATE -DCURL_ENABLED)
-  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIR})
+  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIRS})
   target_link_libraries(proj
     PRIVATE
-      ${CURL_LIBRARY}
+      ${CURL_LIBRARIES}
       $<$<CXX_COMPILER_ID:MSVC>:ws2_32>
       $<$<CXX_COMPILER_ID:MSVC>:wldap32>
       $<$<CXX_COMPILER_ID:MSVC>:advapi32>


### PR DESCRIPTION
FindCURL from cmake defines the variables `${CURL_LIBRARIES}` and `${CURL_INCLUDE_DIRS},` but `${CURL_LIBRARY}` and `${CURL_INCLUDE_DIR}` (empty variables) are used here instead. See [https://cmake.org/cmake/help/v3.23/module/FindCURL.html](https://cmake.org/cmake/help/v3.23/module/FindCURL.html). This has been the case since cmake 3.0, so this fix is backwards compatible.

(The reason why this hasn't been a problem so far is probably due to the fact that CURL libraries are often installed in system directories that are linked to anyway. I noticed this bug when using a custom CURL installation directory.)