### PR TITLE
Fix silly documentation issue (quoted value of pi/2 triggers error)

### DIFF
--- a/docs/source/operations/options/lat_0.rst
+++ b/docs/source/operations/options/lat_0.rst
@@ -8,6 +8,6 @@
         The default convention is to interpret this value as decimal degrees. To
         specify radians instead, follow the value with the "r" character.
 
-        Example: `+lat_0=1.5708r`
+        Example: `+lat_0=1.570796r`
 
         See :ref:`Projection Units <projection_units>` for more information.

--- a/docs/source/operations/options/lat_1.rst
+++ b/docs/source/operations/options/lat_1.rst
@@ -8,6 +8,6 @@
         The default convention is to interpret this value as decimal degrees. To
         specify radians instead, follow the value with the "r" character.
 
-        Example: `+lat_1=1.5708r`
+        Example: `+lat_1=1.570796r`
 
         See :ref:`Projection Units <projection_units>` for more information.

--- a/docs/source/operations/options/lat_2.rst
+++ b/docs/source/operations/options/lat_2.rst
@@ -8,6 +8,6 @@
         The default convention is to interpret this value as decimal degrees. To
         specify radians instead, follow the value with the "r" character.
 
-        Example: `+lat_2=1.5708r`
+        Example: `+lat_2=1.570796r`
 
         See :ref:`Projection Units <projection_units>` for more information.

--- a/docs/source/operations/options/lat_ts.rst
+++ b/docs/source/operations/options/lat_ts.rst
@@ -9,6 +9,6 @@
         The default convention is to interpret this value as decimal degrees. To
         specify radians instead, follow the value with the "r" character.
 
-        Example: `+lat_ts=1.5708r`
+        Example: `+lat_ts=1.570796r`
 
         See :ref:`Projection Units <projection_units>` for more information.

--- a/docs/source/operations/options/lon_0.rst
+++ b/docs/source/operations/options/lon_0.rst
@@ -8,6 +8,6 @@
         The default convention is to interpret this value as decimal degrees. To
         specify radians instead, follow the value with the "r" character.
 
-        Example: `+lon_0=1.5708r`
+        Example: `+lon_0=1.570796r`
 
         See :ref:`Projection Units <projection_units>` for more information.

--- a/docs/source/usage/projections.rst
+++ b/docs/source/usage/projections.rst
@@ -89,7 +89,7 @@ suffix to input values.
 
 Example of use.  The longitude of the central meridian ``+lon_0=90``, can also be expressed more explictly
 with units of decimal degrees as ``+lon_0=90d`` or in radian
-units as ``+lon_0=1.5708r`` (approximately).
+units as ``+lon_0=1.570796r`` (approximately).
 
 
 False Easting/Northing


### PR DESCRIPTION
The documentation included instances of
```
Example: +lat_1=1.5708r
```
However if the poor user tries this setting, the result is
```
|lat_1| should be < 90d
```
This fix uses `1.570796r` instead -- this is a legitimate rounded value of pi/2 and, since it is less than pi/2, it satisfies the requirement that it be less that 90d.  The examples with the `lon_0` are changed for consistency (even though the old value doesn't trigger an error).

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
 - [x] Fully documented, including updating `docs/source/*.rst` for new API