### PR TITLE
CRS instanciation from PROJ.4 string: set 'Unknown based on XXXX ellipsoid' datum name...

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -10365,7 +10365,7 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
                 return GeodeticReferenceFrame::create(
                     grfMap.set(IdentifiedObject::NAME_KEY,
                                title.empty()
-                                   ? "Unknown based on WGS84 ellipsoid" +
+                                   ? "Unknown based on WGS 84 ellipsoid" +
                                          datumNameSuffix
                                    : title),
                     Ellipsoid::WGS84, optionalEmptyString, pm);
@@ -10373,7 +10373,7 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
                 return GeodeticReferenceFrame::create(
                     grfMap.set(IdentifiedObject::NAME_KEY,
                                title.empty()
-                                   ? "Unknown based on GRS80 ellipsoid" +
+                                   ? "Unknown based on GRS 1980 ellipsoid" +
                                          datumNameSuffix
                                    : title),
                     Ellipsoid::GRS1980, optionalEmptyString, pm);
@@ -10441,10 +10441,20 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
     const auto createGRF = [&grfMap, &title, &optionalEmptyString,
                             &datumNameSuffix,
                             &pm](const EllipsoidNNPtr &ellipsoid) {
+        std::string datumName(title);
+        if (title.empty()) {
+            if (ellipsoid->nameStr() != "unknown") {
+                datumName = "Unknown based on ";
+                datumName += ellipsoid->nameStr();
+                datumName += " ellipsoid";
+            } else {
+                datumName = "unknown";
+            }
+            datumName += datumNameSuffix;
+        }
         return GeodeticReferenceFrame::create(
-            grfMap.set(IdentifiedObject::NAME_KEY,
-                       title.empty() ? "unknown" + datumNameSuffix : title),
-            ellipsoid, optionalEmptyString, fixupPrimeMeridan(ellipsoid, pm));
+            grfMap.set(IdentifiedObject::NAME_KEY, datumName), ellipsoid,
+            optionalEmptyString, fixupPrimeMeridan(ellipsoid, pm));
     };
 
     if (a > 0 && (b > 0 || !bStr.empty())) {

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -9656,7 +9656,7 @@ TEST(io, projparse_longlat_ellps_WGS84) {
     f->simulCurNodeHasId();
     crs->exportToWKT(f.get());
     auto expected = "GEODCRS[\"unknown\",\n"
-                    "    DATUM[\"Unknown based on WGS84 ellipsoid\",\n"
+                    "    DATUM[\"Unknown based on WGS 84 ellipsoid\",\n"
                     "        ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n"
                     "            LENGTHUNIT[\"metre\",1]]],\n"
                     "    PRIMEM[\"Greenwich\",0,\n"
@@ -9682,7 +9682,7 @@ TEST(io, projparse_longlat_ellps_GRS80) {
     f->simulCurNodeHasId();
     crs->exportToWKT(f.get());
     auto expected = "GEODCRS[\"unknown\",\n"
-                    "    DATUM[\"Unknown based on GRS80 ellipsoid\",\n"
+                    "    DATUM[\"Unknown based on GRS 1980 ellipsoid\",\n"
                     "        ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
                     "            LENGTHUNIT[\"metre\",1]]],\n"
                     "    PRIMEM[\"Greenwich\",0,\n"
@@ -9735,7 +9735,7 @@ TEST(io, projparse_longlat_a_rf_WGS84) {
     f->simulCurNodeHasId();
     crs->exportToWKT(f.get());
     auto expected = "GEODCRS[\"unknown\",\n"
-                    "    DATUM[\"unknown\",\n"
+                    "    DATUM[\"Unknown based on WGS 84 ellipsoid\",\n"
                     "        ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n"
                     "            LENGTHUNIT[\"metre\",1]]],\n"
                     "    PRIMEM[\"Greenwich\",0,\n"
@@ -11621,7 +11621,7 @@ TEST(io, projparse_geocent) {
     f->setMultiLine(false);
     crs->exportToWKT(f.get());
     auto wkt = f->toString();
-    EXPECT_EQ(wkt, "GEODCRS[\"unknown\",DATUM[\"Unknown based on WGS84 "
+    EXPECT_EQ(wkt, "GEODCRS[\"unknown\",DATUM[\"Unknown based on WGS 84 "
                    "ellipsoid\",ELLIPSOID[\"WGS "
                    "84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],"
                    "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0."


### PR DESCRIPTION
...when instanciating from known +a,+rf

and change WGS84 -> WGS 84 and GRS80 -> GRS 1980 to use EPSG names when building from +ellps=WGS84/GRS80 (fixes #3725)

Now we get
```
$ bin/projinfo  "+proj=geos +lon_0=0 +h=35786400 +ellps=WGS84 +units=m +sweep=y +no_defs +type=crs"
PROJ.4 string:
+proj=geos +lon_0=0 +h=35786400 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs +type=crs

WKT2:2019 string:
PROJCRS["unknown",
    BASEGEOGCRS["unknown",
        DATUM["Unknown based on WGS 84 ellipsoid",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1],
                ID["EPSG",7030]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8901]]],
    CONVERSION["unknown",
        METHOD["Geostationary Satellite (Sweep Y)"],
        PARAMETER["Longitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["Satellite Height",35786400,
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        PARAMETER["False easting",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]]]

$ bin/projinfo  "+proj=geos +lon_0=0 +h=35786400 +a=6378137.0 +rf=298.257223563 +units=m +sweep=y +no_defs +type=crs"
PROJ.4 string:
+proj=geos +lon_0=0 +h=35786400 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs +type=crs

WKT2:2019 string:
PROJCRS["unknown",
    BASEGEOGCRS["unknown",
        DATUM["Unknown based on WGS 84 ellipsoid",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1,
                    ID["EPSG",9001]]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8901]]],
    CONVERSION["unknown",
        METHOD["Geostationary Satellite (Sweep Y)"],
        PARAMETER["Longitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["Satellite Height",35786400,
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        PARAMETER["False easting",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]]]
```
