### PR TITLE
CMake: add a INSTALL_LEGACY_CMAKE_FILES option (fixes OSGeo/gdal#5646)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -90,7 +90,17 @@ else ()
   set (CMAKE_CROSSCOMPILING_STR "OFF")
 endif ()
 
-foreach (PROJECT_VARIANT_NAME ${PROJECT_NAME} ${PROJECT_LEGACY_NAME})
+# If this is a regular build (PROJECT_SOURCE_DIR == CMAKE_SOURCE_DIR), export legacy files by default
+# Otherwise, this is embedded in another project, only export PROJ target
+# cf https://github.com/OSGeo/gdal/issues/5646
+string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}" DEFAULT_VAL)
+option(INSTALL_LEGACY_CMAKE_FILES "Install PROJ4 legacy target CMake files" ${DEFAULT_VAL})
+
+set(PROJECT_LIST ${PROJECT_NAME})
+if (INSTALL_LEGACY_CMAKE_FILES)
+    set(PROJECT_LIST "${PROJECT_LIST}" "${PROJECT_LEGACY_NAME}")
+endif ()
+foreach (PROJECT_VARIANT_NAME IN LISTS PROJECT_LIST)
   string (TOLOWER "${PROJECT_VARIANT_NAME}" PROJECT_VARIANT_LOWER)
   set (CMAKECONFIGSUBDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_VARIANT_LOWER}")
   # proj-config.cmake for the install tree.  It's installed in
@@ -117,9 +127,11 @@ foreach (PROJECT_VARIANT_NAME ${PROJECT_NAME} ${PROJECT_LEGACY_NAME})
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME_LOWER}-targets.cmake
     DESTINATION "${CMAKECONFIGSUBDIR}")
-  install(EXPORT targets
-    NAMESPACE ${PROJECT_LEGACY_NAME}::
-    FILE ${PROJECT_LEGACY_LOWER}-targets.cmake
-    DESTINATION "${CMAKECONFIGSUBDIR}")
+  if (INSTALL_LEGACY_CMAKE_FILES)
+      install(EXPORT targets
+        NAMESPACE ${PROJECT_LEGACY_NAME}::
+        FILE ${PROJECT_LEGACY_LOWER}-targets.cmake
+        DESTINATION "${CMAKECONFIGSUBDIR}")
+  endif()
 endforeach ()
 


### PR DESCRIPTION
to control whether the PROJ4 legacy target should be exported (refs #3168)

The default is ON, unless PROJ is built as part of a CMake subproject.

I've verified this fixes the following reproducer (and that I hit the issue without this PR)
```
add_subdirectory(proj)
add_subdirectory(gdal)
```