### PR TITLE
if(WIN32) add shell32 and ole32 libraries in lib_proj.cmake

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -438,6 +438,13 @@ set_target_properties(proj
 set(PROJ_LIBRARIES proj)
 # hack, required for test/unit
 set(PROJ_LIBRARIES ${PROJ_LIBRARIES} PARENT_SCOPE)
+if(WIN32)
+target_link_libraries (proj
+  PRIVATE
+    shell32.lib
+    ole32.lib
+)
+endif()
 if(UNIX)
   find_library(M_LIB m)
   if(M_LIB)


### PR DESCRIPTION
to fix missing symbols at link time for windows target as described in https://github.com/OSGeo/PROJ/issues/2983

Closes #2983
