### PR TITLE
createOperations(): avoid potential infinite recursions (fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49256)

### DIFF
--- a/src/iso19111/common.cpp
+++ b/src/iso19111/common.cpp
@@ -443,8 +443,14 @@ bool Measure::_isEquivalentTo(const Measure &other,
     if (criterion == util::IComparable::Criterion::STRICT) {
         return operator==(other);
     }
-    return std::fabs(getSIValue() - other.getSIValue()) <=
-           maxRelativeError * std::fabs(getSIValue());
+    const double SIValue = getSIValue();
+    const double otherSIValue = other.getSIValue();
+    // It is arguable that we have to deal with infinite values, but this
+    // helps robustify some situations.
+    if (std::isinf(SIValue) && std::isinf(otherSIValue))
+        return SIValue * otherSIValue > 0;
+    return std::fabs(SIValue - otherSIValue) <=
+           maxRelativeError * std::fabs(SIValue);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_common.cpp
+++ b/test/unit/test_common.cpp
@@ -33,6 +33,8 @@
 #include "proj/metadata.hpp"
 #include "proj/util.hpp"
 
+#include <limits>
+
 using namespace osgeo::proj::common;
 using namespace osgeo::proj::metadata;
 using namespace osgeo::proj::operation;
@@ -69,7 +71,23 @@ TEST(common, unit_of_measure) {
 
 // ---------------------------------------------------------------------------
 
-TEST(common, measure) { EXPECT_TRUE(Measure(1.0) == Measure(1.0)); }
+TEST(common, measure) {
+    EXPECT_TRUE(Measure(0.0) == Measure(0.0));
+    EXPECT_TRUE(Measure(1.0) == Measure(1.0));
+    EXPECT_FALSE(Measure(1.0) == Measure(2.0));
+    EXPECT_FALSE(Measure(1.0) == Measure(0.0));
+    EXPECT_FALSE(Measure(0.0) == Measure(1.0));
+    EXPECT_TRUE(Measure(std::numeric_limits<double>::infinity()) ==
+                Measure(std::numeric_limits<double>::infinity()));
+    EXPECT_TRUE(Measure(-std::numeric_limits<double>::infinity()) ==
+                Measure(-std::numeric_limits<double>::infinity()));
+    EXPECT_FALSE(Measure(std::numeric_limits<double>::infinity()) ==
+                 Measure(-std::numeric_limits<double>::infinity()));
+    EXPECT_FALSE(Measure(std::numeric_limits<double>::infinity()) ==
+                 Measure(1.0));
+    EXPECT_FALSE(Measure(1.0) ==
+                 Measure(std::numeric_limits<double>::infinity()));
+}
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The test case of ossfuzz #49256 involves a "a=inf" PROJ string
parameter, which is normally rejected by our parsing code. I'm not sure
how in the ossfuzz context this gets accepted...
