### PR TITLE
Fix doc docker ubuntu 22.04

### DIFF
--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     graphviz python3-matplotlib wget unzip enchant-2 locales
 
 RUN python3 -m pip install "Sphinx<7" breathe \
-    sphinx_bootstrap_theme awscli sphinxcontrib-bibtex \
+    sphinx_bootstrap_theme sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     "sphinxcontrib-spelling!=7.4.0,<8"
 

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN python3 -m pip install "Sphinx<7" breathe \
     sphinx_bootstrap_theme awscli sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
-    sphinxcontrib-spelling!=7.4.0
+    "sphinxcontrib-spelling!=7.4.0,<8"
 
 # Set the locale for spelling
 RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
Trying to fix #3859 (the doc build part)

It removes `awscli` python dependency that was producing some problems. It also limits the version of `sphinxcontrib-spelling`.