### PR TITLE
proj-config.cmake generation: only add find_dependency(CURL) for static builds

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -12,9 +12,11 @@ if(@PROJECT_VARIANT_NAME@ STREQUAL "PROJ4")
 endif()
 
 include(CMakeFindDependencyMacro)
-if("@CURL_ENABLED@" STREQUAL "TRUE")
-  # Chainload CURL usage requirements
-  find_dependency(CURL)
+if(NOT "@BUILD_SHARED_LIBS@")
+    if("@CURL_ENABLED@" STREQUAL "TRUE")
+      # Chainload CURL usage requirements
+      find_dependency(CURL)
+    endif()
 endif()
 
 # Tell the user project where to find our headers and libraries


### PR DESCRIPTION
CC @dg0yt 
At least one user recently raised the issue about PROJ dragging CURL dependency (can't remember where exactly). I see that in GDAL build, dependencies are only added for static builds, so I guess this is OK for PROJ