### PR TITLE
[Backport 9.3] setargv.obj is not available on uwp

### DIFF
--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -37,10 +37,12 @@ if(NOT MSVC)
 
 else()
 
+  if(NOT WINDOWS_STORE)
     # Linking to setargv.obj enables wildcard globbing for the
     # command line utilities, when compiling with MSVC
     # https://docs.microsoft.com/cpp/c-language/expanding-wildcard-arguments
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} setargv.obj")
+  endif()
 
 endif()
 


### PR DESCRIPTION
Backport #3889
 **Authored by:** @autoantwort