### PR TITLE
Remove copy and move constructors from AxisDirection

### DIFF
--- a/include/proj/coordinatesystem.hpp
+++ b/include/proj/coordinatesystem.hpp
@@ -60,6 +60,11 @@ class AxisDirection : public util::CodeList {
     valueOf(const std::string &nameIn) noexcept;
     //! @endcond
 
+    AxisDirection(const AxisDirection&) = delete;
+    AxisDirection& operator=(const AxisDirection&) = delete;
+    AxisDirection(AxisDirection&&) = delete;
+    AxisDirection& operator=(AxisDirection&&) = delete;
+
     PROJ_DLL static const AxisDirection NORTH;
     PROJ_DLL static const AxisDirection NORTH_NORTH_EAST;
     PROJ_DLL static const AxisDirection NORTH_EAST;

--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -555,7 +555,7 @@ int main(int argc, char **argv) {
                 try {
                     auto crs = dynamic_cast<const NS_PROJ::crs::ProjectedCRS *>(
                         P->iso_obj.get());
-                    auto dir =
+                    auto& dir =
                         crs->coordinateSystem()->axisList()[0]->direction();
                     swapAxisCrs = dir == NS_PROJ::cs::AxisDirection::NORTH ||
                                   dir == NS_PROJ::cs::AxisDirection::SOUTH;


### PR DESCRIPTION
Recently it took me a few hours and the help from @hernando to find out the reason of a failure in my code.

Let's say I am trying to make this function
```C++
        auto axis = [&] (const std::string& name, const std::string& abbr, AxisDirection dir) {
            return CoordinateSystemAxis::create(
                PropertyMap().set(IdentifiedObject::NAME_KEY, name), abbr,
                dir, UnitOfMeasure::METRE);
        };
```
Currently it is assigning some garbage to the direction because it is passed by copy, and not by reference. I was calling it with `AxisDirection::EAST`, that naïvely I supposed it was an `enum` or `enum class`.
(the solution is passing the direction by reference... but the compiler was not helping me. The consequence was a crash later in the execution, not a compile error).

The implementation of the `create` function takes the pointer of the direction (pay attention to the `&` in `&directionIn`), that has a "wrong" value if it was copied. The consequence was a later segmentation fault when serializing to JSON.
```C++
CoordinateSystemAxisNNPtr CoordinateSystemAxis::create(
    const util::PropertyMap &properties, const std::string &abbreviationIn,
    const AxisDirection &directionIn, const common::UnitOfMeasure &unitIn,
    const MeridianPtr &meridianIn) {
    auto csa(CoordinateSystemAxis::nn_make_shared<CoordinateSystemAxis>());
    csa->setProperties(properties);
    csa->d->abbreviation = abbreviationIn;
    csa->d->direction = &directionIn;
    csa->d->unit = unitIn;
    csa->d->meridian = meridianIn;
    return csa;
}
```

The easy solution I implement in this PR is deleting the copy and move constructors / assignments operator, so the compiler it not allowing me that wrong operation.

That opens the question: why is it taking a pointer? I find that obscure. But probably changing that implementation may break the API, and would be a lot of work.