### PR TITLE
proj_create_crs_to_crs(): restore behaviour of PROJ 9.1

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -3250,6 +3250,17 @@ bool DatabaseContext::lookForGridInfo(
     bool &directDownload, bool &openLicense, bool &gridAvailable) const {
     Private::GridInfoCache info;
 
+    if (projFilename == "null") {
+        // Special case for implicit "null" grid.
+        fullFilename.clear();
+        packageName.clear();
+        url.clear();
+        directDownload = false;
+        openLicense = true;
+        gridAvailable = true;
+        return true;
+    }
+
     auto ctxt = d->pjCtxt();
     if (ctxt == nullptr) {
         ctxt = pj_get_default_ctx();

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1218,6 +1218,36 @@ EOF
 rm -rf tmp_dir
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+echo 39 -3 0 | PROJ_DATA=tmp_dir PROJ_DEBUG=2 $EXE EPSG:4326+5773 EPSG:4326+5782 -E 2>&1|grep -v pj_open_lib >> ${OUT}
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) --only-best=no with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+echo 39 -3 0 | PROJ_DATA=tmp_dir PROJ_DEBUG=2 $EXE --only-best=no EPSG:4326+5773 EPSG:4326+5782 -E 2>&1|grep -v pj_open_lib >> ${OUT}
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs (grid missing) --only-best with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+echo 39 -3 0 | PROJ_DISPLAY_PROGRAM_NAME=NO PROJ_DATA=tmp_dir PROJ_DEBUG=2 $EXE --only-best EPSG:4326+5773 EPSG:4326+5782 -E 2>&1|grep -v pj_open_lib >> ${OUT}
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
 echo "Test Similarity Transformation (example from EPSG Guidance Note 7.2)" >> ${OUT}
 #
 $EXE -d 3 EPSG:23031 EPSG:25831 -E >>${OUT} 2>&1 <<EOF

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -592,6 +592,21 @@ Test cs2cs (grid missing) with scenario of https://github.com/OSGeo/PROJ/issues/
 569704.5660295591 4269024.671083651	569720.46	4268813.88 0.00
 569704.5660295591 4269024.671083651	569720.46	4268813.88 0.00
 ##############################################################
+Test cs2cs (grid missing) with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html
+Attempt to use coordinate operation Inverse of WGS 84 to EGM96 height (1) + ETRS89 to Alicante height (1) using ETRS89 to WGS 84 (1) failed. Grid es_ign_egm08-rednap.tif is not available. Consult https://proj.org/resource_files.html for guidance. Grid us_nga_egm96_15.tif is not available. Consult https://proj.org/resource_files.html for guidance. This might become an error in a future PROJ major release. Set the ONLY_BEST option to YES or NO. This warning will no longer be emitted (for the current transformation instance).
+Using coordinate operation Transformation from EGM96 height to Alicante height (ballpark vertical transformation)
+39 -3 0	39.00	-3.00 0.00
+##############################################################
+Test cs2cs (grid missing) --only-best=no with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html
+39 -3 0	39.00	-3.00 0.00
+##############################################################
+Test cs2cs (grid missing) --only-best with scenario of https://lists.osgeo.org/pipermail/proj/2023-April/011003.html
+Attempt to use coordinate operation Inverse of WGS 84 to EGM96 height (1) + ETRS89 to Alicante height (1) using ETRS89 to WGS 84 (1) failed. Grid es_ign_egm08-rednap.tif is not available. Consult https://proj.org/resource_files.html for guidance. Grid us_nga_egm96_15.tif is not available. Consult https://proj.org/resource_files.html for guidance.
+
+cannot initialize transformation
+cause: File not found or invalid
+program abnormally terminated
+##############################################################
 Test Similarity Transformation (example from EPSG Guidance Note 7.2)
 300000 4500000	299905.060	4499796.515 0.000
 ##############################################################

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -5976,7 +5976,7 @@ TEST(operation, vertCRS_to_vertCRS_context) {
         authFactory->createCoordinateReferenceSystem("7968"),
         // NAVD88 height (1)
         authFactory->createCoordinateReferenceSystem("5703"), ctxt);
-    ASSERT_EQ(list.size(), 3U);
+    ASSERT_EQ(list.size(), 4U);
     EXPECT_EQ(list[0]->nameStr(), "NGVD29 height (m) to NAVD88 height (3)");
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=vgridshift +grids=us_noaa_vertcone.tif +multiplier=1");
@@ -5993,7 +5993,7 @@ TEST(operation, vertCRS_to_vertCRS_New_Zealand_context) {
         authFactory->createCoordinateReferenceSystem("7839"),
         // Auckland 1946 height
         authFactory->createCoordinateReferenceSystem("5759"), ctxt);
-    ASSERT_EQ(list.size(), 1U);
+    ASSERT_EQ(list.size(), 2U);
     EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=vgridshift +grids=nz_linz_auckht1946-nzvd2016.tif "
               "+multiplier=1");


### PR DESCRIPTION
proj_create_crs_to_crs(): restore behaviour of PROJ 9.1

Fixes https://lists.osgeo.org/pipermail/proj/2023-April/011003.html
that is ``cs2cs EPSG:4326+5773 EPSG:4326+5782`` without grids available.

Fixes situations where getting operations in PROJ_GRID_AVAILABILITY_KNOWN_AVAILABLE
mode returns one single gridded operations where the grid isn't available or
a ballpark operation.
We retry in PROJ_GRID_AVAILABILITY_DISCARD_OPERATION_IF_MISSING_GRID
mode to get a potential ballpark operation.

Follow-up to similar fix of https://github.com/OSGeo/PROJ/pull/3614
