### PR TITLE
Update clang static analyzer CI and docs for ubuntu-22.04

### DIFF
--- a/.github/workflows/clang_static_analyzer.yml
+++ b/.github/workflows/clang_static_analyzer.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
 
   clang_static_analyzer:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run
         run: .github/workflows/clang_static_analyzer/start.sh

--- a/docs/source/community/code_contributions.rst
+++ b/docs/source/community/code_contributions.rst
@@ -116,18 +116,16 @@ Clang Static Analyzer (CSA)
 
 CSA is run by a GitHub Actions workflow. You may also run it locally.
 
-Preliminary step: install clang. For example:
+Preliminary step: install clang tools. For example, on a Debian-like OS:
 
 ::
 
-    wget https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    tar xJf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang+llvm-9
-    export PATH=$PWD/clang+llvm-9/bin:$PATH
+    sudo apt install clang-tools libfindbin-libs-perl
 
 Configure PROJ with the `scan-build <https://clang-analyzer.llvm.org/scan-build.html>`__ utility of clang:
 
 ::
+
     mkdir csa_build
     cd csa_build
     scan-build cmake ..


### PR DESCRIPTION
Recent Ubuntu has clang's `scan-build` in their [`clang-tools` package](https://packages.ubuntu.com/jammy/clang-tools) (jammy depends on [`clang-tools-14`](https://packages.ubuntu.com/jammy/clang-tools-14)), so this PR changes to the packaged version.

With this change, the CI script has a new error:
> jq: error (at <stdin>:809): null (null) and string ("_generated...) cannot have their containment checked

which is (maybe?) resolved via [this Q/A](https://stackoverflow.com/a/70188269/) to use `index` instead of `contains`.

This also upgrades to `ubuntu-22.04` and `actions/checkout@v3`. (I have a follow-up PR to upgrade other overdue CI components elsewhere).