### PR TITLE
proj_trans(): fix performance regression

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -277,7 +277,7 @@ similarly, but prefers the 2D resp. 3D interfaces if available.
         direction = opposite_direction(direction);
 
     if (P->iso_obj != nullptr &&
-        dynamic_cast<NS_PROJ::operation::CoordinateOperation*>(P->iso_obj.get()) == nullptr ) {
+        !P->iso_obj_is_coordinate_operation ) {
         pj_log(P->ctx, PJ_LOG_ERROR, "Object is not a coordinate operation");
         proj_errno_set (P, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE);
         return proj_coord_error ();

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -202,6 +202,7 @@ static PJ *pj_obj_create(PJ_CONTEXT *ctx, const IdentifiedObjectNNPtr &objIn) {
             ctx->defer_grid_opening = false;
             if (pj) {
                 pj->iso_obj = objIn;
+                pj->iso_obj_is_coordinate_operation = true;
                 return pj;
             }
         } catch (const std::exception &) {
@@ -214,6 +215,7 @@ static PJ *pj_obj_create(PJ_CONTEXT *ctx, const IdentifiedObjectNNPtr &objIn) {
         pj->ctx = ctx;
         pj->descr = "ISO-19111 object";
         pj->iso_obj = objIn;
+        pj->iso_obj_is_coordinate_operation = coordop != nullptr;
         try {
             auto crs = dynamic_cast<const CRS *>(objIn.get());
             if (crs) {

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -577,6 +577,7 @@ struct PJconsts {
     **************************************************************************************/
 
     NS_PROJ::common::IdentifiedObjectPtr iso_obj{};
+    bool                                 iso_obj_is_coordinate_operation = false;
 
     // cached results
     mutable std::string lastWKT{};


### PR DESCRIPTION
The dynamic_cast<> introduced in 718e074a062bf1595eb711f1468be30a8bca801f can be a performance killer for pipelines that are not very computational heavy.

Before this fix:

```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=merc" 2 49
2 49 -> 222638.981586547 6242595.99979511
Duration: 877 ms
Throughput: 5.70 million coordinates/s

$ bin/bench_proj_trans --pipeline "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad" 2 49
2 49 -> 0.0349065850398866 0.855211333477221
Duration: 276 ms
Throughput: 18.12 million coordinates/s
```

After this fix:
```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=merc" 2 49
2 49 -> 222638.981586547 6242595.99979511
Duration: 739 ms
Throughput: 6.77 million coordinates/s

$ bin/bench_proj_trans --pipeline "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad" 2 49
2 49 -> 0.0349065850398866 0.855211333477221
Duration: 146 ms
Throughput: 34.25 million coordinates/s
```
