### PR TITLE
[Backport 9.3] Move static NameSpace::GLOBAL definition in static.cpp to avoid 'static initialization fiasco' (fixes various Coverity warnings)

### DIFF
--- a/src/iso19111/static.cpp
+++ b/src/iso19111/static.cpp
@@ -66,6 +66,10 @@ NS_PROJ_START
 
 // ---------------------------------------------------------------------------
 
+const NameSpaceNNPtr NameSpace::GLOBAL(NameSpace::createGLOBAL());
+
+// ---------------------------------------------------------------------------
+
 /** \brief Key to set the authority citation of a metadata::Identifier.
  *
  * The value is to be provided as a string or a metadata::Citation.

--- a/src/iso19111/util.cpp
+++ b/src/iso19111/util.cpp
@@ -494,10 +494,6 @@ NameSpaceNNPtr NameSpace::createGLOBAL() {
 
 // ---------------------------------------------------------------------------
 
-const NameSpaceNNPtr NameSpace::GLOBAL(NameSpace::createGLOBAL());
-
-// ---------------------------------------------------------------------------
-
 //! @cond Doxygen_Suppress
 struct LocalName::Private {
     NameSpacePtr scope{};


### PR DESCRIPTION
Backport #3955
 **Authored by:** @rouault