### PR TITLE
[Backport 9.3] CoordinateOperationFactory: deal with CompoundToCompound with a horizontal similarity transformation and a ballpark vertical (fixes #3854)

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -9110,7 +9110,8 @@ PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj) {
                         alt.idxInOriginalList, minxSrc, minySrc, maxxSrc,
                         maxySrc, minxDst, minyDst, maxxDst, maxyDst,
                         pjNormalized, co->nameStr(), alt.accuracy,
-                        alt.isOffshore, alt.pjSrcGeocentricToLonLat,
+                        alt.pseudoArea, alt.isOffshore,
+                        alt.pjSrcGeocentricToLonLat,
                         alt.pjDstGeocentricToLonLat);
                 }
             }

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -1384,16 +1384,23 @@ struct FilterResults {
             }
 
 #if 0
-            std::cerr << op->nameStr() << " ";
-            std::cerr << area << " ";
-            std::cerr << getAccuracy(op) << " ";
-            std::cerr << isPROJExportable << " ";
-            std::cerr << hasGrids << " ";
-            std::cerr << gridsAvailable << " ";
-            std::cerr << gridsKnown << " ";
-            std::cerr << stepCount << " ";
-            std::cerr << op->hasBallparkTransformation() << " ";
-            std::cerr << isNullTransformation(op->nameStr()) << " ";
+            std::cerr << "name=" << op->nameStr() << " ";
+            std::cerr << "area=" << area << " ";
+            std::cerr << "accuracy=" << getAccuracy(op) << " ";
+            std::cerr << "isPROJExportable=" << isPROJExportable << " ";
+            std::cerr << "hasGrids=" << hasGrids << " ";
+            std::cerr << "gridsAvailable=" << gridsAvailable << " ";
+            std::cerr << "gridsKnown=" << gridsKnown << " ";
+            std::cerr << "stepCount=" << stepCount << " ";
+            std::cerr << "projStepCount=" << projStepCount << " ";
+            std::cerr << "ballpark=" << op->hasBallparkTransformation() << " ";
+            std::cerr << "vertBallpark="
+                      << (op->nameStr().find(
+                              BALLPARK_VERTICAL_TRANSFORMATION) !=
+                          std::string::npos)
+                      << " ";
+            std::cerr << "isNull=" << isNullTransformation(op->nameStr())
+                      << " ";
             std::cerr << std::endl;
 #endif
             map[op.get()] = PrecomputedOpCharacteristics(

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -2385,6 +2385,29 @@ struct MyPROJStringExportableHorizVerticalHorizPROJBased final
 MyPROJStringExportableHorizVerticalHorizPROJBased::
     ~MyPROJStringExportableHorizVerticalHorizPROJBased() = default;
 
+// ---------------------------------------------------------------------------
+
+struct MyPROJStringExportableHorizNullVertical final
+    : public io::IPROJStringExportable {
+    CoordinateOperationPtr horizTransform{};
+
+    MyPROJStringExportableHorizNullVertical(
+        const CoordinateOperationPtr &horizTransformIn)
+        : horizTransform(horizTransformIn) {}
+
+    ~MyPROJStringExportableHorizNullVertical() override;
+
+    void
+    // cppcheck-suppress functionStatic
+    _exportToPROJString(io::PROJStringFormatter *formatter) const override {
+
+        horizTransform->_exportToPROJString(formatter);
+    }
+};
+
+MyPROJStringExportableHorizNullVertical::
+    ~MyPROJStringExportableHorizNullVertical() = default;
+
 //! @endcond
 
 } // namespace operation
@@ -2395,6 +2418,7 @@ namespace dropbox{ namespace oxygen {
 template<> nn<std::shared_ptr<NS_PROJ::operation::MyPROJStringExportableGeodToGeod>>::~nn() = default;
 template<> nn<std::shared_ptr<NS_PROJ::operation::MyPROJStringExportableHorizVertical>>::~nn() = default;
 template<> nn<std::shared_ptr<NS_PROJ::operation::MyPROJStringExportableHorizVerticalHorizPROJBased>>::~nn() = default;
+template<> nn<std::shared_ptr<NS_PROJ::operation::MyPROJStringExportableHorizNullVertical>>::~nn() = default;
 }}
 #endif
 
@@ -2667,6 +2691,40 @@ static CoordinateOperationNNPtr createHorizVerticalHorizPROJBased(
 
     return createPROJBased(properties, exportable, sourceCRS, targetCRS,
                            nullptr, accuracies, hasBallparkTransformation);
+}
+
+// ---------------------------------------------------------------------------
+
+static CoordinateOperationNNPtr createHorizNullVerticalPROJBased(
+    const crs::CRSNNPtr &sourceCRS, const crs::CRSNNPtr &targetCRS,
+    const operation::CoordinateOperationNNPtr &horizTransform,
+    const operation::CoordinateOperationNNPtr &verticalTransform) {
+
+    auto exportable =
+        util::nn_make_shared<MyPROJStringExportableHorizNullVertical>(
+            horizTransform);
+
+    std::vector<CoordinateOperationNNPtr> ops = {horizTransform,
+                                                 verticalTransform};
+    const std::string opName = computeConcatenatedName(ops);
+
+    auto properties = util::PropertyMap();
+    properties.set(common::IdentifiedObject::NAME_KEY, opName);
+
+    bool emptyIntersection = false;
+    auto extent = getExtent(ops, false, emptyIntersection);
+    if (extent) {
+        properties.set(common::ObjectUsage::DOMAIN_OF_VALIDITY_KEY,
+                       NN_NO_CHECK(extent));
+    }
+
+    const auto remarks = getRemarks(ops);
+    if (!remarks.empty()) {
+        properties.set(common::IdentifiedObject::REMARKS_KEY, remarks);
+    }
+
+    return createPROJBased(properties, exportable, sourceCRS, targetCRS,
+                           nullptr, {}, /*hasBallparkTransformation=*/true);
 }
 
 //! @endcond
@@ -4836,6 +4894,18 @@ void CoordinateOperationFactory::Private::createOperationsBoundToVert(
 
 // ---------------------------------------------------------------------------
 
+static std::string
+getBallparkTransformationVertToVert(const crs::CRSNNPtr &sourceCRS,
+                                    const crs::CRSNNPtr &targetCRS) {
+    auto name = buildTransfName(sourceCRS->nameStr(), targetCRS->nameStr());
+    name += " (";
+    name += BALLPARK_VERTICAL_TRANSFORMATION;
+    name += ')';
+    return name;
+}
+
+// ---------------------------------------------------------------------------
+
 void CoordinateOperationFactory::Private::createOperationsVertToVert(
     const crs::CRSNNPtr &sourceCRS, const crs::CRSNNPtr &targetCRS,
     Private::Context &context, const crs::VerticalCRS *vertSrc,
@@ -4881,10 +4951,8 @@ void CoordinateOperationFactory::Private::createOperationsVertToVert(
                        : metadata::Extent::WORLD);
 
     if (!equivalentVDatum) {
-        auto name = buildTransfName(sourceCRS->nameStr(), targetCRS->nameStr());
-        name += " (";
-        name += BALLPARK_VERTICAL_TRANSFORMATION;
-        name += ')';
+        const auto name =
+            getBallparkTransformationVertToVert(sourceCRS, targetCRS);
         auto conv = Transformation::createChangeVerticalUnit(
             map.set(common::IdentifiedObject::NAME_KEY, name), sourceCRS,
             targetCRS,
@@ -6103,6 +6171,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
     }
 
     for (const auto &verticalTransform : verticalTransforms) {
+
         auto interpolationGeogCRS = NN_NO_CHECK(srcGeog);
         auto interpTransformCRS = verticalTransform->interpolationCRS();
         if (interpTransformCRS) {
@@ -6143,6 +6212,37 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
                 } catch (const InvalidOperationEmptyIntersection &) {
                 } catch (const io::FormattingException &) {
                 }
+            }
+        }
+
+        if (verticalTransforms.size() == 1U &&
+            verticalTransform->hasBallparkTransformation() &&
+            context.context->getAuthorityFactory() &&
+            dynamic_cast<crs::ProjectedCRS *>(componentsSrc[0].get()) &&
+            dynamic_cast<crs::ProjectedCRS *>(componentsDst[0].get()) &&
+            verticalTransform->nameStr() ==
+                getBallparkTransformationVertToVert(componentsSrc[1],
+                                                    componentsDst[1])) {
+            // e.g EPSG:3912+EPSG:5779 to EPSG:3794+EPSG:8690
+            // "MGI 1901 / Slovene National Grid + SVS2000 height" to
+            // "Slovenia 1996 / Slovene National Grid + SVS2010 height"
+            // using the "D48/GK to D96/TM (xx)" family of horizontal
+            // transformatoins between the projected CRS
+            // Cf
+            // https://github.com/OSGeo/PROJ/issues/3854#issuecomment-1689964773
+            // We restrict to a ballpark vertical transformation for now,
+            // but ideally we should deal with a regular vertical transformation
+            // but that would involve doing a transformation to its
+            // interpolation CRS and we don't have such cases for now.
+
+            std::vector<CoordinateOperationNNPtr> opsHoriz;
+            createOperationsFromDatabase(
+                componentsSrc[0], componentsDst[0], context, srcGeog.get(),
+                dstGeog.get(), srcGeog.get(), dstGeog.get(),
+                /*vertSrc=*/nullptr, /*vertDst=*/nullptr, opsHoriz);
+            for (const auto &opHoriz : opsHoriz) {
+                res.emplace_back(createHorizNullVerticalPROJBased(
+                    sourceCRS, targetCRS, opHoriz, verticalTransform));
             }
         }
     }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -342,6 +342,7 @@ struct PJCoordOperation {
     PJ *pj = nullptr;
     std::string name{};
     double accuracy = -1.0;
+    double pseudoArea = 0.0;
     bool isOffshore = false;
     bool isPriorityOp = false;
     bool srcIsLonLatDegree = false;
@@ -363,7 +364,7 @@ struct PJCoordOperation {
                      double minySrcIn, double maxxSrcIn, double maxySrcIn,
                      double minxDstIn, double minyDstIn, double maxxDstIn,
                      double maxyDstIn, PJ *pjIn, const std::string &nameIn,
-                     double accuracyIn, bool isOffshoreIn,
+                     double accuracyIn, double pseudoAreaIn, bool isOffshoreIn,
                      const PJ *pjSrcGeocentricToLonLatIn,
                      const PJ *pjDstGeocentricToLonLatIn);
 
@@ -376,7 +377,8 @@ struct PJCoordOperation {
           minyDst(other.minyDst), maxxDst(other.maxxDst),
           maxyDst(other.maxyDst), pj(proj_clone(ctx, other.pj)),
           name(std::move(other.name)), accuracy(other.accuracy),
-          isOffshore(other.isOffshore), isPriorityOp(other.isPriorityOp),
+          pseudoArea(other.pseudoArea), isOffshore(other.isOffshore),
+          isPriorityOp(other.isPriorityOp),
           srcIsLonLatDegree(other.srcIsLonLatDegree),
           srcIsLatLonDegree(other.srcIsLatLonDegree),
           dstIsLonLatDegree(other.dstIsLonLatDegree),
@@ -396,8 +398,8 @@ struct PJCoordOperation {
           maxySrc(other.maxySrc), minxDst(other.minxDst),
           minyDst(other.minyDst), maxxDst(other.maxxDst),
           maxyDst(other.maxyDst), name(std::move(other.name)),
-          accuracy(other.accuracy), isOffshore(other.isOffshore),
-          isPriorityOp(other.isPriorityOp),
+          accuracy(other.accuracy), pseudoArea(other.pseudoArea),
+          isOffshore(other.isOffshore), isPriorityOp(other.isPriorityOp),
           srcIsLonLatDegree(other.srcIsLonLatDegree),
           srcIsLatLonDegree(other.srcIsLatLonDegree),
           dstIsLonLatDegree(other.dstIsLonLatDegree),

--- a/test/cli/testvarious
+++ b/test/cli/testvarious
@@ -1320,6 +1320,18 @@ $EXE -d 3 EPSG:25831 EPSG:23031 -E >>${OUT} 2>&1 <<EOF
 299905.060 4499796.515
 EOF
 
+echo "##############################################################" >> ${OUT}
+echo "Test Similarity Transformation through CompoundCRS" >> ${OUT}
+# Cf https://github.com/OSGeo/PROJ/issues/3854#issuecomment-1689964773
+#
+$EXE -d 3 EPSG:3912 EPSG:3794 -E >>${OUT} 2>&1 <<EOF
+477134.28 95134.21
+EOF
+
+$EXE -d 3 EPSG:3912+EPSG:5779 EPSG:3794+EPSG:8690 -E >>${OUT} 2>&1 <<EOF
+477134.28 95134.21 5
+EOF
+
 
 # Done!
 # do 'diff' with distribution results

--- a/test/cli/tv_out.dist
+++ b/test/cli/tv_out.dist
@@ -633,3 +633,7 @@ Test Similarity Transformation (example from EPSG Guidance Note 7.2)
 ##############################################################
 Test inverse of Similarity Transformation (example from EPSG Guidance Note 7.2)
 299905.060 4499796.515	300000.000	4500000.000 0.000
+##############################################################
+Test Similarity Transformation through CompoundCRS
+477134.28 95134.21	476763.303	95620.222 0.000
+477134.28 95134.21 5	476763.303	95620.222 5.000


### PR DESCRIPTION
Backport #3876
 **Authored by:** @rouault