### PR TITLE
CI: update ubuntu images, actions/checkout, actions/cache, unique job IDs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport Bot

--- a/.github/workflows/clang_linux.yml
+++ b/.github/workflows/clang_linux.yml
@@ -20,10 +20,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -14,12 +14,12 @@ concurrency:
 
 jobs:
 
-  cppcheck_2004:
-    runs-on: ubuntu-20.04
+  cppcheck_2204:
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Requirements
         run: |
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Requirements
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  conda:
     name: Conda ${{ matrix.platform }}
     if: github.repository == 'OSGeo/PROJ'
 
@@ -25,12 +25,12 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        channels: conda-forge
-        auto-update-conda: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
 
     - name: Setup
       shell: bash -l {0}

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,4 +1,4 @@
-name: coverity-scan
+name: Coverity scan
 
 # Controls when the action will run. 
 on:
@@ -11,11 +11,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
-    runs-on: ubuntu-20.04
+  coverity:
+    runs-on: ubuntu-22.04
     if: github.repository == 'OSGeo/PROJ'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Libraries
         run: |

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PROJ build dependencies
         run: |
@@ -65,7 +65,7 @@ jobs:
     container: osgeo/proj-docs
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Print versions
       shell: bash -l {0}
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
       PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
       CONTAINER: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint
         id: lint
         run: |

--- a/.github/workflows/linux_gcc_32bit.yml
+++ b/.github/workflows/linux_gcc_32bit.yml
@@ -19,10 +19,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/linux_gcc_5_4.yml
+++ b/.github/workflows/linux_gcc_5_4.yml
@@ -19,10 +19,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -28,7 +28,7 @@ jobs:
           use-mamba: true
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/mingw_w64.yml
+++ b/.github/workflows/mingw_w64.yml
@@ -19,10 +19,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -31,4 +31,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-mingw_w64-
 
       - name: Build
-        run: docker run -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:18.04 $PWD/.github/workflows/mingw_w64/start.sh
+        run: docker run -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:22.04 $PWD/.github/workflows/mingw_w64/start.sh

--- a/.github/workflows/mingw_w64.yml
+++ b/.github/workflows/mingw_w64.yml
@@ -31,4 +31,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-mingw_w64-
 
       - name: Build
-        run: docker run -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:22.04 $PWD/.github/workflows/mingw_w64/start.sh
+        run: docker run -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:18.04 $PWD/.github/workflows/mingw_w64/start.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Cache vcpkg packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
             path: c:\vcpkg\installed
@@ -103,10 +103,10 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: ~/.ccache

--- a/src/apps/gie.cpp
+++ b/src/apps/gie.cpp
@@ -1153,7 +1153,9 @@ static int dispatch(const char *cmnd, const char *args) {
 
 namespace { // anonymous namespace
 static const struct {
+    /* cppcheck-suppress unusedStructMember */
     const char *the_err_const;
+    /* cppcheck-suppress unusedStructMember */
     int the_errno;
 } lookup[] = {
 

--- a/src/transformations/tinshift_impl.hpp
+++ b/src/transformations/tinshift_impl.hpp
@@ -437,11 +437,11 @@ static double distance_point_segment(double x, double y, double x1, double y1,
                                      double x2, double y2, double dist12) {
     // squared distance of point x/y to line segment x1/y1 -- x2/y2
     double t = ((x - x1) * (x2 - x1) + (y - y1) * (y2 - y1)) / dist12;
-    if (t <= 0) {
+    if (t <= 0.0) {
         // closest to x1/y1
         return squared_distance(x, y, x1, y1);
     }
-    if (t >= 1) {
+    if (t >= 1.0) {
         // closest to y2/y2
         return squared_distance(x, y, x2, y2);
     }


### PR DESCRIPTION
This PR upgrades a few components and resolves a few warning messages from GitHub actions, i.e.:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see `https://github.com/actions/virtual-environments/issues/6002`

<s>Ubuntu versions in docker containers like .github/workflows/mingw_w64.yml are upgraded for consistency.</s>

Some job IDs were renamed so they are unique, which is important for tools like [act](https://github.com/nektos/act) (`act -l`).

Other upgrades are handled with #3648.