### PR TITLE
[Backport 9.2] Coord. operation factory: count identified concatenated operations as a single step

### DIFF
--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -1478,7 +1478,12 @@ struct FilterResults {
             const auto curAccuracy = getAccuracy(op);
             bool dummy = false;
             const auto curExtent = getExtent(op, true, dummy);
-            const auto curStepCount = getTransformationStepCount(op);
+            // If a concatenated operation has an identifier, consider it as
+            // a single step (to be opposed to synthetized concatenated
+            // operations). Helps for example to get EPSG:8537,
+            // "Egypt 1907 to WGS 84 (2)"
+            const auto curStepCount =
+                op->identifiers().empty() ? getTransformationStepCount(op) : 1;
 
             if (first) {
                 resTemp.emplace_back(op);

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -1059,7 +1059,7 @@ TEST(operation, geogCRS_to_geogCRS_context_concatenated_operation) {
         authFactory->createCoordinateReferenceSystem("4807"), // NTF(Paris)
         authFactory->createCoordinateReferenceSystem("4171"), // RGF93
         ctxt);
-    ASSERT_EQ(list.size(), 4U);
+    ASSERT_EQ(list.size(), 2U);
 
     EXPECT_EQ(list[0]->nameStr(), "NTF (Paris) to RGF93 v1 (1)");
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
@@ -1088,6 +1088,24 @@ TEST(operation, geogCRS_to_geogCRS_context_concatenated_operation) {
                 nullptr);
     auto grids = list[0]->gridsNeeded(DatabaseContext::create(), false);
     EXPECT_EQ(grids.size(), 1U);
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(operation,
+     geogCRS_to_geogCRS_context_concatenated_operation_Egypt1907_to_WGS84) {
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    auto list = CoordinateOperationFactory::create()->createOperations(
+        authFactory->createCoordinateReferenceSystem("4229"), // Egypt 1907
+        authFactory->createCoordinateReferenceSystem("4326"), // WGS84
+        ctxt);
+    ASSERT_EQ(list.size(), 3U);
+    // Concatenated operation
+    EXPECT_EQ(list[1]->nameStr(), "Egypt 1907 to WGS 84 (2)");
+    ASSERT_EQ(list[1]->coordinateOperationAccuracies().size(), 1U);
+    EXPECT_EQ(list[1]->coordinateOperationAccuracies()[0]->value(), "6.0");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Backport #3673
 **Authored by:** @rouault