### PR TITLE
GeographicBoundingBox::intersects(): avoid infinite recursion and stack overflow on invalid bounding boxes

### DIFF
--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -343,6 +343,13 @@ bool GeographicBoundingBox::Private::intersects(const Private &other) const {
             return false;
         }
 
+        // Bail out on longitudes not in [-180,180]. We could probably make
+        // some sense of them, but this check at least avoid potential infinite
+        // recursion.
+        if (oW > 180 || oE < -180) {
+            return false;
+        }
+
         return intersects(Private(oW, oS, 180.0, oN)) ||
                intersects(Private(-180.0, oS, oE, oN));
 

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -308,15 +308,20 @@ TEST(metadata, extent_edge_cases) {
                  InvalidValueTypeException);
 
     // Scenario of https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57328
+    // and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60084
     {
         auto A = Extent::createFromBBOX(0, 1, 2, 3);
         auto B = Extent::createFromBBOX(200, -80, -100, 80);
+        EXPECT_FALSE(A->intersects(B));
+        EXPECT_FALSE(B->intersects(A));
         EXPECT_TRUE(A->intersection(B) == nullptr);
         EXPECT_TRUE(B->intersection(A) == nullptr);
     }
     {
         auto A = Extent::createFromBBOX(0, 1, 2, 3);
         auto B = Extent::createFromBBOX(100, -80, -200, 80);
+        EXPECT_FALSE(A->intersects(B));
+        EXPECT_FALSE(B->intersects(A));
         EXPECT_TRUE(A->intersection(B) == nullptr);
         EXPECT_TRUE(B->intersection(A) == nullptr);
     }


### PR DESCRIPTION
Very similar to bugfix of 8409e8e03ef487b8a25d5ec6194dd31135d044c8 Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60084
