### PR TITLE
proj_create_crs_to_crs(): restore behaviour of PROJ 9.1 (fixes #3613)

### DIFF
--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1170,6 +1170,19 @@ EOF
 rm -rf tmp_dir
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) with scenario of https://github.com/OSGeo/PROJ/issues/3613 that we are using a WGS 84 intermediate to do NAD27 to NAD83" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+PROJ_DATA=tmp_dir $EXE EPSG:26915 EPSG:26715 -E >>${OUT} 2>&1 <<EOF
+569704.5660295591 4269024.671083651
+569704.5660295591 4269024.671083651
+EOF
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
 echo "Test Similarity Transformation (example from EPSG Guidance Note 7.2)" >> ${OUT}
 #
 $EXE -d 3 EPSG:23031 EPSG:25831 -E >>${OUT} 2>&1 <<EOF

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -573,6 +573,10 @@ Test cs2cs (grid missing) with scenario of https://github.com/OSGeo/PROJ/issues/
 -111.5 45.25919444444	1402288.54	5076296.64 0.00
 -111.5 45.25919444444	1402288.54	5076296.64 0.00
 ##############################################################
+Test cs2cs (grid missing) with scenario of https://github.com/OSGeo/PROJ/issues/3613 that we are using a WGS 84 intermediate to do NAD27 to NAD83
+569704.5660295591 4269024.671083651	569720.46	4268813.88 0.00
+569704.5660295591 4269024.671083651	569720.46	4268813.88 0.00
+##############################################################
 Test Similarity Transformation (example from EPSG Guidance Note 7.2)
 300000 4500000	299905.060	4499796.515 0.000
 ##############################################################


### PR DESCRIPTION
Fixes situations where getting operations in PROJ_GRID_AVAILABILITY_KNOWN_AVAILABLE mode returns only gridded operations where the grids aren't available or ballpark operations.
We retry in PROJ_GRID_AVAILABILITY_DISCARD_OPERATION_IF_MISSING_GRID mode to get potential other transformations using CRS intermediates.
