### PR TITLE
bindings: Use github.com/twpayne/go-proj for Go bindings

### DIFF
--- a/docs/source/development/bindings.rst
+++ b/docs/source/development/bindings.rst
@@ -31,8 +31,8 @@ Rust bindings for the latest stable version of PROJ
 
 Go (Golang)
 ===========
-`go-proj <https://github.com/everystreet/go-proj>`_:
-Go bindings and idiomatic wrapper for PROJ
+`go-proj <https://github.com/twpayne/go-proj>`_:
+Go bindings for PROJ.
 
 Julia
 =====


### PR DESCRIPTION
github.com/everystreet/go-proj seems to be no longer maintained, and github.com/twpayne/go-proj provides much more functionality.

Compare https://pkg.go.dev/github.com/twpayne/go-proj/v10 with https://pkg.go.dev/github.com/everystreet/go-proj.
