### PR TITLE
[Backport 9.2] Fix unreleased regression related to 78d563c97f4920c58a4f04d4a5058df41720fd8c, that caused GDAL's test_gdalwarp_lib_135 test to fail

### DIFF
--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -297,7 +297,9 @@ bool CoordinateOperation::isPROJInstantiable(
     }
     for (const auto &gridDesc :
          gridsNeeded(databaseContext, considerKnownGridsAsAvailable)) {
-        if (!gridDesc.available) {
+        // Grid name starting with @ are considered as optional.
+        if (!gridDesc.available &&
+            (gridDesc.shortName.empty() || gridDesc.shortName[0] != '@')) {
             return false;
         }
     }

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1248,6 +1248,13 @@ echo 39 -3 0 | PROJ_DISPLAY_PROGRAM_NAME=NO PROJ_DATA=tmp_dir PROJ_DEBUG=2 $EXE 
 rm -rf tmp_dir
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs grid missing with @gridname" >> ${OUT}
+
+$EXE +proj=longlat +datum=WGS84 +units=m +geoidgrids=@i_dont_exist.tif +vunits=m +no_defs +type=crs +to EPSG:4979 >> ${OUT} <<EOF
+2 49 0
+EOF
+
+echo "##############################################################" >> ${OUT}
 echo "Test Similarity Transformation (example from EPSG Guidance Note 7.2)" >> ${OUT}
 #
 $EXE -d 3 EPSG:23031 EPSG:25831 -E >>${OUT} 2>&1 <<EOF

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -607,6 +607,9 @@ cannot initialize transformation
 cause: File not found or invalid
 program abnormally terminated
 ##############################################################
+Test cs2cs grid missing with @gridname
+49dN	2dE 0.000
+##############################################################
 Test Similarity Transformation (example from EPSG Guidance Note 7.2)
 300000 4500000	299905.060	4499796.515 0.000
 ##############################################################


### PR DESCRIPTION
Backport #3724
 **Authored by:** @rouault