### PR TITLE
[Backport 9.2] CMake: avoid imbalanced cmake_policy push/pop if TIFF or CURL dependency cannot be found (fixes #3696)

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -13,12 +13,25 @@ endif()
 
 include(CMakeFindDependencyMacro)
 
+# We cannot have a find_dependency() call between cmake_policy(PUSH)/cmake_policy(POP)
+# because find_dependency() issues a return() on failure, which results in
+# imbalanced push/pop
+# Cf https://gitlab.kitware.com/cmake/cmake/-/issues/17612
 cmake_policy(PUSH)
 cmake_policy(SET CMP0012 NEW)
 if("@ENABLE_TIFF@")
-    find_dependency(TIFF)
+    set(PROJ_CONFIG_FIND_TIFF_DEP ON)
 endif()
 if("@CURL_ENABLED@")
+    set(PROJ_CONFIG_FIND_CURL_DEP ON)
+endif()
+cmake_policy(POP)
+
+if(DEFINED PROJ_CONFIG_FIND_TIFF_DEP)
+    find_dependency(TIFF)
+endif()
+
+if(DEFINED PROJ_CONFIG_FIND_CURL_DEP)
   # Chainload CURL usage requirements
   find_dependency(CURL)
   # Target CURL::libcurl only defined since CMake 3.12
@@ -30,7 +43,6 @@ if("@CURL_ENABLED@")
       )
   endif()
 endif()
-cmake_policy(POP)
 
 function(set_variable_from_rel_or_absolute_path var root rel_or_abs_path)
   if(IS_ABSOLUTE "${rel_or_abs_path}")


### PR DESCRIPTION
Backport #3697
 **Authored by:** @rouault