### PR TITLE
[Backport 9.3] ESRI WKT import: normalize GCS_unknown to unknown and D_unknown to unknown (fixes #3871)

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -1732,6 +1732,8 @@ PropertyMap &WKTParser::Private::buildProperties(const WKTNodeNNPtr &node,
                 esriStyle_ = true;
                 if (name == "GCS_WGS_1984") {
                     name = "WGS 84";
+                } else if (name == "GCS_unknown") {
+                    name = "unknown";
                 } else {
                     tableNameForAlias = "geodetic_crs";
                 }
@@ -2376,6 +2378,8 @@ GeodeticReferenceFrameNNPtr WKTParser::Private::buildGeodeticReferenceFrame(
             name = "European Terrestrial Reference System 1989";
             authNameFromAlias = Identifier::EPSG;
             codeFromAlias = "6258";
+        } else if (name == "D_unknown") {
+            name = "unknown";
         } else {
             tableNameForAlias = "geodetic_datum";
         }

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -833,6 +833,19 @@ TEST(wkt_parse, wkt1_non_conformant_inf_inverse_flattening) {
 
 // ---------------------------------------------------------------------------
 
+TEST(wkt_parse, wkt1_esri_GCS_unknown_D_unknown) {
+    auto obj = WKTParser().setStrict(false).createFromWKT(
+        "GEOGCS[\"GCS_unknown\",DATUM[\"D_unknown\","
+        "SPHEROID[\"unknown\",6370997,0]],"
+        "PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.017453292519943295]]");
+    auto crs = nn_dynamic_pointer_cast<GeographicCRS>(obj);
+    ASSERT_TRUE(crs != nullptr);
+    EXPECT_EQ(crs->nameStr(), "unknown");
+    EXPECT_EQ(crs->datum()->nameStr(), "unknown");
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(wkt_parse, wkt2_GEODCRS_EPSG_4326) {
     auto obj = WKTParser().createFromWKT("GEODCRS" + contentWKT2_EPSG_4326);
     auto crs = nn_dynamic_pointer_cast<GeographicCRS>(obj);


### PR DESCRIPTION
Backport #3873
 **Authored by:** @rouault