### PR TITLE
SSL_OPTIONS: set SSL options on Curl library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,14 @@ if(ENABLE_CURL)
         INTERFACE_LINK_LIBRARIES      "${CURL_LIBRARIES}"
       )
     endif()
+
+    # Curl SSL options are described in
+    #   https://curl.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
+    #set(CURLSSLOPT_NO_REVOKE 2)
+    #set(SSL_OPTIONS ${CURLSSLOPT_NO_REVOKE})
+    #add_compile_definitions(SSL_OPTIONS=${SSL_OPTIONS})
+    #mark_as_advanced(SSL_OPTIONS)
+
   else()
     message(SEND_ERROR "curl dependency not found!")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,6 @@ if(ENABLE_CURL)
     #set(CURLSSLOPT_NO_REVOKE 2)
     #set(SSL_OPTIONS ${CURLSSLOPT_NO_REVOKE})
     #add_compile_definitions(SSL_OPTIONS=${SSL_OPTIONS})
-    #mark_as_advanced(SSL_OPTIONS)
 
   else()
     message(SEND_ERROR "curl dependency not found!")

--- a/src/networkfilemanager.cpp
+++ b/src/networkfilemanager.cpp
@@ -1620,6 +1620,13 @@ CurlFileHandle::CurlFileHandle(PJ_CONTEXT *ctx, const char *url, CURL *handle)
         CHECK_RET(ctx, curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L));
     }
 
+#if defined(SSL_OPTIONS)
+    // https://curl.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
+    auto ssl_options = static_cast<long>(SSL_OPTIONS);
+    CHECK_RET(ctx,
+              curl_easy_setopt(handle, CURLOPT_SSL_OPTIONS, ssl_options));
+#endif
+
     const auto ca_bundle_path = pj_context_get_bundle_path(ctx);
     if (!ca_bundle_path.empty()) {
         CHECK_RET(ctx, curl_easy_setopt(handle, CURLOPT_CAINFO,


### PR DESCRIPTION
I would like to suggest a build-time option for adjusting Curl SSL options on PROJ.  The default Curl SSL options appear to be more pedantic on certificate revocation checks than web browsers are. It could be discussed, if fail-hard checking is needed, when grid data downloads are concerned. See https://en.wikipedia.org/wiki/Certificate_revocation for some general info.

PROJ has the environment variable PROJ_UNSAFE_SSL for turning off all SSL checks. However, I would like to be able to use CURLSSLOPT_NO_REVOKE option in some environments, and keep all the other SSL checks enabled.

After the code change suggested in this pull request, CURLSSLOPT_NO_REVOKE could be selected at build-time by this kind of addition to PROJ cmake command:
  -DCMAKE_CXX_FLAGS="-DSSL_OPTIONS=2"

Curl SSL options are described in https://curl.se/libcurl/c/CURLOPT_SSL_OPTIONS.html

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API