### PR TITLE
Remove parameter that is default anyway

### DIFF
--- a/docs/source/operations/projections/healpix.rst
+++ b/docs/source/operations/projections/healpix.rst
@@ -40,7 +40,7 @@ Usage
 
 To run a forward HEALPix projection on a unit sphere model, use the following command::
 
-    proj +proj=healpix +lon_0=0 +a=1 -E <<EOF
+    proj +proj=healpix +a=1 -E <<EOF
     0 0
     EOF
     # output


### PR DESCRIPTION
Make example less cluttered.