### PR TITLE
cs2cs / proj_create_crs_to_crs(): fix regression with geocentric CRS

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -9073,7 +9073,8 @@ PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj) {
                         alt.idxInOriginalList, minxSrc, minySrc, maxxSrc,
                         maxySrc, minxDst, minyDst, maxxDst, maxyDst,
                         pjNormalized, co->nameStr(), alt.accuracy,
-                        alt.isOffshore);
+                        alt.isOffshore, alt.pjSrcGeocentricToLonLat,
+                        alt.pjDstGeocentricToLonLat);
                 }
             }
             return pjNew.release();

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1255,6 +1255,58 @@ $EXE +proj=longlat +datum=WGS84 +units=m +geoidgrids=@i_dont_exist.tif +vunits=m
 EOF
 
 echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geographic -> geocentric using BETA2007.gsb grid" >> ${OUT}
+
+$EXE EPSG:4746 EPSG:4978 >> ${OUT} <<EOF
+50.5 10 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geocentric -> geographic using BETA2007.gsb grid" >> ${OUT}
+
+$EXE EPSG:4978 EPSG:4746 >> ${OUT} <<EOF
+4003461.55 705832.08 4898267.79
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geographic -> geocentric, normally using BETA2007.gsb grid but missing" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+PROJ_DATA=tmp_dir $EXE EPSG:4746 EPSG:4978 >> ${OUT} <<EOF
+50.5 10 0
+EOF
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geocentric -> geographic, normally using BETA2007.gsb grid but missing" >> ${OUT}
+
+mkdir tmp_dir
+cp $PROJ_DATA/proj.db tmp_dir
+
+PROJ_DATA=tmp_dir $EXE EPSG:4978 EPSG:4746 >> ${OUT} <<EOF
+4003461.37 705832.04 4898267.94
+EOF
+
+rm -rf tmp_dir
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geographic -> geocentric outside BETA2007.gsb grid" >> ${OUT}
+
+$EXE EPSG:4746 EPSG:4978 >> ${OUT} <<EOF
+49 2 0
+EOF
+
+echo "##############################################################" >> ${OUT}
+echo "Test cs2cs geocentric -> geographic outside BETA2007.gsb grid" >> ${OUT}
+
+$EXE EPSG:4978 EPSG:4746  >> ${OUT} <<EOF
+4189881.02 146313.87 4790558.75
+EOF
+
+echo "##############################################################" >> ${OUT}
 echo "Test Similarity Transformation (example from EPSG Guidance Note 7.2)" >> ${OUT}
 #
 $EXE -d 3 EPSG:23031 EPSG:25831 -E >>${OUT} 2>&1 <<EOF

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -610,6 +610,24 @@ program abnormally terminated
 Test cs2cs grid missing with @gridname
 49dN	2dE 0.000
 ##############################################################
+Test cs2cs geographic -> geocentric using BETA2007.gsb grid
+4003461.55	705832.08 4898267.79
+##############################################################
+Test cs2cs geocentric -> geographic using BETA2007.gsb grid
+50d30'N	10dE -0.001
+##############################################################
+Test cs2cs geographic -> geocentric, normally using BETA2007.gsb grid but missing
+4003461.37	705832.04 4898267.94
+##############################################################
+Test cs2cs geocentric -> geographic, normally using BETA2007.gsb grid but missing
+50d30'N	10dE -0.002
+##############################################################
+Test cs2cs geographic -> geocentric outside BETA2007.gsb grid
+4189881.02	146313.87 4790558.75
+##############################################################
+Test cs2cs geocentric -> geographic outside BETA2007.gsb grid
+49dN	2dE 0.002
+##############################################################
 Test Similarity Transformation (example from EPSG Guidance Note 7.2)
 300000 4500000	299905.060	4499796.515 0.000
 ##############################################################


### PR DESCRIPTION
Related to use case of https://github.com/OSGeo/gdal/issues/7753

When a transformation involved a datum shift with a grid and a geocentric CRS as source/target, since PROJ 9.2.0 and the changes for the only_best mode, even in just warning mode, if the grid of the "best" transformation was missing, then the transformation would completely fail, whereas with earlier versions it would fallback to a ballpark transformation. So restore that mode, and actually enhance the operation selection logic, by allowing to select operations based on their area of validity even if the input coordinate are geocentric (in which case a conversion of them to geographic is done).
