### PR TITLE
CI: update other actions, use apt-get for scripts

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -26,7 +26,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/clang_static_analyzer/start.sh
+++ b/.github/workflows/clang_static_analyzer/start.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt update
+sudo apt-get update
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
     g++ cmake make sqlite3 libsqlite3-dev libtiff-dev libcurl4-openssl-dev jq \

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install Requirements
         run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends cppcheck
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cppcheck
 
       - name: Run cppcheck test
         run: ./scripts/cppcheck.sh
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Requirements
         run: |
-            sudo apt install python3-pip
+            sudo apt-get install python3-pip
             sudo pip3 install cffconvert
 
       - name: Validate citation file

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -44,7 +44,7 @@ jobs:
       working-directory: ./proj.4-feedstock
 
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.platform }}-conda-package
         path: ./proj.4-feedstock/packages/

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -49,7 +49,7 @@ jobs:
             export PROJ_DATA=/opt/proj/share/proj
             ./plot.py plotdefs.json images/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Images
           path: docs/plot/images
@@ -73,7 +73,7 @@ jobs:
           sphinx-build --version
           python3 -m pip list --not-required --format=columns
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       name: Images
       with:
         name: Images
@@ -103,15 +103,15 @@ jobs:
       run: |
         make spelling
       working-directory: ./docs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: PDF
         path: docs/build/latex/proj.pdf
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: HTML
         path: docs/build/html/*
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Misspelled
         path: docs/build/spelling/output.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,19 +42,19 @@ jobs:
           echo "ref" ${{ github.ref }}
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: latest
       - if: ${{ env.PUSH_PACKAGES == 'true' }}
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
       - if: ${{ env.PUSH_PACKAGES == 'true' }}
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -68,7 +68,7 @@ jobs:
           echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=VERSION::${VERSION}
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: ${{ env.PUSH_PACKAGES == 'true' }}
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Update a few other CI actions that needed attention:

- `actions/download-artifact` -> `@v3`
- `actions/upload-artifact` -> `@v3`
- `docker/setup-buildx-action` -> `@v2`
- `docker/login-action` -> `@v2`
- `docker/build-push-action` -> `@v4`

Also `apt-get` should be used for scripts instead of `apt`, which is designed for terminal use.