### PR TITLE
Remove dead prototype for pj_qsfn

### DIFF
--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -820,7 +820,6 @@ double  pj_tsfn(double, double, double);
 double  pj_msfn(double, double, double);
 double  PROJ_DLL pj_phi2(PJ_CONTEXT *, const double, const double);
 double  pj_sinhpsi2tanphi(PJ_CONTEXT *, const double, const double);
-double  pj_qsfn_(double, PJ *);
 double *pj_authset(double);
 double  pj_authlat(double, double *);
 


### PR DESCRIPTION
pj_qsfn now takes its eccentricity parameters, `e` and `1+e*e`, directly as function parameters. The old version, taking a pointer to `PJ` was left in `proj_internal.h`. While not doing any harm there, there's also no compelling reason to keep it.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
