### PR TITLE
WKT import: when importing LOCAL_CS["foo"], generates a non-empty name for the datum

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -6929,7 +6929,9 @@ void EngineeringCRS::_exportToWKT(io::WKTFormatter *formatter) const {
                                 : io::WKTConstants::LOCAL_CS,
                          !identifiers().empty());
     formatter->addQuotedString(nameStr());
-    if (isWKT2 || !datum()->nameStr().empty()) {
+    const auto &datumName = datum()->nameStr();
+    if (isWKT2 ||
+        (!datumName.empty() && datumName != "Unknown engineering datum")) {
         datum()->_exportToWKT(formatter);
     }
     if (!isWKT2) {

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -5080,7 +5080,12 @@ WKTParser::Private::buildEngineeringCRSFromLocalCS(const WKTNodeNNPtr &node) {
             :
             // In theory OGC 01-009 mandates LOCAL_DATUM, but GDAL has a
             // tradition of emitting just LOCAL_CS["foo"]
-            emptyPropertyMap);
+            []() {
+                PropertyMap map;
+                map.set(IdentifiedObject::NAME_KEY,
+                        "Unknown engineering datum");
+                return map;
+            }());
     return EngineeringCRS::create(buildProperties(node), datum, cs);
 }
 

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -5273,7 +5273,7 @@ TEST(wkt_parse, LOCAL_CS_short) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->nameStr(), "Engineering CRS");
-    EXPECT_FALSE(!crs->datum()->nameStr().empty());
+    EXPECT_EQ(crs->datum()->nameStr(), "Unknown engineering datum");
     auto cs = crs->coordinateSystem();
     ASSERT_EQ(cs->axisList().size(), 2U);
 


### PR DESCRIPTION
Otherwise, the WKT2 output as a engineering CRS will be technically invalid, as the BNF of WKT2 requires a non-empty double-quoted string.

Fixes https://github.com/r-spatial/sf/issues/2049#issuecomment-1333884055
