### PR TITLE
[Backport 9.3] JSON export: avoid non-significant decimal digits in version field (fixes #3863)

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -5981,7 +5981,7 @@ IdentifierNNPtr JSONParser::buildId(const json &j, bool removeInverseOf) {
                 static_cast<int>(dblVersion) == dblVersion) {
                 version = internal::toString(static_cast<int>(dblVersion));
             } else {
-                version = internal::toString(dblVersion);
+                version = internal::toString(dblVersion, /*precision=*/15);
             }
         } else {
             throw ParsingException("Unexpected type for value of \"version\"");

--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1142,15 +1142,9 @@ void Identifier::_exportToJSON(JSONFormatter *formatter) const {
         if (!l_version.empty()) {
             writer->AddObjKey("version");
             bool isDouble = false;
-            const double dblVersion = c_locale_stod(l_version, isDouble);
+            (void)c_locale_stod(l_version, isDouble);
             if (isDouble) {
-                if (dblVersion >= std::numeric_limits<int>::min() &&
-                    dblVersion <= std::numeric_limits<int>::max() &&
-                    static_cast<int>(dblVersion) == dblVersion) {
-                    writer->Add(static_cast<int>(dblVersion));
-                } else {
-                    writer->Add(dblVersion, /*precision=*/15);
-                }
+                writer->AddUnquoted(l_version.c_str());
             } else {
                 writer->Add(l_version);
             }

--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1088,10 +1088,11 @@ void Identifier::_exportToWKT(WKTFormatter *formatter) const {
                 formatter->addQuotedString(l_code);
             }
             if (!l_version.empty()) {
-                try {
-                    (void)c_locale_stod(l_version);
+                bool isDouble = false;
+                (void)c_locale_stod(l_version, isDouble);
+                if (isDouble) {
                     formatter->add(l_version);
-                } catch (const std::exception &) {
+                } else {
                     formatter->addQuotedString(l_version);
                 }
             }
@@ -1140,16 +1141,17 @@ void Identifier::_exportToJSON(JSONFormatter *formatter) const {
 
         if (!l_version.empty()) {
             writer->AddObjKey("version");
-            try {
-                const double dblVersion = c_locale_stod(l_version);
+            bool isDouble = false;
+            const double dblVersion = c_locale_stod(l_version, isDouble);
+            if (isDouble) {
                 if (dblVersion >= std::numeric_limits<int>::min() &&
                     dblVersion <= std::numeric_limits<int>::max() &&
                     static_cast<int>(dblVersion) == dblVersion) {
                     writer->Add(static_cast<int>(dblVersion));
                 } else {
-                    writer->Add(dblVersion);
+                    writer->Add(dblVersion, /*precision=*/15);
                 }
-            } catch (const std::exception &) {
+            } else {
                 writer->Add(l_version);
             }
         }

--- a/src/proj_json_streaming_writer.cpp
+++ b/src/proj_json_streaming_writer.cpp
@@ -219,6 +219,11 @@ void CPLJSonStreamingWriter::Add(const char *pszStr) {
     Print(FormatString(pszStr));
 }
 
+void CPLJSonStreamingWriter::AddUnquoted(const char *pszStr) {
+    EmitCommaIfNeeded();
+    Print(pszStr);
+}
+
 void CPLJSonStreamingWriter::Add(GIntBig nVal) {
     EmitCommaIfNeeded();
     Print(CPLSPrintf(CPL_FRMT_GIB, nVal));

--- a/src/proj_json_streaming_writer.hpp
+++ b/src/proj_json_streaming_writer.hpp
@@ -86,6 +86,7 @@ class CPL_DLL CPLJSonStreamingWriter {
 
     void Add(const std::string &str);
     void Add(const char *pszStr);
+    void AddUnquoted(const char *pszStr);
     void Add(bool bVal);
     void Add(int nVal) { Add(static_cast<GIntBig>(nVal)); }
     void Add(unsigned int nVal) { Add(static_cast<GIntBig>(nVal)); }


### PR DESCRIPTION
Backport #3864
 **Authored by:** @rouault