### PR TITLE
docker.yml: replace depecated 'echo ::set-output name=KEY::VALUE' with echo 'name=value' >> $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,8 +65,8 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\//}
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
       - name: Build image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
cf https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/