### PR TITLE
Update helmert.rst

### DIFF
--- a/docs/source/operations/transformations/helmert.rst
+++ b/docs/source/operations/transformations/helmert.rst
@@ -331,7 +331,7 @@ The three rotation matrices can be combined in one:
 .. math::
 
     \begin{align}
-        \mathbf{R} = \mathbf{R_X} \mathbf{R_Y} \mathbf{R_Y}
+        \mathbf{R} = \mathbf{R_X} \mathbf{R_Y} \mathbf{R_Z}
     \end{align}
 
 


### PR DESCRIPTION
The section on 3D helmert had the specification 2x for R_Y, instead of R_Y and R_Z, Fixing as:


    \begin{align}
        \mathbf{R} = \mathbf{R_X} \mathbf{R_Y} \mathbf{R_Z}
    \end{align}

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API