### PR TITLE
Add link to "quick start"

### DIFF
--- a/docs/source/development/migration.rst
+++ b/docs/source/development/migration.rst
@@ -102,7 +102,7 @@ The same program implemented using PROJ 6:
         return 0;
     }
 
-Further examples of using the PROJ 6 API are in the :doc:`quick start <quickstart>` document.
+Further examples of using the PROJ API are in the :doc:`quick start <quickstart>` document.
 
 Function mapping from old to new API
 ###############################################################################

--- a/docs/source/development/migration.rst
+++ b/docs/source/development/migration.rst
@@ -102,6 +102,7 @@ The same program implemented using PROJ 6:
         return 0;
     }
 
+Further examples of using the PROJ 6 API are in the :doc:`quick start <quickstart>` document.
 
 Function mapping from old to new API
 ###############################################################################


### PR DESCRIPTION
This adds a sentence to the "migration" document with a pointer to "quick start" for more information. 

My apologies if this is an obvious thing. I arrived to this page by googling around, rather than systematically reading the full document page by page. Cross-links among documents, like what I added, can make it easier to find one's way when one is a developer trying to learn a new codebase with its many conventions. 