### PR TITLE
Update cs2cs.rst

### DIFF
--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -137,7 +137,7 @@ The following control parameters can appear in any order:
 
     Where *n* is the number of significant fractional digits to employ for seconds
     output. When ``-W`` is employed the fields will be constant width
-    with leading zeroes.
+    with leading zeroes. Valid range: -W0 through -W8.
 
 .. option:: -v
 


### PR DESCRIPTION
-W9 = -W3 and -W10 = crash

```
==== cs2cs -W7 ...
43d05'18.7380000"E	79d04'11.1590000"S 0.000
==== cs2cs -W8 ...
43d05'18.73800000"E	79d04'11.15900000"S 0.000
==== cs2cs -W9 ...
43d5'18.738"E	79d4'11.159"S 0.000
==== cs2cs -W10 ...
Rel. 9.1.0, September 1st, 2022
<cs2cs>:
invalid option: -0
program abnormally terminated
```

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API