### PR TITLE
createOperations(): Fix possible null dereference on invalid WKT input

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5046,8 +5046,8 @@ AuthorityFactory::createGeodeticCRS(const std::string &code) const {
 crs::GeographicCRSNNPtr
 AuthorityFactory::createGeographicCRS(const std::string &code) const {
     auto crs(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
-             createGeodeticCRS(code, true)));
-    if(!crs) {
+        createGeodeticCRS(code, true)));
+    if (!crs) {
         throw NoSuchAuthorityCodeException("geographicCRS not found",
                                            d->authority(), code);
     }

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5045,8 +5045,13 @@ AuthorityFactory::createGeodeticCRS(const std::string &code) const {
 
 crs::GeographicCRSNNPtr
 AuthorityFactory::createGeographicCRS(const std::string &code) const {
-    return NN_NO_CHECK(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
-        createGeodeticCRS(code, true)));
+    auto crs(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
+             createGeodeticCRS(code, true)));
+    if(!crs) {
+        throw NoSuchAuthorityCodeException("geographicCRS not found",
+                                           d->authority(), code);
+    }
+    return NN_NO_CHECK(crs);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -598,6 +598,18 @@ TEST(factory, AuthorityFactory_createGeodeticCRS_geocentric) {
 
 // ---------------------------------------------------------------------------
 
+TEST(factory, AuthorityFactory_createGeographicCRS) {
+    auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto crs = factory->createGeographicCRS("4979");
+    ASSERT_TRUE(nn_dynamic_pointer_cast<GeographicCRS>(crs) != nullptr);
+    ASSERT_EQ(crs->identifiers().size(), 1U);
+    EXPECT_EQ(crs->identifiers()[0]->code(), "4979");
+
+    EXPECT_THROW(factory->createGeographicCRS("4978"), FactoryException);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(factory, AuthorityFactory_createVerticalCRS) {
     auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     EXPECT_THROW(factory->createVerticalCRS("-1"),


### PR DESCRIPTION
Null pointer dereference can be reproduced with [1.prj.txt](https://github.com/OSGeo/PROJ/files/13257685/1.prj.txt)

Stack trace (before fix):
```
gdb --args projinfo @1.prj
```
```
Program received signal SIGSEGV, Segmentation fault.
std::__uniq_ptr_impl<osgeo::proj::common::ObjectUsage::Private, std::default_delete<osgeo::proj::common::ObjectUsage::Private> >::_M_ptr (this=0x28) at /usr/include/c++/10/bits/unique_ptr.h:173
173	      pointer    _M_ptr() const { return std::get<0>(_M_t); }
(gdb) bt
#0  std::__uniq_ptr_impl<osgeo::proj::common::ObjectUsage::Private, std::default_delete<osgeo::proj::common::ObjectUsage::Private> >::_M_ptr (this=0x28) at /usr/include/c++/10/bits/unique_ptr.h:173
#1  0x00007ffff7bcd1a2 in std::unique_ptr<osgeo::proj::common::ObjectUsage::Private, std::default_delete<osgeo::proj::common::ObjectUsage::Private> >::get (this=0x28) at /usr/include/c++/10/bits/unique_ptr.h:422
#2  0x00007ffff7bce8d6 in std::unique_ptr<osgeo::proj::common::ObjectUsage::Private, std::default_delete<osgeo::proj::common::ObjectUsage::Private> >::operator-> (this=0x28) at /usr/include/c++/10/bits/unique_ptr.h:416
#3  0x00007ffff7bcbe70 in osgeo::proj::common::ObjectUsage::domains (this=0x0)
    at /tmp/proj.4/src/iso19111/common.cpp:1188
#4  0x00007ffff7dd9fa6 in osgeo::proj::operation::getExtent (crs=...)
    at /tmp/proj.4/src/iso19111/operation/oputils.cpp:480
#5  0x00007ffff7dad224 in osgeo::proj::crs::CRS::getResolvedCRS (crs=..., authFactory=
    std::shared_ptr<osgeo::proj::io::AuthorityFactory> (use count 2, weak count 1) = {...}, 
    extentOut=std::shared_ptr<osgeo::proj::metadata::Extent> (empty) = {...})
    at /tmp/proj.4/src/iso19111/operation/coordinateoperationfactory.cpp:7177
#6  0x00007ffff7dac3bf in osgeo::proj::operation::CoordinateOperationFactory::createOperations (this=0x555555685a90, 
    sourceCRS=..., targetCRS=..., context=...) at /tmp/proj.4/src/iso19111/operation/coordinateoperationfactory.cpp:6992
#7  0x00007ffff7bda4cf in osgeo::proj::crs::CRS::createBoundCRSToWGS84IfPossible (this=0x55555568f360, 
    dbContext=std::shared_ptr<osgeo::proj::io::DatabaseContext> (use count 4, weak count 1) = {...}, 
    allowIntermediateCRSUse=osgeo::proj::operation::CoordinateOperationContext::IntermediateCRSUse::IF_NO_DIRECT_TRANSFORMATION) at /tmp/proj.4/src/iso19111/crs.cpp:673
#8  0x0000555555577027 in outputObject (
    dbContext=std::shared_ptr<osgeo::proj::io::DatabaseContext> (use count 4, weak count 1) = {...}, obj=..., 
    allowUseIntermediateCRS=osgeo::proj::operation::CoordinateOperationContext::IntermediateCRSUse::IF_NO_DIRECT_TRANSFORMATION, outputOpt=...) at /tmp/proj.4/src/apps/projinfo.cpp:490
#9  0x000055555557e2b1 in main (argc=2, argv=0x7fffffffdfa8) at /tmp/proj.4/src/apps/projinfo.cpp:1624
```