### PR TITLE
.readthedocs.yaml: do not do builds only if the only changes are in docs/ or .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,17 +12,6 @@ build:
 
   jobs:
     post_checkout:
-      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
-      # You can add any other files or directories that you'd like here as well,
-      # like your docs requirements file, or other files that will change your docs build.
-      #
-      # If there are no changes (git diff exits with 0) we force the command to return with 183.
-      # This is a special exit code on Read the Docs that will cancel the build immediately.
-      - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/master -- docs/ .readthedocs.yaml;
-        then
-          exit 183;
-        fi
       - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viqP "skip ci|ci skip") || exit 183
     pre_build:
       - ./docs/rtd/pre_build.sh


### PR DESCRIPTION
A substantial part of the API documentation comes from Doxygen & Breathe, and thus depends on changes in src/
