### PR TITLE
proj_create_operations(): fix documentation related to 3D transformations (fixes #3651)

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -8349,10 +8349,9 @@ PJ_OPERATION_LIST::getPreparedOperations(PJ_CONTEXT *ctx) {
  * by increasing accuracy. Operations with unknown accuracy are sorted last,
  * whatever their area.
  *
- * When one of the source or target CRS has a vertical component but not the
- * other one, the one that has no vertical component is automatically promoted
- * to a 3D version, where its vertical axis is the ellipsoidal height in metres,
- * using the ellipsoid of the base geodetic CRS.
+ * Starting with PROJ 9.1, vertical transformations are only done if both
+ * source CRS and target CRS are 3D CRS or Compound CRS with a vertical
+ * component. You may need to use proj_crs_promote_to_3D().
  *
  * @param ctx PROJ context, or NULL for default context
  * @param source_crs source CRS. Must not be NULL.


### PR DESCRIPTION
The behaviour was changed per 3e7984f3b26e408e69b960f8e0d03b6ac0576188 in 9.1.0
