### PR TITLE
Improve error message in axisswap

### DIFF
--- a/src/conversions/axisswap.cpp
+++ b/src/conversions/axisswap.cpp
@@ -170,7 +170,7 @@ PJ *PJ_CONVERSION(axisswap, 0) {
     if (!pj_param_exists(P->params, "order") ==
         !pj_param_exists(P->params, "axis")) {
         proj_log_error(P,
-                       _("order and axis parameters are mutually exclusive."));
+                       _("must provide EITHER 'order' OR 'axis' parameter."));
         return pj_default_destructor(
             P, PROJ_ERR_INVALID_OP_MUTUALLY_EXCLUSIVE_ARGS);
     }


### PR DESCRIPTION
The test for parameters in axisswap actually is a bit convoluted, but in essence it checks both whether ANY of the 'axis' and 'order' parameters are given, and whether BOTH are given.

Hence, the error message

"order and axis parameters are mutually exclusive"

is misleading in the case where none of the two is given. The updated message:

"must provide EITHER 'order' OR 'axis' parameter"

is intended to cover both cases in an informative way

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Added clear title that can be used to generate release notes
