### PR TITLE
Mention the proj_create function

### DIFF
--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -46,11 +46,11 @@ Next we create the :c:type:`PJ` transformation object ``P`` with the function
   :dedent: 4
 
 Here we have set up a transformation from geographic coordinates to UTM zone
-32N. In general, this is a transform between two different projections
+32N. In general, this is a transformation between two different coordinate reference systems
 (one of which is here in geographic coordinates).  The related function 
-:c:func:`proj_create` can be used with a single 
-projection, and can transform from that projection to geographic
-coordinates for the same geodetic datum, and vice versa.
+:c:func:`proj_create` can be used set up transformations that are not available through 
+the PROJ database, for instance for converting geodetic coordinates to a custom definition
+of a map projection.
 
 :c:func:`proj_create_crs_to_crs` takes as its arguments:
 

--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -48,7 +48,7 @@ Next we create the :c:type:`PJ` transformation object ``P`` with the function
 Here we have set up a transformation from geographic coordinates to UTM zone
 32N. In general, this is a transformation between two different coordinate reference systems
 (one of which is here in geographic coordinates).  The related function 
-:c:func:`proj_create` can be used set up transformations that are not available through 
+:c:func:`proj_create` can be used to set up transformations that are not available through 
 the PROJ database, for instance for converting geodetic coordinates to a custom definition
 of a map projection.
 

--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -46,7 +46,11 @@ Next we create the :c:type:`PJ` transformation object ``P`` with the function
   :dedent: 4
 
 Here we have set up a transformation from geographic coordinates to UTM zone
-32N.
+32N. In general, this is a transform between two different projections
+(one of which is here in geographic coordinates).  The related function 
+:c:func:`proj_create` can be used with a single 
+projection, and can transform from that projection to geographic
+coordinates for the same geodetic datum, and vice versa.
 
 :c:func:`proj_create_crs_to_crs` takes as its arguments:
 


### PR DESCRIPTION
Following the PROJ doc is like jumping through many hoops. Or if you wish, many reprojections across documents are needed for something coherent to emerge. This adds a blurb mentioning the proj_create() function, which is really one of the two workhorses of this library, together with proj_create_crs_to_crs. 

If this is accepted, I plan to also add an example of using this function, with every step spelled out.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API