### PR TITLE
PROJ: add missing <cstdint> includes

### DIFF
--- a/src/proj_json_streaming_writer.hpp
+++ b/src/proj_json_streaming_writer.hpp
@@ -33,6 +33,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #define CPL_DLL
 

--- a/src/projections/s2.cpp
+++ b/src/projections/s2.cpp
@@ -58,6 +58,7 @@
 
 #include <errno.h>
 #include <cmath>
+#include <cstdint>
 
 #include "proj.h"
 #include "proj_internal.h"


### PR DESCRIPTION
Without the change build fails on upcomig `gcc-13` as:

    In file included from /build/PROJ/src/iso19111/operation/conversion.cpp:58:
    src/proj_json_streaming_writer.hpp:42:14:
      error: 'int64_t' in namespace 'std' does not name a type
       42 | typedef std::int64_t GIntBig;
          |              ^~~~~~~

gcc-13 cleaned it's header dependencies and that exposes these failures.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API