### PR TITLE
[Backport 9.2] proj_trans(): set PROJ_ERR_COORD_TRANSFM_NO_OPERATION error when failing in ONLY_BEST=YES mode

### DIFF
--- a/src/4D_api.cpp
+++ b/src/4D_api.cpp
@@ -443,8 +443,10 @@ PJ_COORD proj_trans(PJ *P, PJ_DIRECTION direction, PJ_COORD coord) {
             } else if (P->errorIfBestTransformationNotAvailable ||
                        P->warnIfBestTransformationNotAvailable) {
                 warnAboutMissingGrid(alt.pj);
-                if (P->errorIfBestTransformationNotAvailable)
+                if (P->errorIfBestTransformationNotAvailable) {
+                    proj_errno_set(P, PROJ_ERR_COORD_TRANSFM_NO_OPERATION);
                     return res;
+                }
                 P->warnIfBestTransformationNotAvailable = false;
                 skipNonInstantiable = true;
             }


### PR DESCRIPTION
Backport #3730
 **Authored by:** @rouault