### PR TITLE
[Backport 9.2] CI: upgrade vcpkg tag used for AppVeyor; use --triplet option

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,9 +46,7 @@ jobs:
         shell: cmd
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-            vcpkg install sqlite3[core,tool]:${{ env.ARCH }}-windows
-            vcpkg install tiff:${{ env.ARCH }}-windows
-            vcpkg install curl:${{ env.ARCH }}-windows
+            vcpkg install sqlite3[core,tool] tiff curl --triplet=${{ env.ARCH }}-windows
 
       - name: Build
         shell: cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,10 @@ build_script:
   # The checkout of a precise sha1 for VS2015 is a workaround for https://github.com/microsoft/vcpkg/issues/11666
   - if not exist %VCPKG_INSTALLED%\bin (
       cd "%VCPKG_ROOT%" &
-      git fetch --depth=1 origin 2022.04.12 &
+      git fetch --depth=1 origin 2023.04.15 &
       (if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (git -c advice.detachedHead=false checkout FETCH_HEAD)) &
       .\bootstrap-vcpkg.bat -disableMetrics &
-      vcpkg install curl sqlite3[core,tool] tiff &
+      vcpkg install sqlite3[core,tool] tiff curl --triplet=%platform%-windows &
       cd %APPVEYOR_BUILD_FOLDER%
     )
   - dir %VCPKG_INSTALLED%\bin

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -400,8 +400,8 @@ Install PROJ dependencies
 
 ::
 
-    vcpkg.exe install sqlite3[core,tool]:x86-windows tiff:x86-windows curl:x86-windows
-    vcpkg.exe install sqlite3[core,tool]:x64-windows tiff:x64-windows curl:x64-windows
+    vcpkg install sqlite3[core,tool] tiff curl --triplet=x86-windows
+    vcpkg install sqlite3[core,tool] tiff curl --triplet=x64-windows
 
 .. note:: The tiff and curl dependencies are only needed since PROJ 7.0
 

--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -325,7 +325,7 @@ bool PJCoordOperation::isInstantiable() const {
     /**************************************************************************************/
     if (isInstantiableCached == INSTANTIABLE_STATUS_UNKNOWN)
         isInstantiableCached = proj_coordoperation_is_instantiable(pj->ctx, pj);
-    return bool(isInstantiableCached);
+    return (isInstantiableCached == 1);
 }
 //! @endcond
 

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -9064,7 +9064,7 @@ PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj) {
                             std::swap(maxxDst, maxyDst);
                         }
                     }
-                    ctx->forceOver = alt.pj->over;
+                    ctx->forceOver = alt.pj->over != 0;
                     auto pjNormalized =
                         pj_obj_create(ctx, co->normalizeForVisualization());
                     pjNormalized->over = alt.pj->over;
@@ -9103,7 +9103,7 @@ PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj) {
         return nullptr;
     }
     try {
-        ctx->forceOver = obj->over;
+        ctx->forceOver = obj->over != 0;
         auto pjNormalized = pj_obj_create(ctx, co->normalizeForVisualization());
         pjNormalized->over = obj->over;
         ctx->forceOver = false;


### PR DESCRIPTION
Backport #3712
 **Authored by:** @mwtoews