### PR TITLE
Fuzzer: indicate discarded inputs

### DIFF
--- a/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
+++ b/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
@@ -64,7 +64,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
 #ifdef STANDALONE
         fprintf(stderr, "Input too large\n");
 #endif
-        return 0;
+        return -1;
     }
 
     /* We expect the blob to be 2 lines: */
@@ -76,7 +76,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
     char *first_newline = strchr(first_line, '\n');
     if (!first_newline) {
         free(buf_dup);
-        return 0;
+        return -1;
     }
     first_newline[0] = 0;
     char *second_line = first_newline + 1;


### PR DESCRIPTION
According to [the libFuzzer documentation](https://llvm.org/docs/LibFuzzer.html#rejecting-unwanted-inputs):

> It may be desirable to reject some inputs, i.e. to not add them to the corpus.
> For example, when fuzzing an API consisting of parsing and other logic, one may want to allow only those inputs into the corpus that parse successfully.
> If the fuzz target returns -1 on a given input, libFuzzer will not add that input top the corpus, regardless of what coverage it triggers.

This prevents undesirable inputs from ending up in the corpus, which prevents the fuzzer from slowing down due to attempting to explore these fail-fast branches.