### PR TITLE
Add Slovenian geoid model SLO-VRP2016/Koper

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -274,6 +274,9 @@ VALUES
 -- se_lantmateriet - Sweden
 ('SWEN17_RH2000.gtx','se_lantmateriet_SWEN17_RH2000.tif','SWEN17_RH2000.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/se_lantmateriet_SWEN17_RH2000.tif',1,1,NULL),
 
+-- si_gurs - Slovenia
+('https://isgeoid.polimi.it/Geoid/Europe/Slovenia/public/Slovenia_2016_SLO_VRP2016_Koper_hybrQ_20221122.isg','si_gurs_SLO-VRP2016-Koper.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/si_gurs_SLO-VRP2016-Koper.tif',1,1,NULL),
+
 -- sk_gku - Geodetický a kartografický ústav Bratislava (GKU)
 ('Slovakia_JTSK03_to_JTSK.LAS','sk_gku_JTSK03_to_JTSK.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/sk_gku_JTSK03_to_JTSK.tif',1,1,NULL),
 ('Slovakia_ETRS89h_to_Baltic1957.gtx','sk_gku_Slovakia_ETRS89h_to_Baltic1957.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/sk_gku_Slovakia_ETRS89h_to_Baltic1957.tif',1,1,NULL),


### PR DESCRIPTION
This PR adds a new entry into the `grid_alternatives`-table to link to the GeoTIFF file for the Slovenian geoid model SLO-VRP2016/Koper added in PROJ-data: https://github.com/OSGeo/PROJ-data/pull/93

See that there is already another EPSG-database update in preparation (https://github.com/OSGeo/PROJ/pull/3609) but I don't expect any conflicts with this PR.

Example on `master`:
```
$ echo 46.0 14.5 0 | PROJ_DEBUG=2 cs2cs EPSG:4883  EPSG:4756+8690
pj_open_lib(proj.db): call fopen(.../install/share/proj//proj.db) - succeeded
pj_open_lib(proj.ini): call fopen(.../install/share/proj//proj.ini) - succeeded
Attempt at accessing remote resource not authorized. Either set PROJ_NETWORK=ON or proj_context_set_enable_network(ctx, TRUE)
pj_open_lib(https://isgeoid.polimi.it/Geoid/Europe/Slovenia/public/Slovenia_2016_SLO_VRP2016_Koper_hybrQ_20221122.isg): call fopen(https://isgeoid.polimi.it/Geoid/Europe/Slovenia/public/Slovenia_2016_SLO_VRP2016_Koper_hybrQ_20221122.isg) - failed
...
46.00	14.50 0.00
```

Example on this branch:
```
$ echo 46.0 14.5 0 | PROJ_DEBUG=2 cs2cs EPSG:4883  EPSG:4756+8690
pj_open_lib(proj.db): call fopen(.../install/share/proj/proj.db) - succeeded
pj_open_lib(proj.ini): call fopen(/.../install/share/proj/proj.ini) - succeeded
pj_open_lib(si_gurs_SLO-VRP2016-Koper.tif): call fopen(.../install/share/proj/si_gurs_SLO-VRP2016-Koper.tif) - succeeded
pj_open_lib(si_gurs_SLO-VRP2016-Koper.tif): call fopen(.../install/share/proj/si_gurs_SLO-VRP2016-Koper.tif) - succeeded
Using coordinate operation Slovenia 1996 to SVS2010 height (1) + Inverse of Ballpark geographic offset from VN-2000 to Slovenia 1996
pj_open_lib(si_gurs_SLO-VRP2016-Koper.tif): call fopen(.../install/share/proj/si_gurs_SLO-VRP2016-Koper.tif) - succeeded
46.00	14.50 -46.45
```