### PR TITLE
Update transformation.rst

### DIFF
--- a/docs/source/usage/transformation.rst
+++ b/docs/source/usage/transformation.rst
@@ -70,7 +70,9 @@ solutions for a wide spectrum of geodetic tasks.
 
 As a first example, let us take a look at the iconic
 *geodetic → Cartesian → Helmert → geodetic* case (steps 2 to 4 in the example in
-the introduction). In PROJ it can be implemented as
+the introduction). 
+(Note, for the rest of this book the "+"s are removed from the examples.)
+In PROJ it can be implemented as
 
 ::
 


### PR DESCRIPTION
Note: I have only mentioned that the +'s went away.

Apparently the author is using +init files here, and showing only their contents.

However even if the user placed the example snippets seen in the boxes into files in the current directory, there is no complete working example!

I am saying that earlier in this book, the user was able to run the examples shown.

But now if the user wishes to continue running them, he has to put the +'s back,

or use some special syntax that you haven't shown yet in a complete working example!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API