### PR TITLE
horner: allow arbitrary input type of coordinate

### DIFF
--- a/src/transformations/horner.cpp
+++ b/src/transformations/horner.cpp
@@ -559,7 +559,7 @@ PJ *PROJECTION(horner) {
     P->inv3d = nullptr;
     P->fwd = nullptr;
     P->inv = nullptr;
-    P->left = P->right = PJ_IO_UNITS_PROJECTED;
+    P->left = P->right = PJ_IO_UNITS_WHATEVER;
     P->destructor = horner_freeup;
 
     /* Polynomial degree specified? */


### PR DESCRIPTION
Avoids workaround of https://lists.osgeo.org/pipermail/proj/2023-November/011167.html
to be able to deal with geographic coordinates
