### PR TITLE
createOperations(): prefer simpler pipelines / affects WGS 84 to GDA94/GDA2020

### DIFF
--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -476,6 +476,8 @@ class PROJ_GCC_DLL PROJStringFormatter {
 
     PROJ_INTERNAL Convention convention() const;
 
+    PROJ_INTERNAL size_t getStepCount() const;
+
     //! @endcond
 
   protected:

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -8626,6 +8626,13 @@ PROJStringFormatter::Convention PROJStringFormatter::convention() const {
 
 // ---------------------------------------------------------------------------
 
+// Return the number of steps in the pipeline.
+// Note: this value will change after calling toString() that will run
+// optimizations.
+size_t PROJStringFormatter::getStepCount() const { return d->steps_.size(); }
+
+// ---------------------------------------------------------------------------
+
 bool PROJStringFormatter::getUseApproxTMerc() const {
     return d->useApproxTMerc_;
 }


### PR DESCRIPTION
Prior to this change, transforming to WGS 84 to GDA2020 used in priority
transformation EPSG:9690 ("WGS 84 to GDA2020 (3)"), which is a Helmert
transformation assuming WGS 84 ~= GDA94.
But transforming from GDA2020 to WGS 84 used EPSG:8450 "GDA2020 to WGS
84 (2)" which is a no-op.
Both have the same advertized accuracy 3m
Similar case for WGS 84 <--> GDA94.

This non symetric behaviour is clearly non-desirable in scenarios where
data is transformed back and forth. I believe it is preferable to use in
that situation of transformations with the same accuracy to use the one
that involves the less transformation steps, ie the no-op one.

Seen when checking https://github.com/OSGeo/PROJ/issues/2348 again
(whose bulk issues happens to have been fixed by other previous commits)

CC @nyalldawson 