### PR TITLE
[Backport 9.3] isEquivalentTo(): make a datum name 'unknown' equivalent to another one

### DIFF
--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1547,6 +1547,9 @@ bool GeodeticReferenceFrame::_isEquivalentTo(
 bool GeodeticReferenceFrame::hasEquivalentNameToUsingAlias(
     const IdentifiedObject *other,
     const io::DatabaseContextPtr &dbContext) const {
+    if (nameStr() == "unknown" || other->nameStr() == "unknown") {
+        return true;
+    }
     if (dbContext) {
         if (!identifiers().empty()) {
             const auto &id = identifiers().front();

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -1939,6 +1939,20 @@ findCandidateGeodCRSForDatum(const io::AuthorityFactoryPtr &authFactory,
 
 //! @cond Doxygen_Suppress
 
+static bool
+isSameGeodeticDatum(const datum::GeodeticReferenceFrameNNPtr &datum1,
+                    const datum::GeodeticReferenceFrameNNPtr &datum2,
+                    const io::DatabaseContextPtr &dbContext) {
+    if (datum1->nameStr() == "unknown" && datum2->nameStr() != "unknown")
+        return false;
+    if (datum2->nameStr() == "unknown" && datum1->nameStr() != "unknown")
+        return false;
+    return datum1->_isEquivalentTo(
+        datum2.get(), util::IComparable::Criterion::EQUIVALENT, dbContext);
+}
+
+// ---------------------------------------------------------------------------
+
 // Look in the authority registry for operations from sourceCRS to targetCRS
 // using an intermediate pivot
 std::vector<CoordinateOperationNNPtr>
@@ -1978,10 +1992,7 @@ CoordinateOperationFactory::Private::findsOpsInRegistryWithIntermediate(
                             candidateSrcGeod->datumNonNull(dbContext);
                         const auto dstDatum = geodDst->datumNonNull(dbContext);
                         const bool sameGeodeticDatum =
-                            srcDatum->_isEquivalentTo(
-                                dstDatum.get(),
-                                util::IComparable::Criterion::EQUIVALENT,
-                                dbContext);
+                            isSameGeodeticDatum(srcDatum, dstDatum, dbContext);
                         if (sameGeodeticDatum) {
                             continue;
                         }
@@ -2133,9 +2144,8 @@ createBallparkGeographicOffset(const crs::CRSNNPtr &sourceCRS,
         dynamic_cast<const crs::GeographicCRS *>(targetCRS.get());
     const bool isSameDatum =
         geogSrc && geogDst &&
-        geogSrc->datumNonNull(dbContext)->_isEquivalentTo(
-            geogDst->datumNonNull(dbContext).get(),
-            util::IComparable::Criterion::EQUIVALENT, dbContext);
+        isSameGeodeticDatum(geogSrc->datumNonNull(dbContext),
+                            geogDst->datumNonNull(dbContext), dbContext);
 
     auto name = buildOpName(isSameDatum ? NULL_GEOGRAPHIC_OFFSET
                                         : BALLPARK_GEOGRAPHIC_OFFSET,
@@ -2706,9 +2716,9 @@ CoordinateOperationFactory::Private::createOperationsGeogToGeog(
     const auto dbContext =
         authFactory ? authFactory->databaseContext().as_nullable() : nullptr;
 
-    const bool sameDatum = geogSrc->datumNonNull(dbContext)->_isEquivalentTo(
-        geogDst->datumNonNull(dbContext).get(),
-        util::IComparable::Criterion::EQUIVALENT, dbContext);
+    const bool sameDatum =
+        isSameGeodeticDatum(geogSrc->datumNonNull(dbContext),
+                            geogDst->datumNonNull(dbContext), dbContext);
 
     // Do the CRS differ by their axis order ?
     bool axisReversal2D = false;
@@ -3610,9 +3620,8 @@ bool CoordinateOperationFactory::Private::createOperationsFromDatabase(
 
         const auto srcDatum = geodSrc->datumNonNull(dbContext);
         const auto dstDatum = geodDst->datumNonNull(dbContext);
-        sameGeodeticDatum = srcDatum->_isEquivalentTo(
-            dstDatum.get(), util::IComparable::Criterion::EQUIVALENT,
-            dbContext);
+
+        sameGeodeticDatum = isSameGeodeticDatum(srcDatum, dstDatum, dbContext);
 
         if (res.empty() && !sameGeodeticDatum &&
             !context.inCreateOperationsWithDatumPivotAntiRecursion) {

--- a/test/unit/test_datum.cpp
+++ b/test/unit/test_datum.cpp
@@ -289,6 +289,28 @@ TEST(datum, datum_with_ANCHOREPOCH) {
 
 // ---------------------------------------------------------------------------
 
+TEST(datum, unknown_datum) {
+    auto datum = GeodeticReferenceFrame::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "my_datum"),
+        Ellipsoid::GRS1980, optional<std::string>(), optional<Measure>(),
+        PrimeMeridian::GREENWICH);
+    auto unknown_datum = GeodeticReferenceFrame::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "unknown"),
+        Ellipsoid::GRS1980, optional<std::string>(), optional<Measure>(),
+        PrimeMeridian::GREENWICH);
+
+    EXPECT_FALSE(datum->isEquivalentTo(unknown_datum.get(),
+                                       IComparable::Criterion::STRICT));
+    EXPECT_TRUE(datum->isEquivalentTo(unknown_datum.get(),
+                                      IComparable::Criterion::EQUIVALENT));
+    EXPECT_FALSE(unknown_datum->isEquivalentTo(datum.get(),
+                                               IComparable::Criterion::STRICT));
+    EXPECT_TRUE(unknown_datum->isEquivalentTo(
+        datum.get(), IComparable::Criterion::EQUIVALENT));
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(datum, dynamic_geodetic_reference_frame) {
     auto drf = DynamicGeodeticReferenceFrame::create(
         PropertyMap().set(IdentifiedObject::NAME_KEY, "test"), Ellipsoid::WGS84,


### PR DESCRIPTION
Backport #3879
 **Authored by:** @rouault