### PR TITLE
Add example for how to use proj_create().

### DIFF
--- a/docs/source/development/quickstart.rst
+++ b/docs/source/development/quickstart.rst
@@ -4,10 +4,12 @@
 Quick start
 ================================================================================
 
-This is a short introduction to the PROJ API. In the following section we
-create a simple program that transforms a geodetic coordinate to UTM and back
-again. The program is explained a few lines at a time. The complete program can
-be seen at the end of the section.
+This is a short introduction to the PROJ API. In the following section
+we create two simple programs that illustrate how to transform points
+between two different coordinate systems, and how to convert between
+projected and geodetic (geographic) coordinates for a single
+coordinate system. Explanations for individual code sniplets and the
+full programs are provided.
 
 See the following sections for more in-depth descriptions of different parts of
 the PROJ API or consult the :doc:`API reference <reference/index>` for specifics.
@@ -201,4 +203,12 @@ A complete compilable version of the example code can be seen below:
   :language: c
   :linenos:
   :lines: 39-
+  
+The following example illustrates how to convert between a CRS and
+geodetic coordinates for that CRS.
+
+.. literalinclude:: ../../../examples/crs_to_geodetic.c
+  :language: c
+  :linenos:
+  :lines: 9-
 

--- a/examples/crs_to_geodetic.c
+++ b/examples/crs_to_geodetic.c
@@ -1,0 +1,61 @@
+/*******************************************************************************
+    Example code that illustrates how to convert between a CRS and
+    geodetic coordnates for that CRS.
+
+    Note: This file is in-lined in the documentation. Any changes must be
+    reflected in docs/source/development/quickstart.rst
+
+*******************************************************************************/
+#include <proj.h>
+#include <stdio.h>
+#include <math.h>
+
+int main (void) {
+  
+  /* Create the context. */
+  /* You may set C=PJ_DEFAULT_CTX if you are sure you will     */
+  /* use PJ objects from only one thread                       */
+  PJ_CONTEXT *C = proj_context_create();
+
+  /* Create a projection. */
+  PJ *P = proj_create(C, "+proj=utm +zone=32 +datum=WGS84 +type=crs");
+
+  if (0 == P) {
+    fprintf(stderr, "Failed to create transformation object.\n");
+    return 1;
+  }
+
+  /* Get the geodetic CRS for that projection. */
+  PJ *G = proj_crs_get_geodetic_crs(C, P);
+
+  /* Create the transform from geodetic to projected coordinates.*/
+  PJ_AREA *A = NULL;
+  const char *const *options = NULL;
+  PJ *G2P = proj_create_crs_to_crs_from_pj(C, G, P, A, options);
+  
+  /* Longitude and latitude of Copenhagen, in degrees. */
+  double lon = 12.0, lat = 55.0;
+
+  /* Prepare the input */
+  PJ_COORD c_in;
+  c_in.lpzt.z = 0.0;
+  c_in.lpzt.t = HUGE_VAL; // important only for time-dependent projections
+  c_in.lp.lam = lon;
+  c_in.lp.phi = lat;
+  printf ("Input longitude: %g, latitude: %g (degrees)\n", c_in.lp.lam, c_in.lp.phi);
+
+  /* Compute easting and northing */
+  PJ_COORD c_out = proj_trans(G2P, PJ_FWD, c_in);
+  printf ("Output easting: %g, northing: %g (meters)\n", c_out.enu.e, c_out.enu.n);
+
+  /* Apply the inverse transform */
+  PJ_COORD c_inv = proj_trans(G2P, PJ_INV, c_out);
+  printf ("Inverse applied. Longitude: %g, latitude: %g (degrees)\n", c_inv.lp.lam, c_inv.lp.phi);
+
+  /* Clean up */
+  proj_destroy(P);
+  proj_destroy(G);
+  proj_destroy(G2P);
+  proj_context_destroy(C); /* may be omitted in the single threaded case */
+  return 0;
+}


### PR DESCRIPTION
This is a proposed example for the proj_create() function. This function has its own peculiarities, which can't be inferred from the example illustrating proj_create_crs_to_crs(). It is shown how to populate the longitude and latitude, convert to radians, how to transform to projected units, then transform back, and how to convert back to degrees. 

The code was compiled and tested. It is suggested to verify it compiles and prints what is expected.
