### PR TITLE
Remove one repeated default parameter

### DIFF
--- a/docs/source/operations/projections/rhealpix.rst
+++ b/docs/source/operations/projections/rhealpix.rst
@@ -37,7 +37,7 @@ Usage
 To run a rHEALPix projection on a WGS84 ellipsoidal model, use the following
 command::
 
-    proj +proj=rhealpix -f '%.2f' +ellps=WGS84 +south_square=0 +north_square=2  -E << EOF
+    proj +proj=rhealpix -f '%.2f' +ellps=WGS84 +north_square=2 -E << EOF
     > 55 12
     > EOF
     55 12   6115727.86  1553840.13


### PR DESCRIPTION
Shorten example by removing repeated default parameter.
