### PR TITLE
proj_create_crs_to_crs_from_pj(): add a ONLY_BEST=YES option (fixes #3533)

### DIFF
--- a/data/proj.ini
+++ b/data/proj.ini
@@ -15,6 +15,15 @@ cache_size_MB = 300
 
 cache_ttl_sec = 86400
 
+; Can be set to on so that by default the lack of a known resource files needed
+; for the best transformation PROJ would normally use causes an error. This
+; default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
+; variable if set, and then by the ONLY_BEST setting that can be
+; passed to the proj_create_crs_to_crs() method, or with the --only-best
+; option of the cs2cs program.
+; (added in PROJ 9.2)
+only_best_default = off
+
 ; Filename of the Certificate Authority (CA) bundle.
 ; Can be overriden with the PROJ_CURL_CA_BUNDLE / CURL_CA_BUNDLE environment variable.
 ; (added in PROJ 9.0)

--- a/data/proj.ini
+++ b/data/proj.ini
@@ -16,13 +16,14 @@ cache_size_MB = 300
 cache_ttl_sec = 86400
 
 ; Can be set to on so that by default the lack of a known resource files needed
-; for the best transformation PROJ would normally use causes an error. This
-; default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
+; for the best transformation PROJ would normally use causes an error, or off
+; to accept missing resource files without errors or warnings.
+; This default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
 ; variable if set, and then by the ONLY_BEST setting that can be
 ; passed to the proj_create_crs_to_crs() method, or with the --only-best
 ; option of the cs2cs program.
 ; (added in PROJ 9.2)
-only_best_default = off
+; only_best_default = on
 
 ; Filename of the Certificate Authority (CA) bundle.
 ; Can be overriden with the PROJ_CURL_CA_BUNDLE / CURL_CA_BUNDLE environment variable.

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -13,7 +13,8 @@ Synopsis
 
     | **cs2cs** [**-eEfIlrstvwW** [args]]
     |           [[--area <name_or_code>] | [--bbox <west_long,south_lat,east_long,north_lat>]]
-    |           [--authority <name>] [--no-ballpark] [--accuracy <accuracy>] [--3d]
+    |           [--authority <name>] [--3d]
+    |           [--accuracy <accuracy>] [--only-best] [--no-ballpark]
     |           ([*+opt[=arg]* ...] [+to *+opt[=arg]* ...] | {source_crs} {target_crs})
     |           file ...
 
@@ -165,6 +166,16 @@ The following control parameters can appear in any order:
     `west_long` and `east_long` should be in the [-180,180] range, and
     `south_lat` and `north_lat` in the [-90,90]. `west_long` is generally lower than
     `east_long`, except in the case where the area of interest crosses the antimeridian.
+
+.. option:: --only-best
+
+    .. versionadded:: 9.2.0
+
+    Error out if the best transformation, known of PROJ, and usable by PROJ if
+    all grids known and usable by PROJ were accessible, cannot be used.
+    Best transformation should be understood as the transformation returned by
+    :cpp:func:`proj_get_suggested_operation` if all known grids were
+    accessible (either locally or through network).
 
 .. option:: --no-ballpark
 

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -178,6 +178,10 @@ The following control parameters can appear in any order:
     available among all relevant for the point to transform, and if all known
     grids required to perform such transformation were accessible (either locally
     or through network).
+    Note that the default value for this option can be also set with the
+    :envvar:`PROJ_ONLY_BEST_DEFAULT` environment variable, or with the
+    ``only_best_default`` setting of :ref:`proj-ini` (:option:`--only-best`
+    when specified overrides such default value).
 
 .. option:: --no-ballpark
 

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -14,7 +14,7 @@ Synopsis
     | **cs2cs** [**-eEfIlrstvwW** [args]]
     |           [[--area <name_or_code>] | [--bbox <west_long,south_lat,east_long,north_lat>]]
     |           [--authority <name>] [--3d]
-    |           [--accuracy <accuracy>] [--only-best] [--no-ballpark]
+    |           [--accuracy <accuracy>] [--only-best[=yes|=no]] [--no-ballpark]
     |           ([*+opt[=arg]* ...] [+to *+opt[=arg]* ...] | {source_crs} {target_crs})
     |           file ...
 
@@ -167,15 +167,17 @@ The following control parameters can appear in any order:
     `south_lat` and `north_lat` in the [-90,90]. `west_long` is generally lower than
     `east_long`, except in the case where the area of interest crosses the antimeridian.
 
-.. option:: --only-best
+.. option:: --only-best[=yes|=no]
 
     .. versionadded:: 9.2.0
 
-    Error out if the best transformation, known of PROJ, and usable by PROJ if
-    all grids known and usable by PROJ were accessible, cannot be used.
-    Best transformation should be understood as the transformation returned by
-    :cpp:func:`proj_get_suggested_operation` if all known grids were
-    accessible (either locally or through network).
+    If set to yes, error out if the best transformation, known of PROJ, and
+    usable by PROJ if all grids known and usable by PROJ were accessible,
+    cannot be used.
+    Best transformation should be understood as the most accurate transformation
+    available among all relevant for the point to transform, and if all known
+    grids required to perform such transformation were accessible (either locally
+    or through network).
 
 .. option:: --no-ballpark
 

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -171,13 +171,14 @@ The following control parameters can appear in any order:
 
     .. versionadded:: 9.2.0
 
-    If set to yes, error out if the best transformation, known of PROJ, and
-    usable by PROJ if all grids known and usable by PROJ were accessible,
-    cannot be used.
+    Force `cs2cs` to only use the best transformation known by PROJ.
+    `cs2cs` will return an error if a grid needed for the best transformation is missing.
+    
     Best transformation should be understood as the most accurate transformation
     available among all relevant for the point to transform, and if all known
     grids required to perform such transformation were accessible (either locally
     or through network).
+    
     Note that the default value for this option can be also set with the
     :envvar:`PROJ_ONLY_BEST_DEFAULT` environment variable, or with the
     ``only_best_default`` setting of :ref:`proj-ini` (:option:`--only-best`

--- a/docs/source/apps/cs2cs.rst
+++ b/docs/source/apps/cs2cs.rst
@@ -302,12 +302,42 @@ The x-y output data will appear as three lines of:
 
 ::
 
-    1402285.98  5076292.42 0.00
+    1402285.93  5076292.58 0.00
 
-.. note::
 
-    To get those exact values, you have need to have all current grids installed
-    locally or use networking capabilities mentioned above.
+To get those exact values, you have need to have all current grids installed
+(in that instance the NADCON5 :file:`us_noaa_nadcon5_nad27_nad83_1986_conus.tif` grid)
+locally or use networking capabilities mentioned above.
+
+To make sure you will get the optimal result, you may add :option:`--only-best`.
+Assuming the above mentionned grid is *not* available,
+
+::
+
+    echo -111.5 45.25919444444 | cs2cs --only-best +proj=latlong +datum=NAD83 +to +proj=utm +zone=10 +datum=NAD27
+
+would return:
+
+::
+
+    Attempt to use coordinate operation axis order change (2D) + Inverse of NAD27 to NAD83 (7) + axis order change (2D) + UTM zone 10N failed. Grid us_noaa_nadcon5_nad27_nad83_1986_conus.tif is not available. Consult https://proj.org/resource_files.html for guidance.
+    *   * inf
+
+Otherwise, if you don't have the grid available and you don't specify :option:`--only-best`:
+
+::
+
+    echo -111.5 45.25919444444 | cs2cs --only-best +proj=latlong +datum=NAD83 +to +proj=utm +zone=10 +datum=NAD27
+
+would return:
+
+::
+
+    1402224.57  5076275.42 0.00
+
+which is the result when the NAD27 and NAD83 datums are dealt as identical,
+which is an approximation at a level of several tens of metres.
+
 
 Using EPSG CRS codes
 --------------------

--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -208,6 +208,10 @@ paragraph for more details.
       be understood as the transformation returned by
       :cpp:func:`proj_get_suggested_operation` if all known grids were
       accessible (either locally or through network).
+      Note that the default value for this option can be also set with the
+      :envvar:`PROJ_ONLY_BEST_DEFAULT` environment variable, or with the
+      ``only_best_default`` setting of :ref:`proj-ini` (the ONLY_BEST option
+      when specified overrides such default value).
 
     - FORCE_OVER=YES/NO: can be set to YES to force the ``+over`` flag on the transformation
       returned by this function. See :ref:`longitude_wrapping`

--- a/docs/source/development/reference/functions.rst
+++ b/docs/source/development/reference/functions.rst
@@ -201,6 +201,14 @@ paragraph for more details.
     - ALLOW_BALLPARK=YES/NO: can be set to NO to disallow the use of
       :term:`Ballpark transformation` in the candidate coordinate operations.
 
+    - ONLY_BEST=YES/NO: (PROJ >= 9.2)
+      Can be set to YES to cause PROJ to error out if the best
+      transformation, known of PROJ, and usable by PROJ if all grids known and
+      usable by PROJ were accessible, cannot be used. Best transformation should
+      be understood as the transformation returned by
+      :cpp:func:`proj_get_suggested_operation` if all known grids were
+      accessible (either locally or through network).
+
     - FORCE_OVER=YES/NO: can be set to YES to force the ``+over`` flag on the transformation
       returned by this function. See :ref:`longitude_wrapping`
 

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -117,46 +117,7 @@ network related parameters.
 
 Its default content is:
 
-::
-
-    [general]
-    ; Lines starting by ; are commented lines.
-    ;
-
-    ; Network capabilities disabled by default.
-    ; Can be overridden with the PROJ_NETWORK=ON environment variable.
-    ; network = on
-
-    ; Can be overridden with the PROJ_NETWORK_ENDPOINT environment variable.
-    cdn_endpoint = https://cdn.proj.org
-
-    cache_enabled = on
-
-    cache_size_MB = 300
-
-    cache_ttl_sec = 86400
-
-    ; Can be set to on so that by default the lack of a known resource files needed
-    ; for the best transformation PROJ would normally use causes an error. This
-    ; default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
-    ; variable if set, and then by the ONLY_BEST setting that can be
-    ; passed to the proj_create_crs_to_crs() method, or with the --only-best
-    ; option of the cs2cs program.
-    ; (added in PROJ 9.2)
-    only_best_default = off
-
-    ; Filename of the Certificate Authority (CA) bundle.
-    ; Can be overriden with the PROJ_CURL_CA_BUNDLE / CURL_CA_BUNDLE environment variable.
-    ; (added in PROJ 9.0)
-    ; ca_bundle_path = /path/to/cabundle.pem
-
-    ; Transverse Mercator (and UTM) default algorithm: auto, evenden_snyder or poder_engsager
-    ; * evenden_snyder is the fastest, but less accurate far from central meridian
-    ; * poder_engsager is slower, but more accurate far from central meridian
-    ; * default will auto-select between the two above depending on the coordinate
-    ;   to transform and will use evenden_snyder if the error in doing so is below
-    ;   0.1 mm (for an ellipsoid of the size of Earth)
-    tmerc_default_algo = poder_engsager
+.. literalinclude:: ../../data/proj.ini
 
 
 Transformation grids

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -136,6 +136,15 @@ Its default content is:
 
     cache_ttl_sec = 86400
 
+    ; Can be set to on so that by default the lack of a known resource files needed
+    ; for the best transformation PROJ would normally use causes an error. This
+    ; default value itself is overriden by the PROJ_ONLY_BEST_DEFAULT environment
+    ; variable if set, and then by the ONLY_BEST setting that can be
+    ; passed to the proj_create_crs_to_crs() method, or with the --only-best
+    ; option of the cs2cs program.
+    ; (added in PROJ 9.2)
+    only_best_default = off
+
     ; Filename of the Certificate Authority (CA) bundle.
     ; Can be overriden with the PROJ_CURL_CA_BUNDLE / CURL_CA_BUNDLE environment variable.
     ; (added in PROJ 9.0)

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1935,12 +1935,13 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     if( !ctx ) {
         ctx = pj_get_default_ctx();
     }
+    pj_load_ini(ctx); // to set ctx->errorIfBestTransformationNotAvailableDefault
 
     const char* authority = nullptr;
     double accuracy = -1;
     bool allowBallparkTransformations = true;
     bool forceOver = false;
-    bool errorIfBestTransformationNotAvailable = false;
+    bool errorIfBestTransformationNotAvailable = ctx->errorIfBestTransformationNotAvailableDefault;
     for (auto iter = options; iter && iter[0]; ++iter) {
         const char *value;
         if ((value = getOptionValue(*iter, "AUTHORITY="))) {

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -1942,7 +1942,7 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     double accuracy = -1;
     bool allowBallparkTransformations = true;
     bool forceOver = false;
-    bool warnIfBestTransformationNotAvailable = true;
+    bool warnIfBestTransformationNotAvailable = ctx->warnIfBestTransformationNotAvailableDefault;
     bool errorIfBestTransformationNotAvailable = ctx->errorIfBestTransformationNotAvailableDefault;
     for (auto iter = options; iter && iter[0]; ++iter) {
         const char *value;

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -2069,6 +2069,9 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
             }
         }
 
+        if( P != nullptr ) {
+            P->over = forceOver;
+        }
         return P;
     }
 
@@ -2088,6 +2091,7 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     }
 
     for( auto& op: preparedOpList ) {
+        op.pj->over = forceOver;
         op.pj->errorIfBestTransformationNotAvailable = errorIfBestTransformationNotAvailable;
     }
 
@@ -2103,6 +2107,7 @@ PJ  *proj_create_crs_to_crs_from_pj (PJ_CONTEXT *ctx, const PJ *source_crs, cons
     P->alternativeCoordinateOperations = std::move(preparedOpList);
     // The returned P is rather dummy
     P->descr = "Set of coordinate operations";
+    P->over = forceOver;
     P->iso_obj = nullptr;
     P->fwd = nullptr;
     P->inv = nullptr;

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -79,7 +79,7 @@ static const char *usage =
     "%s\nusage: %s [-dDeEfIlrstvwW [args]]\n"
     "              [[--area name_or_code] | [--bbox west_long,south_lat,east_long,north_lat]]\n"
     "              [--authority {name}] [--3d]\n"
-    "              [--accuracy {accuracy}] [--only-best] [--no-ballpark]\n"
+    "              [--accuracy {accuracy}] [--only-best[=yes|=no]] [--no-ballpark]\n"
     "              [+opt[=arg] ...] [+to +opt[=arg] ...] [file ...]\n";
 
 static double (*informat)(const char *,
@@ -419,6 +419,7 @@ int main(int argc, char **argv) {
     const char* authority = nullptr;
     double accuracy = -1;
     bool allowBallpark = true;
+    bool onlyBestSet = false;
     bool errorIfBestTransformationNotAvailable = false;
     bool promoteTo3D = false;
 
@@ -486,8 +487,14 @@ int main(int argc, char **argv) {
         else if (strcmp(*argv, "--no-ballpark") == 0 ) {
             allowBallpark = false;
         }
-        else if (strcmp(*argv, "--only-best") == 0 ) {
+        else if (strcmp(*argv, "--only-best") == 0 ||
+                 strcmp(*argv, "--only-best=yes") == 0 ) {
+            onlyBestSet = true;
             errorIfBestTransformationNotAvailable = true;
+        }
+        else if (strcmp(*argv, "--only-best=no") == 0 ) {
+            onlyBestSet = true;
+            errorIfBestTransformationNotAvailable = false;
         }
         else if (strcmp(*argv, "--3d") == 0 ) {
             promoteTo3D = true;
@@ -898,8 +905,13 @@ int main(int argc, char **argv) {
     if( !allowBallpark ) {
         options.push_back("ALLOW_BALLPARK=NO");
     }
-    if( errorIfBestTransformationNotAvailable ) {
-        options.push_back("ONLY_BEST=YES");
+    if( onlyBestSet ) {
+        if( errorIfBestTransformationNotAvailable ) {
+            options.push_back("ONLY_BEST=YES");
+        }
+        else {
+            options.push_back("ONLY_BEST=NO");
+        }
     }
     options.push_back(nullptr);
     transformation = proj_create_crs_to_crs_from_pj(nullptr, src, dst,

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -78,7 +78,8 @@ static const char *oterr = "*\t*"; /* output line for unprojectable input */
 static const char *usage =
     "%s\nusage: %s [-dDeEfIlrstvwW [args]]\n"
     "              [[--area name_or_code] | [--bbox west_long,south_lat,east_long,north_lat]]\n"
-    "              [--authority {name}] [--accuracy {accuracy}] [--no-ballpark] [--3d]\n"
+    "              [--authority {name}] [--3d]\n"
+    "              [--accuracy {accuracy}] [--only-best] [--no-ballpark]\n"
     "              [+opt[=arg] ...] [+to +opt[=arg] ...] [file ...]\n";
 
 static double (*informat)(const char *,
@@ -418,6 +419,7 @@ int main(int argc, char **argv) {
     const char* authority = nullptr;
     double accuracy = -1;
     bool allowBallpark = true;
+    bool errorIfBestTransformationNotAvailable = false;
     bool promoteTo3D = false;
 
     /* process run line arguments */
@@ -483,6 +485,9 @@ int main(int argc, char **argv) {
         }
         else if (strcmp(*argv, "--no-ballpark") == 0 ) {
             allowBallpark = false;
+        }
+        else if (strcmp(*argv, "--only-best") == 0 ) {
+            errorIfBestTransformationNotAvailable = true;
         }
         else if (strcmp(*argv, "--3d") == 0 ) {
             promoteTo3D = true;
@@ -892,6 +897,9 @@ int main(int argc, char **argv) {
     }
     if( !allowBallpark ) {
         options.push_back("ALLOW_BALLPARK=NO");
+    }
+    if( errorIfBestTransformationNotAvailable ) {
+        options.push_back("ONLY_BEST=YES");
     }
     options.push_back(nullptr);
     transformation = proj_create_crs_to_crs_from_pj(nullptr, src, dst,

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -150,6 +150,7 @@ pj_ctx::pj_ctx(const pj_ctx& other) :
     lastFullErrorMessage(std::string()),
     last_errno(0),
     debug_level(other.debug_level),
+    warnIfBestTransformationNotAvailable(other.warnIfBestTransformationNotAvailable),
     logger(other.logger),
     logger_app_data(other.logger_app_data),
     cpp_context(other.cpp_context ? other.cpp_context->clone(this) : nullptr),

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -150,7 +150,6 @@ pj_ctx::pj_ctx(const pj_ctx& other) :
     lastFullErrorMessage(std::string()),
     last_errno(0),
     debug_level(other.debug_level),
-    warnIfBestTransformationNotAvailable(other.warnIfBestTransformationNotAvailable),
     errorIfBestTransformationNotAvailableDefault(other.errorIfBestTransformationNotAvailableDefault),
     logger(other.logger),
     logger_app_data(other.logger_app_data),

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -151,6 +151,7 @@ pj_ctx::pj_ctx(const pj_ctx& other) :
     last_errno(0),
     debug_level(other.debug_level),
     warnIfBestTransformationNotAvailable(other.warnIfBestTransformationNotAvailable),
+    errorIfBestTransformationNotAvailableDefault(other.errorIfBestTransformationNotAvailableDefault),
     logger(other.logger),
     logger_app_data(other.logger_app_data),
     cpp_context(other.cpp_context ? other.cpp_context->clone(this) : nullptr),

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -151,6 +151,7 @@ pj_ctx::pj_ctx(const pj_ctx& other) :
     last_errno(0),
     debug_level(other.debug_level),
     errorIfBestTransformationNotAvailableDefault(other.errorIfBestTransformationNotAvailableDefault),
+    warnIfBestTransformationNotAvailableDefault(other.warnIfBestTransformationNotAvailableDefault),
     logger(other.logger),
     logger_app_data(other.logger_app_data),
     cpp_context(other.cpp_context ? other.cpp_context->clone(this) : nullptr),

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1823,6 +1823,7 @@ void pj_load_ini(PJ_CONTEXT *ctx) {
     // from environment first
     const char *proj_only_best_default = getenv("PROJ_ONLY_BEST_DEFAULT");
     if (proj_only_best_default && proj_only_best_default[0] != '\0') {
+        ctx->warnIfBestTransformationNotAvailableDefault = false;
         ctx->errorIfBestTransformationNotAvailableDefault =
             ci_equal(proj_only_best_default, "ON") ||
             ci_equal(proj_only_best_default, "YES") ||
@@ -1890,6 +1891,7 @@ void pj_load_ini(PJ_CONTEXT *ctx) {
                 ctx->ca_bundle_path = value;
             } else if (proj_only_best_default == nullptr &&
                        key == "only_best_default") {
+                ctx->warnIfBestTransformationNotAvailableDefault = false;
                 ctx->errorIfBestTransformationNotAvailableDefault =
                     ci_equal(value, "ON") ||
                     ci_equal(value, "YES") ||

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1819,6 +1819,16 @@ void pj_load_ini(PJ_CONTEXT *ctx) {
         ctx->ca_bundle_path = ca_bundle_path;
     }
 
+    // Load default value for errorIfBestTransformationNotAvailableDefault
+    // from environment first
+    const char *proj_only_best_default = getenv("PROJ_ONLY_BEST_DEFAULT");
+    if (proj_only_best_default && proj_only_best_default[0] != '\0') {
+        ctx->errorIfBestTransformationNotAvailableDefault =
+            ci_equal(proj_only_best_default, "ON") ||
+            ci_equal(proj_only_best_default, "YES") ||
+            ci_equal(proj_only_best_default, "TRUE");
+    }
+
     ctx->iniFileLoaded = true;
     auto file = std::unique_ptr<NS_PROJ::File>(
         reinterpret_cast<NS_PROJ::File *>(pj_open_lib_internal(
@@ -1878,6 +1888,12 @@ void pj_load_ini(PJ_CONTEXT *ctx) {
                 }
             } else if (ca_bundle_path == nullptr && key == "ca_bundle_path") {
                 ctx->ca_bundle_path = value;
+            } else if (proj_only_best_default == nullptr &&
+                       key == "only_best_default") {
+                ctx->errorIfBestTransformationNotAvailableDefault =
+                    ci_equal(value, "ON") ||
+                    ci_equal(value, "YES") ||
+                    ci_equal(value, "TRUE");
             }
         }
 

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -521,10 +521,13 @@ PJ *proj_clone(PJ_CONTEXT *ctx, const PJ *obj) {
             if (newPj) {
                 newPj->descr = "Set of coordinate operations";
                 newPj->ctx = ctx;
+                const int old_debug_level = ctx->debug_level;
+                ctx->debug_level = PJ_LOG_NONE;
                 for (const auto &altOp : obj->alternativeCoordinateOperations) {
                     newPj->alternativeCoordinateOperations.emplace_back(
                         PJCoordOperation(ctx, altOp));
                 }
+                ctx->debug_level = old_debug_level;
             }
             return newPj;
         }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -696,6 +696,7 @@ struct pj_ctx{
     int     last_errno = 0;
     int     debug_level = PJ_LOG_ERROR;
     bool warnIfBestTransformationNotAvailable = true; /* to remove in PROJ 10? */
+    bool errorIfBestTransformationNotAvailableDefault = false;
     void    (*logger)(void *, int, const char *) = nullptr;
     void    *logger_app_data = nullptr;
     struct projCppContext* cpp_context = nullptr; /* internal context for C++ code */

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -595,6 +595,7 @@ struct PJconsts {
     std::vector<PJCoordOperation> alternativeCoordinateOperations{};
     int iCurCoordOp = -1;
     bool errorIfBestTransformationNotAvailable = false;
+    bool warnIfBestTransformationNotAvailable = true; /* to remove in PROJ 10? */
 
     /*************************************************************************************
 
@@ -695,7 +696,6 @@ struct pj_ctx{
     std::string lastFullErrorMessage{}; // used by proj_context_errno_string
     int     last_errno = 0;
     int     debug_level = PJ_LOG_ERROR;
-    bool warnIfBestTransformationNotAvailable = true; /* to remove in PROJ 10? */
     bool errorIfBestTransformationNotAvailableDefault = false;
     void    (*logger)(void *, int, const char *) = nullptr;
     void    *logger_app_data = nullptr;

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -695,6 +695,7 @@ struct pj_ctx{
     std::string lastFullErrorMessage{}; // used by proj_context_errno_string
     int     last_errno = 0;
     int     debug_level = PJ_LOG_ERROR;
+    bool warnIfBestTransformationNotAvailable = true; /* to remove in PROJ 10? */
     void    (*logger)(void *, int, const char *) = nullptr;
     void    *logger_app_data = nullptr;
     struct projCppContext* cpp_context = nullptr; /* internal context for C++ code */

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -594,6 +594,7 @@ struct PJconsts {
     **************************************************************************************/
     std::vector<PJCoordOperation> alternativeCoordinateOperations{};
     int iCurCoordOp = -1;
+    bool errorIfBestTransformationNotAvailable = false;
 
     /*************************************************************************************
 

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -697,6 +697,7 @@ struct pj_ctx{
     int     last_errno = 0;
     int     debug_level = PJ_LOG_ERROR;
     bool errorIfBestTransformationNotAvailableDefault = false;
+    bool warnIfBestTransformationNotAvailableDefault = true;
     void    (*logger)(void *, int, const char *) = nullptr;
     void    *logger_app_data = nullptr;
     struct projCppContext* cpp_context = nullptr; /* internal context for C++ code */

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1082,6 +1082,34 @@ PROJ_DISPLAY_PROGRAM_NAME=NO $EXE -W10 +proj=latlong +datum=WGS84 +to +proj=latl
 0 0
 EOF
 
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (working)" >> ${OUT}
+#
+$EXE --only-best NTF RGF93 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (grid missing)" >> ${OUT}
+#
+$EXE --only-best EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (grid missing)" >> ${OUT}
+#
+$EXE --only-best NAD27 NAD83 -E >>${OUT} 2>&1 <<EOF
+40 -100 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best --no-ballpark (grid missing)" >> ${OUT}
+#
+$EXE --only-best --no-ballpark EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1090,9 +1090,30 @@ $EXE --only-best NTF RGF93 -E >>${OUT} 2>&1 <<EOF
 EOF
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing)" >> ${OUT}
+#
+$EXE EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best=no  (grid missing)" >> ${OUT}
+#
+$EXE --only-best=no EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
 echo "Test cs2cs --only-best (grid missing)" >> ${OUT}
 #
 $EXE --only-best EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best=yes (grid missing)" >> ${OUT}
+#
+$EXE --only-best=yes EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1118,6 +1118,25 @@ $EXE --only-best=yes EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 EOF
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES" >> ${OUT}
+#
+PROJ_ONLY_BEST_DEFAULT=YES $EXE EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) with only_best_default=on in proj.ini" >> ${OUT}
+
+echo "only_best_default=on" > proj.ini
+
+#
+PROJ_DATA=$PWD:$PROJ_DATA $EXE EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+rm proj.ini
+
+echo "##############################################################" >> ${OUT}
 echo "Test cs2cs --only-best (grid missing)" >> ${OUT}
 #
 $EXE --only-best NAD27 NAD83 -E >>${OUT} 2>&1 <<EOF

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -546,6 +546,14 @@ Test cs2cs --only-best=yes (grid missing)
 Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
+Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance. This might become an error in a future PROJ major release. Set the ONLY_BEST option to YES or NO. This warning will no longer be emitted (for the current context).
+49 2 0	*	* inf
+##############################################################
+Test cs2cs (grid missing) with only_best_default=on in proj.ini
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance. This might become an error in a future PROJ major release. Set the ONLY_BEST option to YES or NO. This warning will no longer be emitted (for the current context).
+49 2 0	*	* inf
+##############################################################
 Test cs2cs --only-best (grid missing)
 Attempt to use coordinate operation NAD27 to NAD83 (7) failed. Grid us_noaa_nadcon5_nad27_nad83_1986_conus.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 40 -100 0	*	* inf

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -547,11 +547,11 @@ Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) fail
 49 2 0	*	* inf
 ##############################################################
 Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES
-Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance. This might become an error in a future PROJ major release. Set the ONLY_BEST option to YES or NO. This warning will no longer be emitted (for the current context).
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
 Test cs2cs (grid missing) with only_best_default=on in proj.ini
-Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance. This might become an error in a future PROJ major release. Set the ONLY_BEST option to YES or NO. This warning will no longer be emitted (for the current context).
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
 Test cs2cs --only-best (grid missing)

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -528,3 +528,18 @@ Test cs2cs -W10
 
 -W argument missing or not in range [0,8]
 program abnormally terminated
+##############################################################
+Test cs2cs --only-best (working)
+49 2 0	48d59'59.756"N	1d59'57.4"E 0.000
+##############################################################
+Test cs2cs --only-best (grid missing)
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
+49 2 0	*	* inf
+##############################################################
+Test cs2cs --only-best (grid missing)
+Attempt to use coordinate operation NAD27 to NAD83 (7) failed. Grid us_noaa_nadcon5_nad27_nad83_1986_conus.tif is not available.
+40 -100 0	*	* inf
+##############################################################
+Test cs2cs --only-best --no-ballpark (grid missing)
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
+49 2 0	*	* inf

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -539,17 +539,21 @@ Test cs2cs --only-best=no  (grid missing)
 49 2 0	49dN	2dE 0.000
 ##############################################################
 Test cs2cs --only-best (grid missing)
-Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
 Test cs2cs --only-best=yes (grid missing)
-Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
 Test cs2cs --only-best (grid missing)
-Attempt to use coordinate operation NAD27 to NAD83 (7) failed. Grid us_noaa_nadcon5_nad27_nad83_1986_conus.tif is not available.
+Attempt to use coordinate operation NAD27 to NAD83 (7) failed. Grid us_noaa_nadcon5_nad27_nad83_1986_conus.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 40 -100 0	*	* inf
 ##############################################################
 Test cs2cs --only-best --no-ballpark (grid missing)
-Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
-49 2 0	*	* inf
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
+Rel. 9.2.0, March 1st, 2023
+<cs2cs>: 
+cannot initialize transformation
+cause: File not found or invalid
+program abnormally terminated

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -532,7 +532,17 @@ program abnormally terminated
 Test cs2cs --only-best (working)
 49 2 0	48d59'59.756"N	1d59'57.4"E 0.000
 ##############################################################
+Test cs2cs (grid missing)
+49 2 0	49dN	2dE 0.000
+##############################################################
+Test cs2cs --only-best=no  (grid missing)
+49 2 0	49dN	2dE 0.000
+##############################################################
 Test cs2cs --only-best (grid missing)
+Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
+49 2 0	*	* inf
+##############################################################
+Test cs2cs --only-best=yes (grid missing)
 Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available.
 49 2 0	*	* inf
 ##############################################################


### PR DESCRIPTION
Also add a --only-best switch to cs2cs

ONLY_BEST=YES/NO: (PROJ >= 9.2)
Can be set to YES to cause PROJ to error out if the best transformation, known of PROJ, and usable by PROJ if all grids known and usable by PROJ were accessible, cannot be used. Best transformation should be understood as the transformation returned by
:cpp:func:`proj_get_suggested_operation` if all known grids were accessible (either locally or through network).
