### PR TITLE
createOperations(): fix/improve result of 'BD72 + Ostend height ' to 'WGS84+EGM96 height' (fixes #3191)

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -8228,6 +8228,42 @@ const std::string &PROJStringFormatter::toString() const {
                 }
             }
 
+            // detect a step and its inverse
+            if (curStep.inverted != prevStep.inverted &&
+                curStep.name == prevStep.name &&
+                curStepParamCount == prevStepParamCount) {
+                bool allSame = true;
+                for (size_t j = 0; j < curStepParamCount; j++) {
+                    if (curStep.paramValues[j] != prevStep.paramValues[j]) {
+                        allSame = false;
+                        break;
+                    }
+                }
+                if (allSame) {
+                    deletePrevAndCurIter();
+                    continue;
+                }
+            }
+
+            ++iterCur;
+        }
+    }
+
+    {
+        auto iterCur = steps.begin();
+        if (iterCur != steps.end()) {
+            ++iterCur;
+        }
+        while (iterCur != steps.end()) {
+
+            assert(iterCur != steps.begin());
+            auto iterPrev = std::prev(iterCur);
+            auto &prevStep = *iterPrev;
+            auto &curStep = *iterCur;
+
+            const auto curStepParamCount = curStep.paramValues.size();
+            const auto prevStepParamCount = prevStep.paramValues.size();
+
             // +step +proj=hgridshift +grids=grid_A
             // +step +proj=vgridshift [...] <== curStep
             // +step +inv +proj=hgridshift +grids=grid_A
@@ -8265,42 +8301,6 @@ const std::string &PROJStringFormatter::toString() const {
                     continue;
                 }
             }
-
-            // detect a step and its inverse
-            if (curStep.inverted != prevStep.inverted &&
-                curStep.name == prevStep.name &&
-                curStepParamCount == prevStepParamCount) {
-                bool allSame = true;
-                for (size_t j = 0; j < curStepParamCount; j++) {
-                    if (curStep.paramValues[j] != prevStep.paramValues[j]) {
-                        allSame = false;
-                        break;
-                    }
-                }
-                if (allSame) {
-                    deletePrevAndCurIter();
-                    continue;
-                }
-            }
-
-            ++iterCur;
-        }
-    }
-
-    {
-        auto iterCur = steps.begin();
-        if (iterCur != steps.end()) {
-            ++iterCur;
-        }
-        while (iterCur != steps.end()) {
-
-            assert(iterCur != steps.begin());
-            auto iterPrev = std::prev(iterCur);
-            auto &prevStep = *iterPrev;
-            auto &curStep = *iterCur;
-
-            const auto curStepParamCount = curStep.paramValues.size();
-            const auto prevStepParamCount = prevStep.paramValues.size();
 
             // +step +proj=unitconvert +xy_in=rad +xy_out=deg
             // +step +proj=axisswap +order=2,1

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -4705,6 +4705,77 @@ TEST(operation, compoundCRS_to_compoundCRS_WGS84_EGM96_to_WGS84_Belfast) {
 
 // ---------------------------------------------------------------------------
 
+TEST(operation,
+     compoundCRS_to_compoundCRS_OSGB36_BNG_ODN_height_to_WGS84_EGM96) {
+    auto dbContext = DatabaseContext::create();
+    auto authFactory = AuthorityFactory::create(dbContext, std::string());
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    ctxt->setGridAvailabilityUse(
+        CoordinateOperationContext::GridAvailabilityUse::
+            IGNORE_GRID_AVAILABILITY);
+    // "OSGB36 / British National Grid + ODN height
+    auto srcObj = createFromUserInput("EPSG:27700+5701", dbContext, false);
+    auto src = nn_dynamic_pointer_cast<CRS>(srcObj);
+    ASSERT_TRUE(src != nullptr);
+    auto authFactoryEPSG =
+        AuthorityFactory::create(dbContext, std::string("EPSG"));
+    auto dst = authFactoryEPSG->createCoordinateReferenceSystem(
+        "9707"); // "WGS 84 + EGM96 height"
+
+    {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            NN_NO_CHECK(src), dst, ctxt);
+        ASSERT_GE(list.size(), 1U);
+        EXPECT_EQ(list[0]->nameStr(), "Inverse of British National Grid + "
+                                      "OSGB36 to ETRS89 (2) + "
+                                      "Inverse of ETRS89 to ODN height (2) + "
+                                      "Inverse of OSGB36 to ETRS89 (2) + "
+                                      "OSGB36 to WGS 84 (9) + "
+                                      "WGS 84 to EGM96 height (1)");
+        const char *expected_proj =
+            "+proj=pipeline "
+            "+step +inv +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 "
+            "+x_0=400000 +y_0=-100000 +ellps=airy "
+            "+step +proj=hgridshift +grids=uk_os_OSTN15_NTv2_OSGBtoETRS.tif "
+            "+step +proj=vgridshift +grids=uk_os_OSGM15_GB.tif +multiplier=1 "
+            "+step +inv +proj=vgridshift +grids=us_nga_egm96_15.tif "
+            "+multiplier=1 "
+            "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
+            "+step +proj=axisswap +order=2,1";
+        EXPECT_EQ(
+            list[0]->exportToPROJString(PROJStringFormatter::create().get()),
+            expected_proj);
+    }
+
+    {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            dst, NN_NO_CHECK(src), ctxt);
+        ASSERT_GE(list.size(), 1U);
+        EXPECT_EQ(list[0]->nameStr(), "Inverse of WGS 84 to EGM96 height (1) + "
+                                      "Inverse of OSGB36 to WGS 84 (9) + "
+                                      "OSGB36 to ETRS89 (2) + "
+                                      "ETRS89 to ODN height (2) + "
+                                      "Inverse of OSGB36 to ETRS89 (2) + "
+                                      "British National Grid");
+        const char *expected_proj =
+            "+proj=pipeline "
+            "+step +proj=axisswap +order=2,1 "
+            "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
+            "+step +proj=vgridshift +grids=us_nga_egm96_15.tif +multiplier=1 "
+            "+step +inv +proj=vgridshift +grids=uk_os_OSGM15_GB.tif "
+            "+multiplier=1 "
+            "+step +inv +proj=hgridshift "
+            "+grids=uk_os_OSTN15_NTv2_OSGBtoETRS.tif "
+            "+step +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 "
+            "+x_0=400000 +y_0=-100000 +ellps=airy";
+        EXPECT_EQ(
+            list[0]->exportToPROJString(PROJStringFormatter::create().get()),
+            expected_proj);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(
     operation,
     compoundCRS_to_compoundCRS_concatenated_operation_with_two_vert_transformation) {


### PR DESCRIPTION
New result is:

```
$bin/projinfo -s EPSG:4313+5710 -t EPSG:9707

unknown id, BD72 to ETRS89 (3) + Inverse of ETRS89 to Ostend height (1) + ETRS89 to WGS 84 (1) + WGS 84 to EGM96 height (1), 2.03 m, Belgium - onshore., at least one grid missing

PROJ string:
+proj=pipeline
  +step +proj=axisswap +order=2,1
  +step +proj=unitconvert +xy_in=deg +xy_out=rad
  +step +proj=hgridshift +grids=be_ign_bd72lb72_etrs89lb08.tif
  +step +proj=vgridshift +grids=be_ign_hBG18.tif +multiplier=1
  +step +inv +proj=vgridshift +grids=us_nga_egm96_15.tif +multiplier=1
  +step +proj=unitconvert +xy_in=rad +xy_out=deg
  +step +proj=axisswap +order=2,1
```

```
$ echo 50.6 4.3 131.0 | PROJ_NETWORK=ON bin/cs2cs EPSG:4313+5710 EPSG:4326+5773 -d 3
50.599	4.301 128.592
```