### PR TITLE
Julia package renamed from Proj4.jl to Proj.jl

### DIFF
--- a/docs/source/development/bindings.rst
+++ b/docs/source/development/bindings.rst
@@ -30,7 +30,7 @@ Go bindings and idiomatic wrapper for PROJ
 
 Julia
 =====
-`Proj4.jl <https://github.com/JuliaGeo/Proj4.jl>`_:
+`Proj.jl <https://github.com/JuliaGeo/Proj.jl>`_:
 Julia bindings and idiomatic wrapper for PROJ.
 
 TCL


### PR DESCRIPTION
It currently wraps and provides builds for PROJ 9.