### PR TITLE
createOperations(): fix issues when transforming between Geog3D and DerivedGeog3D CRS with Geographic3D offsets method

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -3201,6 +3201,14 @@ CRSNNPtr WKTParser::Private::buildDerivedGeodeticCRS(const WKTNodeNNPtr &node) {
 
     auto ellipsoidalCS = nn_dynamic_pointer_cast<EllipsoidalCS>(cs);
     if (ellipsoidalCS) {
+
+        if (ellipsoidalCS->axisList().size() == 3 &&
+            baseGeodCRS->coordinateSystem()->axisList().size() == 2) {
+            baseGeodCRS =
+                NN_NO_CHECK(util::nn_dynamic_pointer_cast<GeodeticCRS>(
+                    baseGeodCRS->promoteTo3D(std::string(), dbContext_)));
+        }
+
         return DerivedGeographicCRS::create(buildProperties(node), baseGeodCRS,
                                             derivingConversion,
                                             NN_NO_CHECK(ellipsoidalCS));

--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -3465,12 +3465,16 @@ void Conversion::_exportToPROJString(
         methodEPSGCode == EPSG_CODE_METHOD_AFFINE_PARAMETRIC_TRANSFORMATION;
     const bool isGeographicGeocentric =
         methodEPSGCode == EPSG_CODE_METHOD_GEOGRAPHIC_GEOCENTRIC;
+    const bool isGeographicOffsets =
+        methodEPSGCode == EPSG_CODE_METHOD_GEOGRAPHIC2D_OFFSETS ||
+        methodEPSGCode == EPSG_CODE_METHOD_GEOGRAPHIC3D_OFFSETS ||
+        methodEPSGCode == EPSG_CODE_METHOD_GEOGRAPHIC2D_WITH_HEIGHT_OFFSETS;
     const bool isHeightDepthReversal =
         methodEPSGCode == EPSG_CODE_METHOD_HEIGHT_DEPTH_REVERSAL;
     const bool applySourceCRSModifiers =
         !isZUnitConversion && !isAffineParametric &&
         !isAxisOrderReversal(methodEPSGCode) && !isGeographicGeocentric &&
-        !isHeightDepthReversal;
+        !isGeographicOffsets && !isHeightDepthReversal;
     bool applyTargetCRSModifiers = applySourceCRSModifiers;
 
     if (formatter->getCRSExport()) {


### PR DESCRIPTION
Given test.wkt with:
```
GEOGCRS["CH1903+ with 10m offset on ellipsoidal height",
    BASEGEOGCRS["CH1903+",
        DATUM["CH1903+",
            ELLIPSOID["Bessel 1841",6377397.155,299.1528128,
                LENGTHUNIT["metre",1]],
            ID["EPSG",6150]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8901]]],
    DERIVINGCONVERSION["Offset on ellipsoidal height",
        METHOD["Geographic3D offsets",
            ID["EPSG",9660]],
        PARAMETER["Latitude offset",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8601]],
        PARAMETER["Longitude offset",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8602]],
        PARAMETER["Vertical Offset",10,
            LENGTHUNIT["metre",1],
            ID["EPSG",8603]]],
    CS[ellipsoidal,3],
        AXIS["geodetic latitude (Lat)",north,
            ORDER[1],
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]],
        AXIS["geodetic longitude (Lon)",east,
            ORDER[2],
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]],
        AXIS["ellipsoidal height (h)",up,
            ORDER[3],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]]]
```

```
$ projinfo -s EPSG:4979 -t @test.wkt --spatial-test intersects -o PROJ --hide-ballpark
Candidate operations found: 1
-------------------------------------
Operation No. 1:

unknown id, Inverse of CH1903+ to WGS 84 (1) + Offset on ellipsoidal height, 1 m, Liechtenstein; Switzerland.

PROJ string:
+proj=pipeline
  +step +proj=axisswap +order=2,1
  +step +proj=unitconvert +xy_in=deg +z_in=m +xy_out=rad +z_out=m
  +step +proj=cart +ellps=WGS84
  +step +proj=helmert +x=-674.374 +y=-15.056 +z=-405.346
  +step +inv +proj=cart +ellps=bessel
  +step +proj=geogoffset +dlat=0 +dlon=0 +dh=10
  +step +proj=unitconvert +xy_in=rad +z_in=m +xy_out=deg +z_out=m
  +step +proj=axisswap +order=2,1
```

Fixes https://github.com/OSGeo/PROJ/issues/3407#issuecomment-1287877068