### PR TITLE
In mlfn.cpp, invoke pj_enfn with P->n to avoid recomputating n

### DIFF
--- a/src/mlfn.cpp
+++ b/src/mlfn.cpp
@@ -29,10 +29,10 @@ static double clenshaw(double szeta, double czeta,
     return 2 * szeta * czeta * u0; // sin(2*zeta) * u0
 }
 
-double *pj_enfn(double es) {
+double *pj_enfn(double n) {
 
-    // Expansion of (quarter meridian) / ((a+b)/2 * pi/2) as series in n^2; these
-    // coefficients are ( (2*k - 3)!! / (2*k)!! )^2 for k = 0..3
+    // Expansion of (quarter meridian) / ((a+b)/2 * pi/2) as series in n^2;
+    // these coefficients are ( (2*k - 3)!! / (2*k)!! )^2 for k = 0..3
     static const double coeff_rad[] = {1, 1.0/4, 1.0/64, 1.0/256};
 
     // Coefficients to convert phi to mu, Eq. A5 in arXiv:2212.05818
@@ -56,7 +56,6 @@ double *pj_enfn(double es) {
         293393.0/61440,
     };
 
-    double n = 1 + sqrt(1 - es); n = es / (n * n);
     double n2 = n * n, d = n, *en;
 
     // 2*Lmax for the Fourier coeffs for each direction of conversion + 1 for

--- a/src/projections/aea.cpp
+++ b/src/projections/aea.cpp
@@ -190,7 +190,7 @@ static PJ *setup(PJ *P) {
     if( Q->ellips ) {
         double ml1, m1;
 
-        Q->en = pj_enfn(P->es);
+        Q->en = pj_enfn(P->n);
         if (Q->en == nullptr)
             return destructor(P, 0);
         m1 = pj_msfn(sinphi, cosphi, P->es);

--- a/src/projections/aeqd.cpp
+++ b/src/projections/aeqd.cpp
@@ -297,7 +297,7 @@ PJ *PROJECTION(aeqd) {
         P->inv = aeqd_s_inverse;
         P->fwd = aeqd_s_forward;
     } else {
-        if (!(Q->en = pj_enfn(P->es)))
+        if (!(Q->en = pj_enfn(P->n)))
             return pj_default_destructor (P, 0);
         if (pj_param(P->ctx, P->params, "bguam").i) {
             Q->M1 = pj_mlfn(P->phi0, Q->sinph0, Q->cosph0, Q->en);

--- a/src/projections/bonne.cpp
+++ b/src/projections/bonne.cpp
@@ -127,7 +127,7 @@ PJ *PROJECTION(bonne) {
     }
 
     if (P->es != 0.0) {
-        Q->en = pj_enfn(P->es);
+        Q->en = pj_enfn(P->n);
         if (nullptr==Q->en)
             return destructor(P, PROJ_ERR_OTHER /*ENOMEM*/);
         Q->am1 = sin(Q->phi1);

--- a/src/projections/cass.cpp
+++ b/src/projections/cass.cpp
@@ -131,7 +131,7 @@ PJ *PROJECTION(cass) {
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
     P->destructor = destructor;
 
-    Q->en = pj_enfn (P->es);
+    Q->en = pj_enfn(P->n);
     if (nullptr==Q->en)
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
 

--- a/src/projections/ccon.cpp
+++ b/src/projections/ccon.cpp
@@ -94,7 +94,7 @@ PJ *PROJECTION(ccon) {
         proj_log_error(P, _("Invalid value for lat_1: |lat_1| should be > 0"));
         return destructor(P, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE);
     }
-    if (!(Q->en = pj_enfn(P->es)))
+    if (!(Q->en = pj_enfn(P->n)))
         return destructor(P, PROJ_ERR_OTHER /*ENOMEM*/);
 
     Q->sinphi1 = sin(Q->phi1);

--- a/src/projections/eqdc.cpp
+++ b/src/projections/eqdc.cpp
@@ -103,7 +103,7 @@ PJ *PROJECTION(eqdc) {
         return destructor(P, PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE);
     }
 
-    if (!(Q->en = pj_enfn(P->es)))
+    if (!(Q->en = pj_enfn(P->n)))
         return destructor(P, PROJ_ERR_OTHER /*ENOMEM*/);
 
     sinphi = sin(Q->phi1);

--- a/src/projections/gn_sinu.cpp
+++ b/src/projections/gn_sinu.cpp
@@ -127,7 +127,7 @@ PJ *PROJECTION(sinu) {
     P->opaque = Q;
     P->destructor = destructor;
 
-    if (!(Q->en = pj_enfn(P->es)))
+    if (!(Q->en = pj_enfn(P->n)))
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
 
     if (P->es != 0.0) {

--- a/src/projections/imw_p.cpp
+++ b/src/projections/imw_p.cpp
@@ -186,7 +186,7 @@ PJ *PROJECTION(imw_p) {
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
     P->opaque = Q;
 
-    if (!(Q->en = pj_enfn(P->es))) return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
+    if (!(Q->en = pj_enfn(P->n))) return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
     if( (err = phi12(P, &del, &sig)) != 0) {
         return destructor(P, err);
     }

--- a/src/projections/lcca.cpp
+++ b/src/projections/lcca.cpp
@@ -140,7 +140,7 @@ PJ *PROJECTION(lcca) {
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
     P->opaque = Q;
 
-    (Q->en = pj_enfn(P->es));
+    (Q->en = pj_enfn(P->n));
     if (!Q->en)
         return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
 

--- a/src/projections/poly.cpp
+++ b/src/projections/poly.cpp
@@ -162,7 +162,7 @@ PJ *PROJECTION(poly) {
     P->destructor = destructor;
 
     if (P->es != 0.0) {
-        if (!(Q->en = pj_enfn(P->es)))
+        if (!(Q->en = pj_enfn(P->n)))
             return pj_default_destructor (P, PROJ_ERR_OTHER /*ENOMEM*/);
         Q->ml0 = pj_mlfn(P->phi0, sin(P->phi0), cos(P->phi0), Q->en);
         P->inv = poly_e_inverse;

--- a/src/projections/tmerc.cpp
+++ b/src/projections/tmerc.cpp
@@ -222,7 +222,7 @@ static PJ *setup_approx(PJ *P) {
     auto *Q = &(static_cast<struct tmerc_data*>(P->opaque)->approx);
 
     if (P->es != 0.0) {
-        if (!(Q->en = pj_enfn(P->es)))
+        if (!(Q->en = pj_enfn(P->n)))
             return pj_default_destructor(P, PROJ_ERR_OTHER /*ENOMEM*/);
 
         Q->ml0 = pj_mlfn(P->phi0, sin(P->phi0), cos(P->phi0), Q->en);


### PR DESCRIPTION
This is a cleanup of  PR #3516.  Rather that computing `n` in terms of `es`, `pj_enfn` is now
invoked with `P->n` as its argument.  (Silly of me not to have done this with the original PR.)

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
