### PR TITLE
Implement  alterGeodeticCRS and stripVerticalComponent for DerivedProjected

### DIFF
--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6488,6 +6488,15 @@ TEST(crs, crs_alterGeodeticCRS) {
             createVerticalCRS()->alterGeodeticCRS(GeographicCRS::EPSG_4979);
         EXPECT_TRUE(crs->isEquivalentTo(createVerticalCRS().get()));
     }
+
+    {
+        auto crs = createDerivedProjectedCRS()->alterGeodeticCRS(
+            GeographicCRS::EPSG_4979);
+        auto derivedProjCRS = dynamic_cast<DerivedProjectedCRS *>(crs.get());
+        ASSERT_TRUE(derivedProjCRS != nullptr);
+        EXPECT_TRUE(derivedProjCRS->baseCRS()->baseCRS()->isEquivalentTo(
+            GeographicCRS::EPSG_4979.get()));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6452,6 +6452,20 @@ TEST(crs, crs_stripVerticalComponent) {
         ASSERT_TRUE(projCRS != nullptr);
         EXPECT_EQ(projCRS->coordinateSystem()->axisList().size(), 2U);
     }
+
+    {
+        auto crs3D =
+            createDerivedProjectedCRS()->promoteTo3D(std::string(), nullptr);
+        auto derivedProj3D =
+            nn_dynamic_pointer_cast<DerivedProjectedCRS>(crs3D);
+        ASSERT_TRUE(derivedProj3D != nullptr);
+        EXPECT_EQ(derivedProj3D->coordinateSystem()->axisList().size(), 3U);
+
+        auto derivedProj2D = nn_dynamic_pointer_cast<DerivedProjectedCRS>(
+            derivedProj3D->stripVerticalComponent());
+        ASSERT_TRUE(derivedProj2D != nullptr);
+        EXPECT_EQ(derivedProj2D->coordinateSystem()->axisList().size(), 2U);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes

After #3477 I went through `crs.cpp` looking for functions that may miss the implementation for class `DerivedProjected`. I found these two (there could be more). In previous PRs I did it when I was needing them. I hope this is the last one ;) This PR is done for completeness. 