### PR TITLE
[Backport 9.3] createOperations(): Fix possible null dereference on invalid WKT input

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5037,8 +5037,13 @@ AuthorityFactory::createGeodeticCRS(const std::string &code) const {
 
 crs::GeographicCRSNNPtr
 AuthorityFactory::createGeographicCRS(const std::string &code) const {
-    return NN_NO_CHECK(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
-        createGeodeticCRS(code, true)));
+    auto crs(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
+             createGeodeticCRS(code, true)));
+    if(!crs) {
+        throw NoSuchAuthorityCodeException("geographicCRS not found",
+                                           d->authority(), code);
+    }
+    return NN_NO_CHECK(crs);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -5038,8 +5038,8 @@ AuthorityFactory::createGeodeticCRS(const std::string &code) const {
 crs::GeographicCRSNNPtr
 AuthorityFactory::createGeographicCRS(const std::string &code) const {
     auto crs(util::nn_dynamic_pointer_cast<crs::GeographicCRS>(
-             createGeodeticCRS(code, true)));
-    if(!crs) {
+        createGeodeticCRS(code, true)));
+    if (!crs) {
         throw NoSuchAuthorityCodeException("geographicCRS not found",
                                            d->authority(), code);
     }

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -596,6 +596,18 @@ TEST(factory, AuthorityFactory_createGeodeticCRS_geocentric) {
 
 // ---------------------------------------------------------------------------
 
+TEST(factory, AuthorityFactory_createGeographicCRS) {
+    auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto crs = factory->createGeographicCRS("4979");
+    ASSERT_TRUE(nn_dynamic_pointer_cast<GeographicCRS>(crs) != nullptr);
+    ASSERT_EQ(crs->identifiers().size(), 1U);
+    EXPECT_EQ(crs->identifiers()[0]->code(), "4979");
+
+    EXPECT_THROW(factory->createGeographicCRS("4978"), FactoryException);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(factory, AuthorityFactory_createVerticalCRS) {
     auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     EXPECT_THROW(factory->createVerticalCRS("-1"),


### PR DESCRIPTION
Backport #3945
 **Authored by:** @drons