### PR TITLE
Remove redundant optional default parameters!

### DIFF
--- a/docs/source/operations/projections/gall.rst
+++ b/docs/source/operations/projections/gall.rst
@@ -49,12 +49,12 @@ Unlike the Mercator, the Gall shows the poles as lines running across the top an
 
 Example using Gall Stereographic  ::
 
-    $ echo 9 51 | proj +proj=gall +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m
+    $ echo 9 51 | proj +proj=gall
     708432.90   5193386.36
 
 Example using Gall Stereographic (Central meridian 90°W) ::
 
-    $ echo 9 51 | proj +proj=gall +lon_0=90w +x_0=0 +y_0=0 +ellps=WGS84 +units=m
+    $ echo 9 51 | proj +proj=gall +lon_0=90w
     7792761.91  5193386.36
 
 Parameters


### PR DESCRIPTION
We get the exact same answer without the clutter that doesn't make things any more clearer.

No, even the  +ellps=WGS84 becoming GRS80 doesn't affect the answer, and just adds to the clutter.