### PR TITLE
Identifier::isEquivalentName(): fix when ending by ' + ' which could …

### DIFF
--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1243,14 +1243,14 @@ bool Identifier::isEquivalentName(const char *a, const char *b) noexcept {
     size_t j = 0;
     char lastValidA = 0;
     char lastValidB = 0;
-    while (a[i] != 0 && b[j] != 0) {
+    while (a[i] != 0 || b[j] != 0) {
         char aCh = a[i];
         char bCh = b[j];
-        if (aCh == ' ' && a[i + 1] == '+' && a[i + 2] == ' ') {
+        if (aCh == ' ' && a[i + 1] == '+' && a[i + 2] == ' ' && a[i + 3] != 0) {
             i += 3;
             continue;
         }
-        if (bCh == ' ' && b[j + 1] == '+' && b[j + 2] == ' ') {
+        if (bCh == ' ' && b[j + 1] == '+' && b[j + 2] == ' ' && b[j + 3] != 0) {
             j += 3;
             continue;
         }
@@ -1288,21 +1288,18 @@ bool Identifier::isEquivalentName(const char *a, const char *b) noexcept {
                 j += strlen(replacement->utf8) - 1;
             }
         }
-        if (::tolower(aCh) != ::tolower(bCh)) {
+        if ((aCh == 0 && bCh != 0) || (aCh != 0 && bCh == 0) ||
+            ::tolower(aCh) != ::tolower(bCh)) {
             return false;
         }
         lastValidA = aCh;
         lastValidB = bCh;
-        ++i;
-        ++j;
+        if (aCh != 0)
+            ++i;
+        if (bCh != 0)
+            ++j;
     }
-    while (a[i] != 0 && isIgnoredChar(a[i])) {
-        ++i;
-    }
-    while (b[j] != 0 && isIgnoredChar(b[j])) {
-        ++j;
-    }
-    return a[i] == b[j];
+    return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -383,16 +383,29 @@ TEST(metadata, id) {
 // ---------------------------------------------------------------------------
 
 TEST(metadata, Identifier_isEquivalentName) {
+    EXPECT_TRUE(Identifier::isEquivalentName("", ""));
+    EXPECT_TRUE(Identifier::isEquivalentName("x", "x"));
+    EXPECT_TRUE(Identifier::isEquivalentName("x", "X"));
+    EXPECT_TRUE(Identifier::isEquivalentName("X", "x"));
+    EXPECT_FALSE(Identifier::isEquivalentName("x", ""));
+    EXPECT_FALSE(Identifier::isEquivalentName("", "x"));
+    EXPECT_FALSE(Identifier::isEquivalentName("x", "y"));
     EXPECT_TRUE(Identifier::isEquivalentName("Central_Meridian",
                                              "Central_- ()/Meridian"));
 
     EXPECT_TRUE(Identifier::isEquivalentName("\xc3\xa1", "a"));
+    EXPECT_FALSE(Identifier::isEquivalentName("\xc3", "a"));
 
     EXPECT_TRUE(Identifier::isEquivalentName("a", "\xc3\xa1"));
+    EXPECT_FALSE(Identifier::isEquivalentName("a", "\xc3"));
 
     EXPECT_TRUE(Identifier::isEquivalentName("\xc3\xa4", "\xc3\xa1"));
 
     EXPECT_TRUE(Identifier::isEquivalentName(
         "Unknown based on International 1924 (Hayford 1909, 1910) ellipsoid",
         "Unknown_based_on_International_1924_Hayford_1909_1910_ellipsoid"));
+
+    EXPECT_TRUE(Identifier::isEquivalentName("foo + ", "foo + "));
+    EXPECT_TRUE(Identifier::isEquivalentName("foo + bar", "foo + bar"));
+    EXPECT_TRUE(Identifier::isEquivalentName("foo + bar", "foobar"));
 }


### PR DESCRIPTION
…indirectly cause an infinite stack call in master (fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47475)
