### PR TITLE
pj_get_suggested_operation(): tune for GDA94 <--> WGS84 and GDA2020 <…-> WGS84

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -222,6 +222,18 @@ static bool isSpecialCaseForNAD83_to_NAD83HARN(const PJCoordOperation &op) {
            op.name.find("NAD83 to NAD83(HARN) (50)") != std::string::npos;
 }
 
+// Returns true if the passed operation uses "GDA94 to WGS 84 (1)", which
+// is the null transformation
+static bool isSpecialCaseForGDA94_to_WGS84(const PJCoordOperation &op) {
+    return op.name.find("GDA94 to WGS 84 (1)") != std::string::npos;
+}
+
+// Returns true if the passed operation uses "GDA2020 to WGS 84 (2)", which
+// is the null transformation
+static bool isSpecialCaseForWGS84_to_GDA2020(const PJCoordOperation &op) {
+    return op.name.find("GDA2020 to WGS 84 (2)") != std::string::npos;
+}
+
 /**************************************************************************************/
 int pj_get_suggested_operation(PJ_CONTEXT *,
                                const std::vector<PJCoordOperation> &opList,
@@ -309,7 +321,14 @@ int pj_get_suggested_operation(PJ_CONTEXT *,
                    alt.minySrc >= opList[iBest].minySrc &&
                    alt.maxxSrc <= opList[iBest].maxxSrc &&
                    alt.maxySrc <= opList[iBest].maxySrc &&
-                   !isSpecialCaseForNAD83_to_NAD83HARN(opList[iBest]))) &&
+                   // check that this is not equality
+                   !(alt.minxSrc == opList[iBest].minxSrc &&
+                     alt.minySrc == opList[iBest].minySrc &&
+                     alt.maxxSrc == opList[iBest].maxxSrc &&
+                     alt.maxySrc == opList[iBest].maxySrc) &&
+                   !isSpecialCaseForNAD83_to_NAD83HARN(opList[iBest]) &&
+                   !isSpecialCaseForGDA94_to_WGS84(opList[iBest]) &&
+                   !isSpecialCaseForWGS84_to_GDA2020(opList[iBest]))) &&
                  !alt.isOffshore)) {
 
                 if (skipNonInstantiable &&

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1089,42 +1089,77 @@ PROJ_DISPLAY_PROGRAM_NAME=NO $EXE -W10 +proj=latlong +datum=WGS84 +to +proj=latl
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs --only-best (working)" >> ${OUT}
+echo "Test cs2cs --only-best (grid missing) for NTF to RGF93" >> ${OUT}
 #
 $EXE --only-best NTF RGF93 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs (grid missing)" >> ${OUT}
+echo "Test cs2cs --only-best (working) for EPSG:4326+5773 to EPSG:4979" >> ${OUT}
+#
+$EXE --only-best EPSG:4326+5773 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (working) for EPSG:4326 to GDA94 " >> ${OUT}
+#
+$EXE --only-best EPSG:4326 GDA94 -E >>${OUT} 2>&1 <<EOF
+-30 152 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (working) for GDA94 to EPSG:4326 " >> ${OUT}
+#
+$EXE --only-best GDA94 EPSG:4326 -E >>${OUT} 2>&1 <<EOF
+-30 152 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (working) for EPSG:4326 to GDA2020 " >> ${OUT}
+#
+$EXE --only-best EPSG:4326 GDA2020 -E >>${OUT} 2>&1 <<EOF
+-30 152 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs --only-best (working) for GDA2020 to EPSG:4326 " >> ${OUT}
+#
+$EXE --only-best GDA2020 EPSG:4326 -E >>${OUT} 2>&1 <<EOF
+-30 152 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) for EPSG:4326+3855 to EPSG:4979" >> ${OUT}
 #
 $EXE EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs --only-best=no  (grid missing)" >> ${OUT}
+echo "Test cs2cs --only-best=no (grid missing) for EPSG:4326+3855 to EPSG:4979" >> ${OUT}
 #
 $EXE --only-best=no EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs --only-best (grid missing)" >> ${OUT}
+echo "Test cs2cs --only-best (grid missing) for EPSG:4326+3855 to EPSG:4979" >> ${OUT}
 #
 $EXE --only-best EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs --only-best=yes (grid missing)" >> ${OUT}
+echo "Test cs2cs --only-best=yes (grid missing) for EPSG:4326+3855 to EPSG:4979" >> ${OUT}
 #
 $EXE --only-best=yes EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0
 EOF
 
 echo "##############################################################" >> ${OUT}
-echo "Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES" >> ${OUT}
+echo "Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES for EPSG:4326+3855 to EPSG:4979" >> ${OUT}
 #
 PROJ_ONLY_BEST_DEFAULT=YES $EXE EPSG:4326+3855 EPSG:4979 -E >>${OUT} 2>&1 <<EOF
 49 2 0

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -532,24 +532,40 @@ Test cs2cs -W10
 -W argument missing or not in range [0,8]
 program abnormally terminated
 ##############################################################
-Test cs2cs --only-best (working)
-49 2 0	48d59'59.756"N	1d59'57.4"E 0.000
+Test cs2cs --only-best (grid missing) for NTF to RGF93
+Attempt to use coordinate operation NTF to RGF93 v1 (1) failed. Grid fr_ign_gr3df97a.tif is not available. Consult https://proj.org/resource_files.html for guidance.
+49 2 0	*	* inf
 ##############################################################
-Test cs2cs (grid missing)
+Test cs2cs --only-best (working) for EPSG:4326+5773 to EPSG:4979
+49 2 0	49dN	2dE 45.064
+##############################################################
+Test cs2cs --only-best (working) for EPSG:4326 to GDA94 
+-30 152 0	30dS	152dE 0.000
+##############################################################
+Test cs2cs --only-best (working) for GDA94 to EPSG:4326 
+-30 152 0	30dS	152dE 0.000
+##############################################################
+Test cs2cs --only-best (working) for EPSG:4326 to GDA2020 
+-30 152 0	30dS	152dE 0.000
+##############################################################
+Test cs2cs --only-best (working) for GDA2020 to EPSG:4326 
+-30 152 0	30dS	152dE 0.000
+##############################################################
+Test cs2cs (grid missing) for EPSG:4326+3855 to EPSG:4979
 49 2 0	49dN	2dE 0.000
 ##############################################################
-Test cs2cs --only-best=no  (grid missing)
+Test cs2cs --only-best=no (grid missing) for EPSG:4326+3855 to EPSG:4979
 49 2 0	49dN	2dE 0.000
 ##############################################################
-Test cs2cs --only-best (grid missing)
+Test cs2cs --only-best (grid missing) for EPSG:4326+3855 to EPSG:4979
 Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
-Test cs2cs --only-best=yes (grid missing)
+Test cs2cs --only-best=yes (grid missing) for EPSG:4326+3855 to EPSG:4979
 Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################
-Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES
+Test cs2cs (grid missing) with PROJ_ONLY_BEST_DEFAULT=YES for EPSG:4326+3855 to EPSG:4979
 Attempt to use coordinate operation Inverse of WGS 84 to EGM2008 height (1) failed. Grid us_nga_egm08_25.tif is not available. Consult https://proj.org/resource_files.html for guidance.
 49 2 0	*	* inf
 ##############################################################


### PR DESCRIPTION
Before this change, the au_icsm_GDA94_GDA2020_conformal_and_distortion.tif was considered as the best operation for GDA94 <--> WGS84 and GDA2020 <--> WGS84 from cs2cs / proj_crs_to_crs() point of view. This change makes the null transformation be the prefered one instead. Applying the GDA94 <--> GDA2020 grid was highly questionable GDA2020 <--> WGS84. Not completely sure for GDA94 <--> WGS84 though...

Relates to https://github.com/qgis/QGIS/issues/51792

@nyalldawson Opinion greatly welcome