### PR TITLE
Fix proj-config.cmake to not try including proj4-targets.cmake in INSTALL_LEGACY_CMAKE_FILES=OFF mode

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -63,7 +63,9 @@ set_variable_from_rel_or_absolute_path("@PROJECT_VARIANT_NAME@_BINARY_DIRS" "${_
 set (@PROJECT_VARIANT_NAME@_LIBRARIES @PROJECT_VARIANT_NAME@::proj)
 # Read in the exported definition of the library
 include ("${_DIR}/@PROJECT_NAME_LOWER@-targets.cmake")
-include ("${_DIR}/@PROJECT_LEGACY_LOWER@-targets.cmake")
+if (@INSTALL_LEGACY_CMAKE_FILES@)
+  include ("${_DIR}/@PROJECT_LEGACY_LOWER@-targets.cmake")
+endif()
 
 unset (_ROOT)
 unset (_DIR)

--- a/test/postinstall/test_cmake.sh
+++ b/test/postinstall/test_cmake.sh
@@ -5,11 +5,21 @@
 # First required argument is the installed prefix, which
 # is used to set CMAKE_PREFIX_PATH
 # Second argument is either shared (default) or static
+# Third argument is either BOTH_CONFIG (default), to test both PROJ and PROJ4
+# CMake configurations, or PROJ_CONFIG to only test PROJ.
 cd $(dirname $0)
 . ./common.sh
 main_setup $1 $2
 
-echo "Running post-install tests with CMake (${BUILD_MODE})"
+case $3 in
+"" | BOTH_CONFIG) export TESTED_CONFIGS=BOTH_CONFIG ;;
+     PROJ_CONFIG) export TESTED_CONFIGS=PROJ_CONFIG ;;
+*)
+  echo "Third argument must be either BOTH_CONFIG (default) or PROJ_CONFIG"
+  exit 1 ;;
+esac
+
+echo "Running post-install tests with CMake (${BUILD_MODE}, ${TESTED_CONFIGS})"
 
 
 cmake_make_ctest(){
@@ -28,13 +38,17 @@ cmake_make_ctest(){
 echo "Testing C app"
 cd c_app
 cmake_make_ctest PROJ
-cmake_make_ctest PROJ4
+if test "${TESTED_CONFIGS}" = "BOTH_CONFIG"; then
+    cmake_make_ctest PROJ4
+fi
 cd ..
 
 echo "Testing C++ app"
 cd cpp_app
 cmake_make_ctest PROJ
-cmake_make_ctest PROJ4
+if test "${TESTED_CONFIGS}" = "BOTH_CONFIG"; then
+    cmake_make_ctest PROJ4
+fi
 cd ..
 
-echo "Finished running post-install tests CMake (${BUILD_MODE})"
+echo "Finished running post-install tests CMake (${BUILD_MODE}, ${TESTED_CONFIGS})"

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -92,11 +92,13 @@ cd ..
 mkdir static_build
 cd static_build
 # Also test setting CMAKE_INSTALL_INCLUDEDIR/CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR to absolute directories
+# and INSTALL_LEGACY_CMAKE_FILES=OFF (both are independent from static build particularities)
 cmake \
   -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -D USE_CCACHE=${USE_CCACHE} \
   -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
   -D BUILD_SHARED_LIBS=OFF \
+  -D INSTALL_LEGACY_CMAKE_FILES=OFF \
   -D CMAKE_INSTALL_PREFIX=/tmp/proj_static_install_from_dist \
   -D CMAKE_INSTALL_INCLUDEDIR=/tmp/proj_static_install_from_dist/include \
   -D CMAKE_INSTALL_LIBDIR=/tmp/proj_static_install_from_dist/lib \
@@ -107,7 +109,7 @@ make
 ctest --output-on-failure
 make install
 # find /tmp/proj_static_install_from_dist
-$TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist static
+$TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist static PROJ_CONFIG
 $TRAVIS_BUILD_DIR/test/postinstall/test_autotools.sh /tmp/proj_static_install_from_dist static
 
 # Re-run by unsetting CMAKE_INSTALL_INCLUDEDIR/CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR
@@ -209,7 +211,7 @@ else
 fi
 
 $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_shared_install_from_dist_renamed/subdir shared
-PROJ_DATA=/tmp/proj_static_install_from_dist_renamed/subdir/share/proj $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist_renamed/subdir static
+PROJ_DATA=/tmp/proj_static_install_from_dist_renamed/subdir/share/proj $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist_renamed/subdir static PROJ_CONFIG
 
 if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
     echo "Build PROJ as a subproject"


### PR DESCRIPTION
This is a follow-up to ad660a83982ec1cf85320f19036efbc16c9f00a1
