### PR TITLE
helmert.rst: remove outdated :since: and deprecation

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -2019,7 +2019,7 @@ Updates
 
 * Added "require_grid" option to gie (`#1088 <https://github.com/OSGeo/proj.4/issues/1088>`_)
 
-* Replace :option:`+transpose` option of Helmert transform with :option:`+convention`.
+* Replace ``transpose`` option of Helmert transform with :option:`+convention`.
   From now on the convention used should be explicitly written. An
   error will be returned when using the +transpose option (`#1091 <https://github.com/OSGeo/proj.4/issues/1091>`_)
 

--- a/docs/source/operations/transformations/helmert.rst
+++ b/docs/source/operations/transformations/helmert.rst
@@ -4,8 +4,6 @@
 Helmert transform
 ================================================================================
 
-.. versionadded:: 5.0.0
-
 The Helmert transformation changes coordinates from one reference frame to
 another by means of 3-, 4-and 7-parameter shifts, or one of their 6-, 8- and
 14-parameter kinematic counterparts.
@@ -80,8 +78,6 @@ Parameters
     operation will return the coordinates unchanged.
 
 .. option:: +convention=coordinate_frame/position_vector
-
-    .. versionadded:: 5.2.0
 
     Indicates the convention to express the rotational terms when a 3D-Helmert /
     7-parameter more transform is involved. As soon as a rotational parameter
@@ -181,15 +177,6 @@ Parameters
     Use exact transformation equations.
 
     See :eq:`rot_exact`
-
-.. option:: +transpose
-
-    .. deprecated:: 5.2.0 (removed)
-
-    Transpose rotation matrix and follow the **Position Vector** rotation
-    convention. If :option:`+transpose` is not added the **Coordinate Frame**
-    rotation convention is used.
-
 
 
 Mathematical description


### PR DESCRIPTION
versions 5.0 and 5.2 are ancient. No need to add to the cognitive load of the reader
