### PR TITLE
fix building with GCC 13

### DIFF
--- a/src/proj_json_streaming_writer.hpp
+++ b/src/proj_json_streaming_writer.hpp
@@ -31,6 +31,7 @@
 
 /*! @cond Doxygen_Suppress */
 
+#include <cstdint>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
Building v7.2.1 against libstdc++ from GCC 13 fails because of `std::int64_t` being undefined. After adding the header `<cstdint>` header in one location, it is possible to build v7.2.1 with GCC 13.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [x] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API