### PR TITLE
fix projsync --list-files CSV header

### DIFF
--- a/src/apps/projsync.cpp
+++ b/src/apps/projsync.cpp
@@ -289,7 +289,7 @@ int main(int argc, char *argv[]) {
     file.reset();
 
     if (listFiles) {
-        std::cout << "filename,source_id,area_of_use,file_size" << std::endl;
+        std::cout << "filename,area_of_use,source_id,file_size" << std::endl;
     }
 
     std::string proj_data_version_str;


### PR DESCRIPTION
Running `projsync --list-files` returns CSV data like this:

```
filename,source_id,area_of_use,file_size
at_bev_README.txt,,at_bev,3200
at_bev_AT_GIS_GRID.tif,Austria,at_bev,216878
```

The column order of the header and data don't match, `source_id` and `area_of_use` are swapped. We could swap either the header or the data, in this PR I'm swapping the header.

Here you can see the order of the data:

https://github.com/OSGeo/PROJ/blob/c637eff74c786a8043098e91464e493ec7924319/src/apps/projsync.cpp#L608-L626
