### PR TITLE
Bugfix in CRS::alterCSLinearUnit for DerivedProjectedCRS

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -378,10 +378,14 @@ CRSNNPtr CRS::alterCSLinearUnit(const common::UnitOfMeasure &unit) const {
     {
         auto derivedProjCRS = dynamic_cast<const DerivedProjectedCRS *>(this);
         if (derivedProjCRS) {
+            auto cs = derivedProjCRS->coordinateSystem();
+            auto cartCS = util::nn_dynamic_pointer_cast<cs::CartesianCS>(cs);
+            if (cartCS) {
+                cs = cartCS->alterUnit(unit);
+            }
             return DerivedProjectedCRS::create(
                 createPropertyMap(this), derivedProjCRS->baseCRS(),
-                derivedProjCRS->derivingConversion(),
-                derivedProjCRS->baseCRS()->coordinateSystem()->alterUnit(unit));
+                derivedProjCRS->derivingConversion(), cs);
         }
     }
 

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -6543,6 +6543,24 @@ TEST(crs, crs_alterCSLinearUnit) {
     }
 
     {
+        auto crs = createDerivedProjectedCRSNorthingEasting();
+        auto alteredCRS = crs->alterCSLinearUnit(UnitOfMeasure("my unit", 2));
+
+        auto leftHandedDerivedCRS =
+            dynamic_cast<DerivedProjectedCRS *>(alteredCRS.get());
+        ASSERT_TRUE(leftHandedDerivedCRS != nullptr);
+        auto cs = dynamic_cast<CartesianCS *>(
+            leftHandedDerivedCRS->coordinateSystem().get());
+        ASSERT_EQ(cs->axisList().size(), 2U);
+        EXPECT_EQ(cs->axisList()[0]->unit().name(), "my unit");
+        EXPECT_EQ(cs->axisList()[0]->direction(), AxisDirection::NORTH);
+        EXPECT_EQ(cs->axisList()[0]->unit().conversionToSI(), 2);
+        EXPECT_EQ(cs->axisList()[1]->unit().name(), "my unit");
+        EXPECT_EQ(cs->axisList()[1]->direction(), AxisDirection::EAST);
+        EXPECT_EQ(cs->axisList()[1]->unit().conversionToSI(), 2);
+    }
+
+    {
         auto crs = GeodeticCRS::EPSG_4978->alterCSLinearUnit(
             UnitOfMeasure("my unit", 2));
         auto geodCRS = dynamic_cast<GeodeticCRS *>(crs.get());


### PR DESCRIPTION
The implementation was calling `alterUnit` on the CS of the base projected CRS, but this CS could be different than that of the derived projected CRS being modified (e.g. the axes could be swapped).

The fix consist on altering the unit of the derived projected CRS, but only if the CS can be cast to Cartesian. It's doesn't look like other CS types need to be considered.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes