### PR TITLE
Add Pix4D in users.rst - Proprietary licensed software

### DIFF
--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -30,6 +30,7 @@ Proprietary licensed software
 - `FME <http://www.safe.com>`_  A GIS translator package. Includes a PROJ based transformer.
 - `Avenza Maps <https://www.avenzamaps.com>`_  Top mobile mapping app for offline navigation and data collection.
 - `Bunting Labs <https://buntinglabs.com/>`_ No-code GIS infrastructure
+- `Pix4D <https://www.pix4d.com>`_ Cloud, desktop and mobile photogrammetry processing and data capture software.
 
 Geodetic organizations
 ----------------------


### PR DESCRIPTION
Pix4D added as "Proprietary licensed software" in docs/source/users.rst.
PROJ is used in most of their software to deal with CRSs.