### PR TITLE
Fix deallocation bug in `proj_info()`

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -2232,7 +2232,8 @@ PJ_INFO proj_info (void) {
         }
     }
 
-    free(const_cast<char*>(info.searchpath));
+    if (info.searchpath != empty)
+        free(const_cast<char*>(info.searchpath));
     info.searchpath = buf ? buf : empty;
 
     info.paths = ctx->c_compat_paths;


### PR DESCRIPTION
If `info.searchpath` is set to [the static string `empty`](https://github.com/OSGeo/PROJ/blob/08e123182f5a1404e7f1f9ef30e19f5af8bde1d4/src/4D_api.cpp#L2195) (which could be the case if there was a previous invocation of `proj_info()`), it should not be deallocated.