### PR TITLE
GeographicBoundingBox::intersection(): avoid infinite recursion and stack overflow on invalid bounding boxes

### DIFF
--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -421,6 +421,13 @@ GeographicBoundingBox::Private::intersection(const Private &otherExtent) const {
             return nullptr;
         }
 
+        // Bail out on longitudes not in [-180,180]. We could probably make
+        // some sense of them, but this check at least avoid potential infinite
+        // recursion.
+        if (oW > 180 || oE < -180) {
+            return nullptr;
+        }
+
         // Return larger of two parts of the multipolygon
         auto inter1 = intersection(Private(oW, oS, 180.0, oN));
         auto inter2 = intersection(Private(-180.0, oS, oE, oN));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,3 +108,8 @@ proj_add_gie_test("GIGS-5208" "gigs/5208.gie")
 add_subdirectory(cli)
 add_subdirectory(unit)
 add_subdirectory(benchmark)
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fuzzers")
+  add_subdirectory(fuzzers)
+endif()
+
+

--- a/test/fuzzers/CMakeLists.txt
+++ b/test/fuzzers/CMakeLists.txt
@@ -1,0 +1,8 @@
+if(NOT WIN32)
+
+  add_compile_options(${PROJ_CXX_WARN_FLAGS})
+
+  add_executable(proj_crs_to_crs_fuzzer proj_crs_to_crs_fuzzer.cpp)
+  target_compile_definitions(proj_crs_to_crs_fuzzer PRIVATE -DSTANDALONE)
+  target_link_libraries(proj_crs_to_crs_fuzzer PRIVATE ${PROJ_LIBRARIES})
+endif()

--- a/test/fuzzers/README.TXT
+++ b/test/fuzzers/README.TXT
@@ -8,12 +8,11 @@ and call scripts in this directory.
 The list of issues is in:
 https://bugs.chromium.org/p/oss-fuzz/issues/list?q=proj4
 
-- Build standard_fuzzer in a standalone mode:
-
-    $ g++ -g -std=c++11 standard_fuzzer.cpp -o standard_fuzzer -fvisibility=hidden -DSTANDALONE ../../build/lib/libproj.a -lpthread -lsqlite3 -I../../src -I../../include
+- Build proj_crs_to_crs_fuzzer in a standalone mode with the
+  -DBUILD_TESTING=ON CMake options
 
   Run it:
-    $ PROJ_DATA=../../data ./standard_fuzzer {file_generated_by_oss_fuzz}
+    $ bin/proj_crs_to_crs_fuzzer {file_generated_by_oss_fuzz}
 
 - Run locally OSS Fuzz:
     $ git clone https://github.com/google/oss-fuzz.git
@@ -24,8 +23,8 @@ https://bugs.chromium.org/p/oss-fuzz/issues/list?q=proj4
   Build fuzzers with the address sanitizer (could use undefined, etc...)
     $ python infra/helper.py build_fuzzers --sanitizer address $PROJECT_NAME
 
-  Test a particular fuzzer (replace standard_fuzzer by other fuzzers)
-    $ python infra/helper.py run_fuzzer $PROJECT_NAME standard_fuzzer
+  Test a particular fuzzer (replace proj_crs_to_crs_fuzzer by other fuzzers)
+    $ python infra/helper.py run_fuzzer $PROJECT_NAME proj_crs_to_crs_fuzzer
 
 
 How to deal with issues reported in https://bugs.chromium.org/p/oss-fuzz/issues/list?q=proj4 ?

--- a/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
+++ b/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
@@ -124,7 +124,12 @@ int main(int argc, char *argv[]) {
             fclose(f);
             exit(1);
         }
-        fread(buf, nLen, 1, f);
+        if (fread(buf, nLen, 1, f) != 1) {
+            fprintf(stderr, "fread failed.\n");
+            fclose(f);
+            free(buf);
+            exit(1);
+        }
         fclose(f);
         nRet = LLVMFuzzerTestOneInput((const uint8_t *)(buf), nLen);
         free(buf);

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -284,13 +284,15 @@ TEST(metadata, extent_edge_cases) {
         optional<std::string>(), std::vector<GeographicExtentNNPtr>(),
         std::vector<VerticalExtentNNPtr>(), std::vector<TemporalExtentNNPtr>());
 
-    auto A = Extent::createFromBBOX(-180, -90, 180, 90);
-    auto B = Extent::createFromBBOX(180, -90, 180, 90);
-    EXPECT_FALSE(A->intersects(B));
-    EXPECT_FALSE(B->intersects(A));
-    EXPECT_FALSE(A->contains(B));
-    EXPECT_TRUE(A->intersection(B) == nullptr);
-    EXPECT_TRUE(B->intersection(A) == nullptr);
+    {
+        auto A = Extent::createFromBBOX(-180, -90, 180, 90);
+        auto B = Extent::createFromBBOX(180, -90, 180, 90);
+        EXPECT_FALSE(A->intersects(B));
+        EXPECT_FALSE(B->intersects(A));
+        EXPECT_FALSE(A->contains(B));
+        EXPECT_TRUE(A->intersection(B) == nullptr);
+        EXPECT_TRUE(B->intersection(A) == nullptr);
+    }
 
     EXPECT_THROW(Extent::createFromBBOX(
                      std::numeric_limits<double>::quiet_NaN(), -90, 180, 90),
@@ -304,6 +306,20 @@ TEST(metadata, extent_edge_cases) {
     EXPECT_THROW(Extent::createFromBBOX(
                      -180, -90, 180, std::numeric_limits<double>::quiet_NaN()),
                  InvalidValueTypeException);
+
+    // Scenario of https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57328
+    {
+        auto A = Extent::createFromBBOX(0, 1, 2, 3);
+        auto B = Extent::createFromBBOX(200, -80, -100, 80);
+        EXPECT_TRUE(A->intersection(B) == nullptr);
+        EXPECT_TRUE(B->intersection(A) == nullptr);
+    }
+    {
+        auto A = Extent::createFromBBOX(0, 1, 2, 3);
+        auto B = Extent::createFromBBOX(100, -80, -200, 80);
+        EXPECT_TRUE(A->intersection(B) == nullptr);
+        EXPECT_TRUE(B->intersection(A) == nullptr);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57328
