### PR TITLE
Update link to OSGeo4W Installer

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -84,7 +84,7 @@ accomplished by executing the following command::
    C:\temp\osgeo4w-setup.exe -q -k -r -A -s https://download.osgeo.org/osgeo4w/v2/ -P proj
 
 .. _`OSGeo4W`: https://trac.osgeo.org/osgeo4w/
-.. _`64 bit`: https://download.osgeo.org/osgeo4w/osgeo4w-setup.exe
+.. _`64 bit`: https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe
 
 Linux
 --------------------------------------------------------------------------------


### PR DESCRIPTION
All the following websites mention https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe as the location of the OSGeo4W installer (instead of https://download.osgeo.org/osgeo4w/osgeo4w-setup.exe):
- https://trac.osgeo.org/osgeo4w/
- https://qgis.org/en/site/forusers/alldownloads.html#osgeo4w-installer
- https://grass.osgeo.org/download/windows/#OSGeo4W

It's probably the same file, looking at the size and date, but in order to avoid confusion, it's maybe better to use the same link in the PROJ project.