### PR TITLE
add PJ_TYPE_DERIVED_PROJECTED_CRS

### DIFF
--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -352,7 +352,8 @@ static bool is3DCRS(const PJ* crs) {
         return true;
     if( type == PJ_TYPE_GEOGRAPHIC_3D_CRS )
         return true;
-    if( type == PJ_TYPE_GEODETIC_CRS || type == PJ_TYPE_PROJECTED_CRS )
+    if( type == PJ_TYPE_GEODETIC_CRS || type == PJ_TYPE_PROJECTED_CRS  ||
+        type == PJ_TYPE_DERIVED_PROJECTED_CRS)
     {
         auto cs = proj_crs_get_coordinate_system(nullptr, crs);
         assert(cs);

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -1052,6 +1052,10 @@ convertPJObjectTypeToObjectType(PJ_TYPE type, bool &valid) {
         cppType = AuthorityFactory::ObjectType::PROJECTED_CRS;
         break;
 
+    case PJ_TYPE_DERIVED_PROJECTED_CRS:
+        valid = false;
+        break;
+
     case PJ_TYPE_COMPOUND_CRS:
         cppType = AuthorityFactory::ObjectType::COMPOUND_CRS;
         break;
@@ -1201,25 +1205,19 @@ PJ_TYPE proj_get_type(const PJ *obj) {
             return PJ_TYPE_PARAMETRIC_DATUM;
         }
 
-        {
-            auto crs = dynamic_cast<GeographicCRS *>(ptr);
-            if (crs) {
-                if (crs->coordinateSystem()->axisList().size() == 2) {
-                    return PJ_TYPE_GEOGRAPHIC_2D_CRS;
-                } else {
-                    return PJ_TYPE_GEOGRAPHIC_3D_CRS;
-                }
+        if (auto crs = dynamic_cast<GeographicCRS *>(ptr)) {
+            if (crs->coordinateSystem()->axisList().size() == 2) {
+                return PJ_TYPE_GEOGRAPHIC_2D_CRS;
+            } else {
+                return PJ_TYPE_GEOGRAPHIC_3D_CRS;
             }
         }
 
-        {
-            auto crs = dynamic_cast<GeodeticCRS *>(ptr);
-            if (crs) {
-                if (crs->isGeocentric()) {
-                    return PJ_TYPE_GEOCENTRIC_CRS;
-                } else {
-                    return PJ_TYPE_GEODETIC_CRS;
-                }
+        if (auto crs = dynamic_cast<GeodeticCRS *>(ptr)) {
+            if (crs->isGeocentric()) {
+                return PJ_TYPE_GEOCENTRIC_CRS;
+            } else {
+                return PJ_TYPE_GEODETIC_CRS;
             }
         }
 
@@ -1228,6 +1226,9 @@ PJ_TYPE proj_get_type(const PJ *obj) {
         }
         if (dynamic_cast<ProjectedCRS *>(ptr)) {
             return PJ_TYPE_PROJECTED_CRS;
+        }
+        if (dynamic_cast<DerivedProjectedCRS *>(ptr)) {
+            return PJ_TYPE_DERIVED_PROJECTED_CRS;
         }
         if (dynamic_cast<CompoundCRS *>(ptr)) {
             return PJ_TYPE_COMPOUND_CRS;

--- a/src/proj.h
+++ b/src/proj.h
@@ -803,6 +803,8 @@ typedef enum
     PJ_TYPE_TEMPORAL_DATUM,
     PJ_TYPE_ENGINEERING_DATUM,
     PJ_TYPE_PARAMETRIC_DATUM,
+
+    PJ_TYPE_DERIVED_PROJECTED_CRS,
 } PJ_TYPE;
 
 /** Comparison criterion. */

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -105,6 +105,20 @@ class CApi : public ::testing::Test {
             CartesianCS::createEastingNorthing(UnitOfMeasure::METRE));
     }
 
+    static DerivedProjectedCRSNNPtr createDerivedProjectedCRS() {
+        auto derivingConversion = Conversion::create(
+            PropertyMap().set(IdentifiedObject::NAME_KEY, "unnamed"),
+            PropertyMap().set(IdentifiedObject::NAME_KEY, "PROJ unimplemented"),
+            std::vector<OperationParameterNNPtr>{},
+            std::vector<ParameterValueNNPtr>{});
+
+        return DerivedProjectedCRS::create(
+            PropertyMap().set(IdentifiedObject::NAME_KEY,
+                              "derived projectedCRS"),
+            createProjectedCRS(), derivingConversion,
+            CartesianCS::createEastingNorthing(UnitOfMeasure::METRE));
+    }
+
     static VerticalCRSNNPtr createVerticalCRS() {
         PropertyMap propertiesVDatum;
         propertiesVDatum.set(Identifier::CODESPACE_KEY, "EPSG")
@@ -819,6 +833,19 @@ TEST_F(CApi, proj_get_type) {
         ObjectKeeper keeper(obj);
         ASSERT_NE(obj, nullptr);
         EXPECT_EQ(proj_get_type(obj), PJ_TYPE_PROJECTED_CRS);
+    }
+    {
+        auto obj = proj_create_from_wkt(
+            m_ctxt,
+            createDerivedProjectedCRS()
+                ->exportToWKT(
+                    WKTFormatter::create(WKTFormatter::Convention::WKT2_2019)
+                        .get())
+                .c_str(),
+            nullptr, nullptr, nullptr);
+        ObjectKeeper keeper(obj);
+        ASSERT_NE(obj, nullptr);
+        EXPECT_EQ(proj_get_type(obj), PJ_TYPE_DERIVED_PROJECTED_CRS);
     }
     {
         auto obj =


### PR DESCRIPTION
The function `PJ_TYPE proj_get_type(const PJ *obj)` does not cover the case of a `DerivedProjectedCRS`, so it returns the generic type `PJ_TYPE_OTHER_CRS`. This PR defined the type `PJ_TYPE_DERIVED_PROJECTED_CRS`, and returns it in that case.

 - [x] Closes https://lists.osgeo.org/pipermail/proj/2022-November/010829.html
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
