### PR TITLE
Add links to crs-explorer in documentation

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -297,7 +297,7 @@ The following control parameters can appear in any order:
     Affected by options :option:`--authority`, :option:`--area`, :option:`--bbox` and :option:`--spatial-test`
 
     A visual alternative is the webpage
-    `CRS Explorer <https://jjimenezshaw.github.io/crs-explorer/?all=true>`_ .
+    `CRS Explorer <https://crs-explorer.proj.org/?all=true>`_ .
 
 .. option:: --3d
 

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -296,6 +296,9 @@ The following control parameters can appear in any order:
     geographic,geographic_2d,geographic_3d,vertical,projected,compound.
     Affected by options :option:`--authority`, :option:`--area`, :option:`--bbox` and :option:`--spatial-test`
 
+    A visual alternative is the webpage
+    `CRS Explorer <https://jjimenezshaw.github.io/crs-explorer/?all=true>`_ .
+
 .. option:: --3d
 
     .. versionadded:: 6.3

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -103,7 +103,7 @@ Which CRS apply to a given location?
 --------------------------------------------------------------------------------
 
 You can use the webpage
-`CRS Explorer <https://jjimenezshaw.github.io/crs-explorer/>`_
+`CRS Explorer <https://crs-explorer.proj.org/>`_
 to view a list of all coordinate reference systems in `proj.db`, and
 filter by type, authority, name and location (clicking on the map). It provides
 WKTs for every coordinate reference system and quick links to epsg.org.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -99,6 +99,15 @@ erroneous transformations.
 For compatibility reasons PROJ supports several WKT dialects
 (see :option:`projinfo -o`). If possible WKT2 should be used.
 
+Which CRS apply to a given location?
+--------------------------------------------------------------------------------
+
+You can use the webpage
+`CRS Explorer <https://jjimenezshaw.github.io/crs-explorer/>`_
+to view a list of all coordinate reference systems in `proj.db`, and
+filter by type, authority, name and location (clicking on the map). It provides
+WKTs for every coordinate reference system and quick links to epsg.org.
+
 Why is the axis ordering in PROJ not consistent?
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add links in the documentation to the webpage https://jjimenezshaw.github.io/crs-explorer/ , an open source page that lists all the coordinate reference systems from `proj.db`.

 - [x] Fully documented, including updating `docs/source/*.rst` for new API