### PR TITLE
[Backport 9.3] Doc: give all EPSG potential names for lon_0/lat_0/x_0/y_0 (fixes #3904)

### DIFF
--- a/docs/source/operations/options/lat_0.rst
+++ b/docs/source/operations/options/lat_0.rst
@@ -1,6 +1,8 @@
 .. option:: +lat_0=<value>
 
-    Latitude of projection center.
+    Latitude of natural origin, latitude of false origin or latitude of
+    projection centre (naming and semantic depend on the
+    projection method).
 
     *Defaults to 0.0.*
 

--- a/docs/source/operations/options/lat_0.rst
+++ b/docs/source/operations/options/lat_0.rst
@@ -1,7 +1,7 @@
 .. option:: +lat_0=<value>
 
     Latitude of natural origin, latitude of false origin or latitude of
-    projection centre (naming and semantic depend on the
+    projection centre (naming and meaning depend on the
     projection method).
 
     *Defaults to 0.0.*

--- a/docs/source/operations/options/lon_0.rst
+++ b/docs/source/operations/options/lon_0.rst
@@ -1,7 +1,7 @@
 .. option:: +lon_0=<value>
 
     Central meridian/longitude of natural origin, longitude of
-    origin or longitude of false origin (naming and semantic depend on the
+    origin or longitude of false origin (naming and meaning depend on the
     projection method).
 
     *Defaults to 0.0.*

--- a/docs/source/operations/options/lon_0.rst
+++ b/docs/source/operations/options/lon_0.rst
@@ -1,6 +1,6 @@
 .. option:: +lon_0=<value>
 
-    Longitude of central meridian/longitude of natural origin, longitude of
+    Central meridian/longitude of natural origin, longitude of
     origin or longitude of false origin (naming and semantic depend on the
     projection method).
 

--- a/docs/source/operations/options/lon_0.rst
+++ b/docs/source/operations/options/lon_0.rst
@@ -1,6 +1,8 @@
 .. option:: +lon_0=<value>
 
-    Longitude of projection center.
+    Longitude of central meridian/longitude of natural origin, longitude of
+    origin or longitude of false origin (naming and semantic depend on the
+    projection method).
 
     *Defaults to 0.0.*
 

--- a/docs/source/operations/options/x_0.rst
+++ b/docs/source/operations/options/x_0.rst
@@ -1,5 +1,6 @@
 .. option:: +x_0=<value>
 
-    False easting, in meters.
+    False easting, easting at false origin or easting at projection centre (naming
+    and semantic depend on the projection method). Always in meters.
 
     *Defaults to 0.0.*

--- a/docs/source/operations/options/x_0.rst
+++ b/docs/source/operations/options/x_0.rst
@@ -1,6 +1,6 @@
 .. option:: +x_0=<value>
 
     False easting, easting at false origin or easting at projection centre (naming
-    and semantic depend on the projection method). Always in meters.
+    and meaning depend on the projection method). Always in meters.
 
     *Defaults to 0.0.*

--- a/docs/source/operations/options/y_0.rst
+++ b/docs/source/operations/options/y_0.rst
@@ -1,6 +1,6 @@
 .. option:: +y_0=<value>
 
     False northing, northing at false origin or northing at projection centre (naming
-    and semantic depend on the projection method). Always in meters.
+    and meaning depend on the projection method). Always in meters.
 
     *Defaults to 0.0.*

--- a/docs/source/operations/options/y_0.rst
+++ b/docs/source/operations/options/y_0.rst
@@ -1,5 +1,6 @@
 .. option:: +y_0=<value>
 
-    False northing, in meters.
+    False northing, northing at false origin or northing at projection centre (naming
+    and semantic depend on the projection method). Always in meters.
 
     *Defaults to 0.0.*


### PR DESCRIPTION
Backport #3905
 **Authored by:** @rouault