### PR TITLE
omerc: mention in doc that +lon_0 is ignored, align name of +lat_0 and…

### DIFF
--- a/docs/source/operations/projections/omerc.rst
+++ b/docs/source/operations/projections/omerc.rst
@@ -124,11 +124,13 @@ Central point and azimuth method
 
 .. option:: +lonc=<value>
 
-    Longitude of the central point.
+    Longitude of the projection centre. Note that this value is used to
+    override the :option:`+lon_0` parameter, so the latter should not be
+    specified as it would get ignored.
 
 .. option:: +lat_0=<value>
 
-    Latitude of the central point.
+    Latitude of the projection centre.
 
 Two point method
 --------------------------------------------------------------------------------
@@ -165,8 +167,6 @@ Optional
     Do not offset origin to center of projection.
 
 .. include:: ../options/k_0.rst
-
-.. include:: ../options/lon_0.rst
 
 .. include:: ../options/x_0.rst
 

--- a/src/projections/omerc.cpp
+++ b/src/projections/omerc.cpp
@@ -185,6 +185,12 @@ PJ *PROJECTION(omerc) {
             return pj_default_destructor(P, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE);
         }
     }
+
+    if( pj_param(P->ctx, P->params, "rlon_0").i )
+    {
+        proj_log_trace(P, _("lon_0 is ignored."));
+    }
+
     com = sqrt(P->one_es);
     if (fabs(P->phi0) > EPS) {
         sinph0 = sin(P->phi0);


### PR DESCRIPTION
… +lonc with EPSG names, and emit a trace when +lon_0 is used (fixes #3464)
