### PR TITLE
Implement alterCSLinearUnit for DerivedProjectedCRS

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -368,6 +368,16 @@ CRSNNPtr CRS::alterCSLinearUnit(const common::UnitOfMeasure &unit) const {
         }
     }
 
+    {
+        auto derivedProjCRS = dynamic_cast<const DerivedProjectedCRS *>(this);
+        if (derivedProjCRS) {
+            return DerivedProjectedCRS::create(
+                createPropertyMap(this), derivedProjCRS->baseCRS(),
+                derivedProjCRS->derivingConversion(),
+                derivedProjCRS->baseCRS()->coordinateSystem()->alterUnit(unit));
+        }
+    }
+
     return NN_NO_CHECK(
         std::dynamic_pointer_cast<CRS>(shared_from_this().as_nullable()));
 }

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6485,6 +6485,19 @@ TEST(crs, crs_alterCSLinearUnit) {
     }
 
     {
+        auto crs = createDerivedProjectedCRS()->alterCSLinearUnit(
+            UnitOfMeasure("my unit", 2));
+        auto derivedProjCRS = dynamic_cast<DerivedProjectedCRS *>(crs.get());
+        ASSERT_TRUE(derivedProjCRS != nullptr);
+        auto cs = derivedProjCRS->coordinateSystem();
+        ASSERT_EQ(cs->axisList().size(), 2U);
+        EXPECT_EQ(cs->axisList()[0]->unit().name(), "my unit");
+        EXPECT_EQ(cs->axisList()[0]->unit().conversionToSI(), 2);
+        EXPECT_EQ(cs->axisList()[1]->unit().name(), "my unit");
+        EXPECT_EQ(cs->axisList()[1]->unit().conversionToSI(), 2);
+    }
+
+    {
         auto crs = GeodeticCRS::EPSG_4978->alterCSLinearUnit(
             UnitOfMeasure("my unit", 2));
         auto geodCRS = dynamic_cast<GeodeticCRS *>(crs.get());


### PR DESCRIPTION
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes

Working with `DerivedProjectedCRS`, having this functionality would be useful (in combination with `promoteTo3D`)