### PR TITLE
Always use the cleanest examples.

### DIFF
--- a/docs/source/apps/proj.rst
+++ b/docs/source/apps/proj.rst
@@ -192,13 +192,14 @@ The following script
 
 .. code-block:: console
 
-    proj +proj=utm +zone=12 +ellps=GRS80 -r <<EOF
+    proj +proj=utm +zone=12 -r <<EOF
     45d15'33.1" 111.5W
     45d15.551666667N -111d30
     +45.25919444444 111d30'000w
     EOF
 
 will perform UTM zone 12 forward projection.
+The default +ellps=GRS80 is used as no +ellps was specified.
 The geographic values of this example are equivalent
 and meant as examples of various forms of DMS input. The x-y output
 data will appear as three lines of::


### PR DESCRIPTION
Move repetitive default into text explanation.

P.S., maybe one day even consider changing the
default +ellps=GRS80 to +ellps=WGS84... but no big deal...
