### PR TITLE
setargv.obj is not available on uwp

### DIFF
--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -37,10 +37,12 @@ if(NOT MSVC)
 
 else()
 
+  if(NOT WINDOWS_STORE)
     # Linking to setargv.obj enables wildcard globbing for the
     # command line utilities, when compiling with MSVC
     # https://docs.microsoft.com/cpp/c-language/expanding-wildcard-arguments
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} setargv.obj")
+  endif()
 
 endif()
 


### PR DESCRIPTION
You get errors like:
```
[236/239] cmd.exe /C "cd . && C:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\apps\CMakeFiles\binproj.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe  src\apps\CMakeFiles\binproj.dir\proj.cpp.obj src\apps\CMakeFiles\binproj.dir\emess.cpp.obj src\apps\CMakeFiles\binproj.dir\utils.cpp.obj  /out:bin\proj.exe /implib:lib\binproj.lib /pdb:bin\proj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO  setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF  /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib  WindowsApp.lib && cd ."
FAILED: bin/proj.exe 
cmd.exe /C "cd . && C:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\apps\CMakeFiles\binproj.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe  src\apps\CMakeFiles\binproj.dir\proj.cpp.obj src\apps\CMakeFiles\binproj.dir\emess.cpp.obj src\apps\CMakeFiles\binproj.dir\utils.cpp.obj  /out:bin\proj.exe /implib:lib\binproj.lib /pdb:bin\proj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO  setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF  /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib  WindowsApp.lib && cd ."
LINK: command "C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe src\apps\CMakeFiles\binproj.dir\proj.cpp.obj src\apps\CMakeFiles\binproj.dir\emess.cpp.obj src\apps\CMakeFiles\binproj.dir\utils.cpp.obj /out:bin\proj.exe /implib:lib\binproj.lib /pdb:bin\proj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib WindowsApp.lib" failed (exit code 1181) with the following output:
Microsoft (R) Incremental Linker Version 14.37.32822.0
Copyright (C) Microsoft Corporation.  All rights reserved.

LINK : warning LNK4075: ignoring '/MANIFESTUAC' due to '/MANIFEST:NO' specification

LINK : fatal error LNK1181: cannot open input file 'setargv.obj'
````