### PR TITLE
Avoid C++ exceptions to be thrown (and caught) when parsing strings like '+proj=longlat +datum=WGS84 +type=crs'

### DIFF
--- a/include/proj/internal/internal.hpp
+++ b/include/proj/internal/internal.hpp
@@ -162,6 +162,9 @@ PROJ_FOR_TEST std::string toString(double val, int precision = 15);
 PROJ_FOR_TEST double
 c_locale_stod(const std::string &s); // throw(std::invalid_argument)
 
+// Variant of above that doesn't emit exceptions
+double c_locale_stod(const std::string &s, bool &success);
+
 std::string concat(const std::string &, const std::string &) = delete;
 std::string concat(const char *, const char *) = delete;
 std::string concat(const char *a, const std::string &b);

--- a/src/iso19111/internal.cpp
+++ b/src/iso19111/internal.cpp
@@ -240,7 +240,17 @@ bool ends_with(const std::string &str, const std::string &suffix) noexcept {
 // ---------------------------------------------------------------------------
 
 double c_locale_stod(const std::string &s) {
+    bool success;
+    double val = c_locale_stod(s, success);
+    if (!success) {
+        throw std::invalid_argument("non double value");
+    }
+    return val;
+}
 
+double c_locale_stod(const std::string &s, bool &success) {
+
+    success = true;
     const auto s_size = s.size();
     // Fast path
     if (s_size > 0 && s_size < 15) {
@@ -277,7 +287,8 @@ double c_locale_stod(const std::string &s) {
     double d;
     iss >> d;
     if (!iss.eof() || iss.fail()) {
-        throw std::invalid_argument("non double value");
+        success = false;
+        d = 0;
     }
     return d;
 }

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -10779,16 +10779,11 @@ SphericalCSNNPtr PROJStringParser::Private::buildSphericalCS(
 
 static double getNumericValue(const std::string &paramValue,
                               bool *pHasError = nullptr) {
-    try {
-        double value = c_locale_stod(paramValue);
-        if (pHasError)
-            *pHasError = false;
-        return value;
-    } catch (const std::invalid_argument &) {
-        if (pHasError)
-            *pHasError = true;
-        return 0.0;
-    }
+    bool success;
+    double value = c_locale_stod(paramValue, success);
+    if (pHasError)
+        *pHasError = !success;
+    return value;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This makes it more friendly with debuggers under Windows, and should help workarounding https://github.com/MapServer/MapServer/issues/6915 (note however that the issue in that ticket is more a 'system level' issue than a PROJ bug)
