### PR TITLE
WKT import: 3D-promote base CRS of 3D DerivedProjectedCRS (fixes #3340)

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -5145,6 +5145,13 @@ WKTParser::Private::buildDerivedProjectedCRS(const WKTNodeNNPtr &node) {
         ThrowMissing(WKTConstants::CS_);
     }
     auto cs = buildCS(csNode, node, UnitOfMeasure::NONE);
+
+    if (cs->axisList().size() == 3 &&
+        baseProjCRS->coordinateSystem()->axisList().size() == 2) {
+        baseProjCRS = NN_NO_CHECK(util::nn_dynamic_pointer_cast<ProjectedCRS>(
+            baseProjCRS->promoteTo3D(std::string(), dbContext_)));
+    }
+
     return DerivedProjectedCRS::create(buildProperties(node), baseProjCRS,
                                        conversion, cs);
 }

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6853,6 +6853,21 @@ TEST(crs, promoteTo3D_and_demoteTo2D) {
         EXPECT_TRUE(crs3DAsDerivedProj->promoteTo3D(std::string(), nullptr)
                         ->isEquivalentTo(crs3DAsDerivedProj.get()));
 
+        // Check that importing an exported DerivedProjected 3D CRS as WKT keeps
+        // the 3D aspect of the baseCRS (see #3340)
+        {
+            WKTFormatterNNPtr f(
+                WKTFormatter::create(WKTFormatter::Convention::WKT2_2019));
+            crs3DAsDerivedProj->exportToWKT(f.get());
+            auto obj = WKTParser().createFromWKT(f->toString());
+            auto crsFromWkt = nn_dynamic_pointer_cast<DerivedProjectedCRS>(obj);
+            ASSERT_TRUE(crsFromWkt != nullptr);
+            EXPECT_EQ(crsFromWkt->coordinateSystem()->axisList().size(), 3U);
+            EXPECT_EQ(
+                crsFromWkt->baseCRS()->coordinateSystem()->axisList().size(),
+                3U);
+        }
+
         auto demoted = crs3DAsDerivedProj->demoteTo2D(std::string(), dbContext);
         EXPECT_EQ(demoted->baseCRS()->coordinateSystem()->axisList().size(),
                   2U);


### PR DESCRIPTION
With the fix
```
$ projinfo -s  EPSG:6318+6360 -t @derivedproj3D.wkt --spatial-test intersects -o PROJ -q

+proj=pipeline
  +step +proj=axisswap +order=2,1
  +step +proj=unitconvert +xy_in=deg +z_in=us-ft +xy_out=rad +z_out=m
  +step +proj=vgridshift +grids=us_noaa_g2018u0.tif +multiplier=1
  +step +proj=tmerc +lat_0=41 +lon_0=-73 +k=1 +x_0=0 +y_0=0 +ellps=GRS80
  +step +proj=unitconvert +xy_in=m +xy_out=us-ft +z_in=m +z_out=us-ft
  +step +proj=affine +xoff=5 +yoff=52 +zoff=10
  +step +proj=unitconvert +xy_in=us-ft +xy_out=m +z_in=us-ft +z_out=m
  +step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft
  +step +proj=axisswap +order=2,1
```

where derivedproj3D.wkt is
```
DERIVEDPROJCRS["Custom Site Calibrated 3D CRS",
    BASEPROJCRS["Transverse Mercator centered in area of interest",
        BASEGEOGCRS["NAD83(2011)",
            DATUM["NAD83 (National Spatial Reference System 2011)",
                ELLIPSOID["GRS 1980",6378137,298.257222101,
                    LENGTHUNIT["metre",1]]],
            PRIMEM["Greenwich",0,
                ANGLEUNIT["degree",0.0174532925199433]]],
        CONVERSION["Transverse Mercator",
            METHOD["Transverse Mercator",
                ID["EPSG",9807]],
            PARAMETER["Latitude of natural origin",41,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8801]],
            PARAMETER["Longitude of natural origin",-73,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8802]],
            PARAMETER["Scale factor at natural origin",1,
                SCALEUNIT["unity",1],
                ID["EPSG",8805]],
            PARAMETER["False easting",0,
                LENGTHUNIT["US survey foot",0.304800609601219],
                ID["EPSG",8806]],
            PARAMETER["False northing",0,
                LENGTHUNIT["US survey foot",0.304800609601219],
                ID["EPSG",8807]]]],
    DERIVINGCONVERSION["Affine transformation as PROJ-based",
        METHOD["PROJ-based operation method: +proj=pipeline  +step +proj=unitconvert +xy_in=m +xy_out=us-ft +z_in=m +z_out=us-ft +step +proj=affine +xoff=5 +yoff=52 +zoff=10 +step +proj=unitconvert +xy_in=us-ft +xy_out=m +z_in=us-ft +z_out=m"]],
    CS[Cartesian,3],
        AXIS["(Y)",north,
            ORDER[1],
            LENGTHUNIT["US survey foot",0.304800609601219,
                ID["EPSG",9003]]],
        AXIS["(X)",east,
            ORDER[2],
            LENGTHUNIT["US survey foot",0.304800609601219,
                ID["EPSG",9003]]],
        AXIS["(Z)",up,
            ORDER[3],
            LENGTHUNIT["US survey foot",0.304800609601219,
                ID["EPSG",9003]]]]
```

Possible workarounds:
- add a non conformant CS[] definition with 3 axis to the BASEPROJCRS[] and BASEGEOGCRS[]
- export the WTK to PROJJSON and edit the coordinate_system of the 2 base_crs to have a Z axis
