### PR TITLE
Add method DerivedProjectedCRS::demoteTo2D and implement promoteTo3D

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -1273,6 +1273,10 @@ class PROJ_GCC_DLL DerivedProjectedCRS final : public DerivedCRS {
            const operation::ConversionNNPtr &derivingConversionIn,
            const cs::CoordinateSystemNNPtr &csIn);
 
+    PROJ_DLL DerivedProjectedCRSNNPtr
+    demoteTo2D(const std::string &newName,
+               const io::DatabaseContextPtr &dbContext) const;
+
     //! @cond Doxygen_Suppress
     PROJ_INTERNAL void _exportToWKT(io::WKTFormatter *formatter)
         const override; // throw(io::FormattingException)

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -136,6 +136,7 @@ osgeo::proj::crs::DerivedGeographicCRS::demoteTo2D(std::string const&, std::shar
 osgeo::proj::crs::DerivedGeographicCRS::~DerivedGeographicCRS()
 osgeo::proj::crs::DerivedProjectedCRS::baseCRS() const
 osgeo::proj::crs::DerivedProjectedCRS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::crs::ProjectedCRS> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::operation::Conversion> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystem> > const&)
+osgeo::proj::crs::DerivedProjectedCRS::demoteTo2D(std::string const&, std::shared_ptr<osgeo::proj::io::DatabaseContext> const&) const
 osgeo::proj::crs::DerivedProjectedCRS::~DerivedProjectedCRS()
 osgeo::proj::crs::DerivedVerticalCRS::baseCRS() const
 osgeo::proj::crs::DerivedVerticalCRS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::crs::VerticalCRS> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::operation::Conversion> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::VerticalCS> > const&)

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1261,12 +1261,12 @@ CRSNNPtr CRS::promoteTo3D(const std::string &newName,
     }
 
     else if (auto derivedProjCRS =
-            dynamic_cast<const DerivedProjectedCRS *>(this)) {
+                 dynamic_cast<const DerivedProjectedCRS *>(this)) {
         const auto &axisList = derivedProjCRS->coordinateSystem()->axisList();
         if (axisList.size() == 2) {
-            auto cs = cs::CartesianCS::create(
-                util::PropertyMap(), axisList[0], axisList[1],
-                verticalAxisIfNotAlreadyPresent);
+            auto cs = cs::CartesianCS::create(util::PropertyMap(), axisList[0],
+                                              axisList[1],
+                                              verticalAxisIfNotAlreadyPresent);
             auto baseProj3DCRS = util::nn_dynamic_pointer_cast<ProjectedCRS>(
                 derivedProjCRS->baseCRS()->promoteTo3D(
                     std::string(), dbContext, verticalAxisIfNotAlreadyPresent));
@@ -1375,7 +1375,8 @@ CRSNNPtr CRS::demoteTo2D(const std::string &newName,
         return derivedGeogCRS->demoteTo2D(newName, dbContext);
     }
 
-    else if (auto derivedProjCRS = dynamic_cast<const DerivedProjectedCRS *>(this)) {
+    else if (auto derivedProjCRS =
+                 dynamic_cast<const DerivedProjectedCRS *>(this)) {
         return derivedProjCRS->demoteTo2D(newName, dbContext);
     }
 
@@ -6525,13 +6526,14 @@ DerivedProjectedCRSNNPtr DerivedProjectedCRS::create(
  * applicable.
  * @since 9.1.1
  */
-DerivedProjectedCRSNNPtr DerivedProjectedCRS::demoteTo2D(
-    const std::string &newName, const io::DatabaseContextPtr &dbContext) const {
+DerivedProjectedCRSNNPtr
+DerivedProjectedCRS::demoteTo2D(const std::string &newName,
+                                const io::DatabaseContextPtr &dbContext) const {
 
     const auto &axisList = coordinateSystem()->axisList();
     if (axisList.size() == 3) {
         auto cs = cs::CartesianCS::create(util::PropertyMap(), axisList[0],
-                                            axisList[1]);
+                                          axisList[1]);
         auto baseProj2DCRS = util::nn_dynamic_pointer_cast<ProjectedCRS>(
             baseCRS()->demoteTo2D(std::string(), dbContext));
         return DerivedProjectedCRS::create(

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1260,6 +1260,23 @@ CRSNNPtr CRS::promoteTo3D(const std::string &newName,
         }
     }
 
+    else if (auto derivedProjCRS =
+            dynamic_cast<const DerivedProjectedCRS *>(this)) {
+        const auto &axisList = derivedProjCRS->coordinateSystem()->axisList();
+        if (axisList.size() == 2) {
+            auto cs = cs::CartesianCS::create(
+                util::PropertyMap(), axisList[0], axisList[1],
+                verticalAxisIfNotAlreadyPresent);
+            auto baseProj3DCRS = util::nn_dynamic_pointer_cast<ProjectedCRS>(
+                derivedProjCRS->baseCRS()->promoteTo3D(
+                    std::string(), dbContext, verticalAxisIfNotAlreadyPresent));
+            return util::nn_static_pointer_cast<CRS>(
+                DerivedProjectedCRS::create(
+                    createProperties(), NN_CHECK_THROW(baseProj3DCRS),
+                    derivedProjCRS->derivingConversion(), cs));
+        }
+    }
+
     else if (auto geogCRS = dynamic_cast<const GeographicCRS *>(this)) {
         const auto &axisList = geogCRS->coordinateSystem()->axisList();
         if (axisList.size() == 2) {
@@ -1356,6 +1373,10 @@ CRSNNPtr CRS::demoteTo2D(const std::string &newName,
     if (auto derivedGeogCRS =
             dynamic_cast<const DerivedGeographicCRS *>(this)) {
         return derivedGeogCRS->demoteTo2D(newName, dbContext);
+    }
+
+    else if (auto derivedProjCRS = dynamic_cast<const DerivedProjectedCRS *>(this)) {
+        return derivedProjCRS->demoteTo2D(newName, dbContext);
     }
 
     else if (auto geogCRS = dynamic_cast<const GeographicCRS *>(this)) {
@@ -6489,6 +6510,38 @@ DerivedProjectedCRSNNPtr DerivedProjectedCRS::create(
     crs->setProperties(properties);
     crs->setDerivingConversionCRS();
     return crs;
+}
+
+// ---------------------------------------------------------------------------
+
+/** \brief Return a variant of this CRS "demoted" to a 2D one, if not already
+ * the case.
+ *
+ *
+ * @param newName Name of the new CRS. If empty, nameStr() will be used.
+ * @param dbContext Database context to look for potentially already registered
+ *                  2D CRS. May be nullptr.
+ * @return a new CRS demoted to 2D, or the current one if already 2D or not
+ * applicable.
+ * @since 9.1.1
+ */
+DerivedProjectedCRSNNPtr DerivedProjectedCRS::demoteTo2D(
+    const std::string &newName, const io::DatabaseContextPtr &dbContext) const {
+
+    const auto &axisList = coordinateSystem()->axisList();
+    if (axisList.size() == 3) {
+        auto cs = cs::CartesianCS::create(util::PropertyMap(), axisList[0],
+                                            axisList[1]);
+        auto baseProj2DCRS = util::nn_dynamic_pointer_cast<ProjectedCRS>(
+            baseCRS()->demoteTo2D(std::string(), dbContext));
+        return DerivedProjectedCRS::create(
+            util::PropertyMap().set(common::IdentifiedObject::NAME_KEY,
+                                    !newName.empty() ? newName : nameStr()),
+            NN_CHECK_THROW(baseProj2DCRS), derivingConversion(), cs);
+    }
+
+    return NN_NO_CHECK(std::dynamic_pointer_cast<DerivedProjectedCRS>(
+        shared_from_this().as_nullable()));
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6791,6 +6791,32 @@ TEST(crs, promoteTo3D_and_demoteTo2D) {
         EXPECT_TRUE(demoted->demoteTo2D(std::string(), nullptr)
                         ->isEquivalentTo(demoted.get()));
     }
+
+    {
+        auto crs = createDerivedProjectedCRS();
+        auto crs3D = crs->promoteTo3D(std::string(), dbContext);
+        auto crs3DAsDerivedProj =
+            nn_dynamic_pointer_cast<DerivedProjectedCRS>(crs3D);
+        ASSERT_TRUE(crs3DAsDerivedProj != nullptr);
+        EXPECT_EQ(crs3DAsDerivedProj->baseCRS()
+                      ->coordinateSystem()
+                      ->axisList()
+                      .size(),
+                  3U);
+        EXPECT_EQ(crs3DAsDerivedProj->coordinateSystem()->axisList().size(),
+                  3U);
+        EXPECT_TRUE(crs3DAsDerivedProj->promoteTo3D(std::string(), nullptr)
+                        ->isEquivalentTo(crs3DAsDerivedProj.get()));
+
+        auto demoted = crs3DAsDerivedProj->demoteTo2D(std::string(), dbContext);
+        EXPECT_EQ(demoted->baseCRS()->coordinateSystem()->axisList().size(),
+                  2U);
+        EXPECT_EQ(demoted->coordinateSystem()->axisList().size(), 2U);
+        EXPECT_TRUE(demoted->isEquivalentTo(
+            crs.get(), IComparable::Criterion::EQUIVALENT));
+        EXPECT_TRUE(demoted->demoteTo2D(std::string(), nullptr)
+                        ->isEquivalentTo(demoted.get()));
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`DerivedProjectedCRS` do not work properly with `promoteTo3D` and `demoteTo2D`.
This PR tries to implement that functionality.

 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes