### PR TITLE
Synchronize with 2.1 for geographiclib-c for geodesic support

### DIFF
--- a/src/geodesic.h
+++ b/src/geodesic.h
@@ -31,7 +31,7 @@
  * The minor version of the geodesic library.  (This tracks the version of
  * GeographicLib.)
  **********************************************************************/
-#define GEODESIC_VERSION_MINOR 0
+#define GEODESIC_VERSION_MINOR 1
 /**
  * The patch level of the geodesic library.  (This tracks the version of
  * GeographicLib.)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,7 +772,7 @@ pj_init_ctx_with_allow_init_epsg(PJ_CONTEXT *ctx, int argc, char **argv, int all
     PIN->geod = static_cast<struct geod_geodesic*>(calloc (1, sizeof (struct geod_geodesic)));
     if (nullptr==PIN->geod)
         return pj_default_destructor (PIN, PROJ_ERR_OTHER /*ENOMEM*/);
-    geod_init(PIN->geod, PIN->a,  PIN->es / (1 + sqrt (PIN->one_es)));
+    geod_init(PIN->geod, PIN->a,  PIN->f);
 
     /* Projection specific initialization */
     err = proj_errno_reset (PIN);

--- a/src/tests/geodsigntest.c
+++ b/src/tests/geodsigntest.c
@@ -30,6 +30,19 @@ typedef double T;
 #define nullptr 0
 #endif
 
+#if !defined(OLD_BUGGY_REMQUO)
+/*
+ * glibc prior to version 2.22 had a bug in remquo.  This was reported in 2014
+ * and fixed in 2015.  See
+ * https://sourceware.org/bugzilla/show_bug.cgi?id=17569
+ *
+ * The bug causes some of the tests here to fail.  The failures aren't terribly
+ * serious (just a loss of accuracy).  If you're still using the buggy glibc,
+ * then define OLD_BUGGY_REMQUO to be 1.
+ */
+#define OLD_BUGGY_REMQUO 0
+#endif
+
 static const T wgs84_a = 6378137, wgs84_f = 1/298.257223563; /* WGS84 */
 
 static int equiv(T x, T y) {
@@ -123,7 +136,9 @@ int main() {
   check( geod_AngRound( 90.0       ),  90         );
 
   checksincosd(-  inf,  nan,  nan);
+#if !OLD_BUGGY_REMQUO
   checksincosd(-810.0, -1.0, +0.0);
+#endif
   checksincosd(-720.0, -0.0, +1.0);
   checksincosd(-630.0, +1.0, +0.0);
   checksincosd(-540.0, -0.0, -1.0);
@@ -142,10 +157,13 @@ int main() {
   checksincosd(+540.0, +0.0, -1.0);
   checksincosd(+630.0, -1.0, +0.0);
   checksincosd(+720.0, +0.0, +1.0);
+#if !OLD_BUGGY_REMQUO
   checksincosd(+810.0, +1.0, +0.0);
+#endif
   checksincosd(+  inf,  nan,  nan);
   checksincosd(   nan,  nan,  nan);
 
+#if !OLD_BUGGY_REMQUO
   {
     T s1, c1, s2, c2, s3, c3;
     geod_sincosd(         9.0, &s1, &c1);
@@ -156,6 +174,7 @@ int main() {
       ++n;
     }
   }
+#endif
 
   check( geod_atan2d(+0.0 , -0.0 ), +180 );
   check( geod_atan2d(-0.0 , -0.0 ), -180 );


### PR DESCRIPTION
Changes are
   - Minor improvement in the logic for the geodesic inverse problem.
   - Relax overly strict convergence test for inverse problem.
   - Allow for buggy remquo in geodsigntest.c.

First two deal with performance issues uncovered by high-precision testing with `MPFR` and will have hardly any (= no?) impact when using ordinary doubles.

Attention @xylar: The buggy remquo fix is an aid for the integration of [conda-forge/proj.4-feedstock](https://github.com/conda-forge/proj.4-feedstock) and will allow the current `0001-disable-geodsigntest.patch` to be replaced by a one-line change.

Also note:

`polyval` renamed to `polyvalx` to avoid potential conflict with function of the same name but slightly different semantics in `src/mlfn.cpp`.  (Both are static functions, so there wouldn't in fact be a conflict.)

Invocation of `geod_init` in `src/init.cpp` now uses `PIN->f` directly instead of computing the flattening from `PIN->es`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes