### PR TITLE
Doc: add a page about users of PROJ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -194,3 +194,14 @@ call the software PROJ.
 Use of name PROJ.4 is now strictly reserved for describing legacy behavior
 of the software, e.g. "PROJ.4 strings" as seen in :program:`projinfo`
 output.
+
+
+Who uses PROJ ?
+---------------
+
+See :ref:`users`:
+
+.. toctree::
+   :hidden:
+
+   users

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -1,0 +1,51 @@
+.. _users:
+
+================================================================================
+Software and organizations using or contributing to PROJ
+================================================================================
+
+Free and open source software
+-----------------------------
+
+- `GDAL <https://gdal.org>`_ Translator library for raster and vector geospatial data formats, used by > 100 other software
+- `GRASS GIS <http://grass.osgeo.org>`_  A raster/vector open source GIS
+- `libgeotiff <https://github.com/OSGeo/libgeotiff>`_ Library to read/write GeoTIFF keys
+- `MapServer <http://mapserver.org/index.html>`_  A popular web mapping application
+- `PDAL <https://pdal.io>`_  Point Cloud Data Abstraction Library
+- `PostGIS <http://www.postgis.net>`_ Spatial database extender for PostgreSQL
+- `pyproj <https://pyproj4.github.io/pyproj>`_ Python interface to PROJ
+- `QGIS <http://www.qgis.org>`_ A cross platform desktop GIS.
+- `R <http://www.r-project.org>`_ A free software environment for statistical computing and graphics
+
+Proprietary licensed software
+-----------------------------
+
+- `FME <http://www.safe.com>`_  A GIS translator package. Includes a PROJ based transformer.
+
+Geodetic organizations
+----------------------
+
+- `Agency for Data Supply and Infrastructure of Denmark (SDFI) <https://eng.sdfi.dk/>`_ 
+- `Land Information New Zealand (LINZ) <https://www.linz.govt.nz/>`_
+- `National Land Survey of Finland (NLS) <https://www.maanmittauslaitos.fi/en>`_
+- `National Land Survey of Iceland (NLS) <https://www.lmi.is/>`_
+- `Nordic Geodetic commission (NKG) <https://www.nordicgeodeticcommission.com/>`_
+- `Norwegian Mapping Authority (Kartverket) <https://kartverket.no/en>`_
+- `Swedish mapping, cadastral and land registration authority (Lantmäteriet) <https://www.lantmateriet.se/>`_
+- `USGS <https://www.usgs.gov/>`_: PROJ initial author, Gerald E. Evenden, worked at USGS
+
+Public organizations
+--------------------
+
+(add yourself here if you are a direct user of PROJ API or utilities)
+
+Private organizations
+---------------------
+
+(add yourself here if you are a direct user of PROJ API or utilities)
+
+Sponsors
+--------
+
+PROJ development, as an upstream dependency of GDAL, benefits from funding
+brought by its `sponsors <https://gdal.org/sponsors/>`_


### PR DESCRIPTION
Equivalent of https://gdal.org/software_using_gdal.html

I've started this page as I needed thta information for an upcoming presentation for PROJ :-)

We should publicize it on the mailing list so that people can add themselves to the list