### PR TITLE
[Backport 9.2] Use ghcr.io/osgeo/proj-docs as Docker hub is sunsetting free organizations (refs OSGeo/gdal#7447)

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-    container: osgeo/proj-docs
+    container: ghcr.io/osgeo/proj-docs
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/docbuild/README.md
+++ b/docs/docbuild/README.md
@@ -4,5 +4,5 @@ From the base PROJ repository directory:
 
 ```bash
 cd docs
-docker run -i -t -v $PWD/..:/io -w /io/docs/ osgeo/proj-docs make html
+docker run -i -t -v $PWD/..:/io -w /io/docs/ ghcr.io/osgeo/proj-docs make html
 ```

--- a/travis/build_docs.sh
+++ b/travis/build_docs.sh
@@ -8,7 +8,7 @@ fi
 
 cd docs
 echo "building docs for $TRAVIS_BUILD_DIR/docs"
-docker run --user $(id -u):$(id -g) -v $TRAVIS_BUILD_DIR:/data -w /data/docs osgeo/proj-docs make html
-docker run --user $(id -u):$(id -g) -v $TRAVIS_BUILD_DIR:/data -w /data/docs osgeo/proj-docs make latexpdf
+docker run --user $(id -u):$(id -g) -v $TRAVIS_BUILD_DIR:/data -w /data/docs ghcr.io/osgeo/proj-docs make html
+docker run --user $(id -u):$(id -g) -v $TRAVIS_BUILD_DIR:/data -w /data/docs ghcr.io/osgeo/proj-docs make latexpdf
 
 

--- a/travis/docker.sh
+++ b/travis/docker.sh
@@ -5,6 +5,6 @@
 # it is build from docs/docbuild/Dockerfile
 # and is manually pushed as needed to DockerHub
 
-docker pull osgeo/proj-docs
+docker pull ghcr.io/osgeo/proj-docs
 
 


### PR DESCRIPTION
Backport #3665
 **Authored by:** @rouault