### PR TITLE
VerticalCRS::_isEquivalentTo(): do not consider VerticalCRS and DerivedVerticalCRS as equivalent

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -3728,6 +3728,10 @@ bool VerticalCRS::_isEquivalentTo(
     const util::IComparable *other, util::IComparable::Criterion criterion,
     const io::DatabaseContextPtr &dbContext) const {
     auto otherVertCRS = dynamic_cast<const VerticalCRS *>(other);
+    if (otherVertCRS == nullptr ||
+        !util::isOfExactType<VerticalCRS>(*otherVertCRS)) {
+        return false;
+    }
     // TODO test geoidModel and velocityModel
     return otherVertCRS != nullptr &&
            SingleCRS::baseIsEquivalentTo(other, criterion, dbContext);

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -5962,6 +5962,19 @@ TEST(crs, parametricCRS_WKT1) {
 
 // ---------------------------------------------------------------------------
 
+TEST(crs, derivedVerticalCRS_basic) {
+
+    auto crs = createDerivedVerticalCRS();
+    EXPECT_TRUE(crs->isEquivalentTo(crs.get()));
+    EXPECT_TRUE(crs->shallowClone()->isEquivalentTo(crs.get()));
+    EXPECT_TRUE(!crs->isEquivalentTo(createUnrelatedObject().get()));
+
+    EXPECT_FALSE(crs->isEquivalentTo(crs->baseCRS().get()));
+    EXPECT_FALSE(crs->baseCRS()->isEquivalentTo(crs.get()));
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(crs, DerivedVerticalCRS_WKT2) {
 
     auto expected = "VERTCRS[\"Derived vertCRS\",\n"
@@ -5976,10 +5989,6 @@ TEST(crs, DerivedVerticalCRS_WKT2) {
                     "                ID[\"EPSG\",9001]]]]";
 
     auto crs = createDerivedVerticalCRS();
-    EXPECT_TRUE(crs->isEquivalentTo(crs.get()));
-    EXPECT_TRUE(crs->shallowClone()->isEquivalentTo(crs.get()));
-    EXPECT_TRUE(!crs->isEquivalentTo(createUnrelatedObject().get()));
-
     EXPECT_EQ(crs->exportToWKT(
                   WKTFormatter::create(WKTFormatter::Convention::WKT2).get()),
               expected);


### PR DESCRIPTION
This cause incorrect result when transforming from/to a DerivedVerticalCRS or a CompoundCRS made of a DerivedVerticalCRS

With that fix:
```
$ echo 46.9524055555556 7.43958333333333 400 | cs2cs -d 12 EPSG:4979 "$(cat test.wkt)"
46.953728423809	7.440534369109 361.014348853429
```

Fixes #3407
