### PR TITLE
Docker: update base image to ubuntu:22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # OSGeo/PROJ
 
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 MAINTAINER Howard Butler <howard@hobu.co>
 
@@ -27,7 +27,7 @@ RUN cd /PROJ \
 
 
 
-FROM ubuntu:20.04 as runner
+FROM ubuntu:22.04 as runner
 
 RUN date
 

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-dev python3-pip g++ doxygen dvipng latexmk \
     cmake libjpeg8-dev zlib1g-dev texlive-latex-base \
     texlive-latex-extra git latex-cjk-all texlive-lang-all \
-    graphviz python3-matplotlib wget unzip enchant locales
+    graphviz python3-matplotlib wget unzip enchant-2 locales
 
-RUN python3 -m pip install Sphinx breathe \
+RUN python3 -m pip install "Sphinx<7" breathe \
     sphinx_bootstrap_theme awscli sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     sphinxcontrib-spelling!=7.4.0


### PR DESCRIPTION
Upgrade the Ubuntu-based docker images to the latest Ubuntu LTS, with end of standard support in April 2027 and EOL 2032.

Specific motivation for Dockerfile is to use it with `pyproj` that requires python 3.9, which is no longer supported upstream and by many packages in use. Ubuntu 22.04 includes support for Python 3.10.

Images and docs (html) were built locally, and look fine.