### PR TITLE
Ellipsoid::_isEquivalentTo(): fix so that an ellipsoid of semi-major …

### DIFF
--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1156,7 +1156,7 @@ bool Ellipsoid::_isEquivalentTo(const util::IComparable *other,
         }
 
     } else {
-        if (!otherEllipsoid->computeSemiMinorAxis()._isEquivalentTo(
+        if (!computeSemiMinorAxis()._isEquivalentTo(
                 otherEllipsoid->computeSemiMinorAxis(), criterion)) {
             return false;
         }

--- a/test/unit/test_datum.cpp
+++ b/test/unit/test_datum.cpp
@@ -124,6 +124,12 @@ TEST(datum, ellipsoid_from_inverse_flattening) {
 
     EXPECT_FALSE(Ellipsoid::WGS84->isEquivalentTo(
         Ellipsoid::GRS1980.get(), IComparable::Criterion::EQUIVALENT));
+
+    auto sphere = Ellipsoid::createSphere(PropertyMap(), Length(6378137));
+    EXPECT_FALSE(Ellipsoid::WGS84->isEquivalentTo(
+        sphere.get(), IComparable::Criterion::EQUIVALENT));
+    EXPECT_FALSE(sphere->isEquivalentTo(Ellipsoid::WGS84.get(),
+                                        IComparable::Criterion::EQUIVALENT));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
…axis A (and non-zero inv flattening) isn't equivalent to a sphere of radius A...

or to another ellipsoid of same semi-major axis but defined from a semi-minor axis and not inverse flattening

Discovered when debugging corner cases of https://github.com/OSGeo/PROJ/pull/3879 ...