### PR TITLE
projinfo / cs2cs : auto promotion to 3D of CRS specified by name

### DIFF
--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -3751,16 +3751,21 @@ bool SingleOperation::exportToPROJStringGeneric(
         double offsetDeg =
             parameterValueNumeric(EPSG_CODE_PARAMETER_LONGITUDE_OFFSET,
                                   common::UnitOfMeasure::DEGREE);
-
+        auto l_sourceCRS = sourceCRS();
         auto sourceCRSGeog =
-            dynamic_cast<const crs::GeographicCRS *>(sourceCRS().get());
+            l_sourceCRS ? extractGeographicCRSIfGeographicCRSOrEquivalent(
+                              NN_NO_CHECK(l_sourceCRS))
+                        : nullptr;
         if (!sourceCRSGeog) {
             throw io::FormattingException(
                 concat("Can apply ", methodName, " only to GeographicCRS"));
         }
 
+        auto l_targetCRS = targetCRS();
         auto targetCRSGeog =
-            dynamic_cast<const crs::GeographicCRS *>(targetCRS().get());
+            l_targetCRS ? extractGeographicCRSIfGeographicCRSOrEquivalent(
+                              NN_NO_CHECK(l_targetCRS))
+                        : nullptr;
         if (!targetCRSGeog) {
             throw io::FormattingException(
                 concat("Can apply ", methodName + " only to GeographicCRS"));

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -131,6 +131,14 @@ echo "Testing EPSG:32631 --3d" >> ${OUT}
 $EXE EPSG:32631 --3d >>${OUT} 2>&1
 echo "" >>${OUT}
 
+echo "Testing -s "WGS 84" -t "WGS 84 + EGM96 height" --hide-ballpark --summary" >> ${OUT}
+$EXE -s "WGS 84" -t "WGS 84 + EGM96 height" --hide-ballpark --summary >>${OUT} 2>&1
+echo "" >>${OUT}
+
+echo "Testing -s "WGS 84 + EGM96 height" -t "WGS 84" --hide-ballpark --summary" >> ${OUT}
+$EXE -s "WGS 84 + EGM96 height" -t "WGS 84" --hide-ballpark --summary >>${OUT} 2>&1
+echo "" >>${OUT}
+
 echo "Testing -s EPSG:32631 -t EPSG:4326+3855 --summary" >> ${OUT}
 $EXE -s EPSG:32631 -t EPSG:4326+3855 --summary >>${OUT} 2>&1
 echo "" >>${OUT}

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1240,6 +1240,14 @@ PROJCRS["WGS 84 / UTM zone 31N",
         BBOX[0,0,84,6]],
     REMARK["Promoted to 3D from EPSG:32631"]]
 
+Testing -s WGS 84 -t WGS 84 + EGM96 height --hide-ballpark --summary
+Candidate operations found: 1
+unknown id, WGS 84 to EGM96 height (1), 1 m, World.
+
+Testing -s WGS 84 + EGM96 height -t WGS 84 --hide-ballpark --summary
+Candidate operations found: 1
+unknown id, Inverse of WGS 84 to EGM96 height (1), 1 m, World.
+
 Testing -s EPSG:32631 -t EPSG:4326+3855 --summary
 Candidate operations found: 1
 unknown id, Inverse of UTM zone 31N + Inverse of Null geographic offset from WGS 84 to WGS 84, 0 m, World.

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1033,6 +1033,16 @@ $EXE -E EPSG:4326 "NAD83(HARN)" >> ${OUT} <<EOF
 34 -120
 EOF
 
+echo  "##############################################################" >> ${OUT}
+echo  "Check that we promote CRS specified by name to 3D when the other one is 3D" >> ${OUT}
+$EXE -d 3 -E "WGS 84" "WGS 84 + EGM96 height" >> ${OUT} <<EOF
+49 2 50
+EOF
+
+$EXE -d 3 -E "WGS 84 + EGM96 height" "WGS 84" >> ${OUT} <<EOF
+49 2 0
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -500,3 +500,7 @@ Check that we can use a transformation spanning the antimeridian (should use Pul
 ##############################################################
 Check that we select the operation that has the smallest area of use, when 2 have the same accuracy
 34 -120	33d59'59.983"N	119d59'59.955"W 0.000
+##############################################################
+Check that we promote CRS specified by name to 3D when the other one is 3D
+49 2 50	49.000	2.000 4.936
+49 2 0	49.000	2.000 45.064


### PR DESCRIPTION
- Avoid error on "projinfo -s 'NTF (Paris) + NGF IGN69 height' -t ETRS89" which by itself is not super sensical without the --3d flag to ask for ETRS89 3D.
- projinfo: when source (or target) CRS is specified by name, promote it to 3D if there's a known 3D CRS of same name and that the other CRS is 3D
- cs2cs: when source (or target) CRS is specified by name, promote it to 3D if there's a known 3D CRS of same name and that the other CRS is 3D
