### PR TITLE
add Alan to PSC roster

### DIFF
--- a/docs/source/community/rfc/rfc-1.rst
+++ b/docs/source/community/rfc/rfc-1.rst
@@ -37,7 +37,7 @@ pass a proposal.
 
 List of PSC Members
 -------------------
-(up-to-date as of 2018-06)
+(up-to-date as of 2023-01)
 
 * Kristian Evers `@kbevers <https://github.com/kbevers>`_ (DK) **Chair**
 * Howard Butler `@hobu <https://github.com/hobu>`_ (USA)
@@ -45,6 +45,7 @@ List of PSC Members
 * Thomas Knudsen `@busstoptaktik <https://github.com/busstoptaktik>`_ (DK)
 * Even Rouault `@rouault <https://github.com/rouault>`_ (FR)
 * Kurt Schwehr `@schwehr <https://github.com/schwehr>`_ (USA)
+* Alan Snow `@snowman2 <https://github.com/snowman2>`_ (USA)
 * Frank Warmerdam `@warmerdam <https://github.com/warmerdam>`_ (USA) **Emeritus**
 
 Detailed Process


### PR DESCRIPTION
Alan Snow was [nominated and elected](https://lists.osgeo.org/pipermail/proj/2023-January/010870.html) to the PSC in January of 2023.

