### PR TITLE
Revert SOVERSION back to 25.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ message(STATUS "Configuring PROJ:")
 ################################################################################
 include(ProjVersion)
 proj_version(MAJOR 9 MINOR 0 PATCH 1)
-set(PROJ_SOVERSION 26)
+set(PROJ_SOVERSION 25)
 set(PROJ_BUILD_VERSION "${PROJ_SOVERSION}.${PROJ_VERSION}")
 
 ################################################################################


### PR DESCRIPTION
Bumping the SOVERSION, and by extension the SONAME, in a patch release is not appropriate.