### PR TITLE
Database: add entry in grid_alternatives for ChartDatum_above_Ellipsod_EUREF89_v2023b.bin / no_kv_CD_above_Ell_ETRS89_v2023b.tif

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -248,6 +248,7 @@ VALUES
 ('href2008a.bin','no_kv_href2008a.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/no_kv_href2008a.tif',1,1,NULL),
 ('no_kv_NKGETRF14_EPSG7922_2000.tif','no_kv_NKGETRF14_EPSG7922_2000.tif',NULL,'GTiff','geocentricoffset',0,NULL,'https://cdn.proj.org/no_kv_NKGETRF14_EPSG7922_2000.tif',1,1,NULL),
 ('ChartDatum_above_Ellipsoid_EUREF89_v2021a.bin','no_kv_CD_above_Ell_ETRS89_v2021a.tif',NULL,'GTiff','vgridshift',0,NULL,'https://cdn.proj.org/no_kv_CD_above_Ell_ETRS89_v2021a.tif',1,1,NULL),
+('ChartDatum_above_Ellipsoid_EUREF89_v2023b.bin','no_kv_CD_above_Ell_ETRS89_v2023b.tif',NULL,'GTiff','vgridshift',0,NULL,'https://cdn.proj.org/no_kv_CD_above_Ell_ETRS89_v2023b.tif',1,1,NULL),
 ('no_kv_ETRS89NO_NGO48_TIN.json','no_kv_ETRS89NO_NGO48_TIN.json',NULL,'JSON','tinshift',0,NULL,'https://cdn.proj.org/no_kv_ETRS89NO_NGO48_TIN.json',1,1,NULL),
 ('arcgp-2006-sk.bin','no_kv_arcgp-2006-sk.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/no_kv_arcgp-2006-sk.tif',1,1,NULL),
 

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -883,7 +883,7 @@ TEST(operation, geog3DCRS_to_vertCRS_depth_context) {
                   "+step +proj=axisswap +order=2,1 "
                   "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                   "+step +inv +proj=vgridshift "
-                  "+grids=no_kv_CD_above_Ell_ETRS89_v2021a.tif +multiplier=1 "
+                  "+grids=no_kv_CD_above_Ell_ETRS89_v2023b.tif +multiplier=1 "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
                   "+step +proj=axisswap +order=2,1");
@@ -909,7 +909,7 @@ TEST(operation, geog3DCRS_to_vertCRS_depth_context) {
                   "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=vgridshift "
-                  "+grids=no_kv_CD_above_Ell_ETRS89_v2021a.tif +multiplier=1 "
+                  "+grids=no_kv_CD_above_Ell_ETRS89_v2023b.tif +multiplier=1 "
                   "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
                   "+step +proj=axisswap +order=2,1");
     }
@@ -940,7 +940,7 @@ TEST(operation, geog3DCRS_to_geog2DCRS_plus_vertCRS_depth_context) {
                   "+step +proj=axisswap +order=2,1 "
                   "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                   "+step +inv +proj=vgridshift "
-                  "+grids=no_kv_CD_above_Ell_ETRS89_v2021a.tif +multiplier=1 "
+                  "+grids=no_kv_CD_above_Ell_ETRS89_v2023b.tif +multiplier=1 "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
                   "+step +proj=axisswap +order=2,1");
@@ -966,7 +966,7 @@ TEST(operation, geog3DCRS_to_geog2DCRS_plus_vertCRS_depth_context) {
                   "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=vgridshift "
-                  "+grids=no_kv_CD_above_Ell_ETRS89_v2021a.tif +multiplier=1 "
+                  "+grids=no_kv_CD_above_Ell_ETRS89_v2023b.tif +multiplier=1 "
                   "+step +proj=unitconvert +xy_in=rad +xy_out=deg "
                   "+step +proj=axisswap +order=2,1");
     }


### PR DESCRIPTION

The transformation had been added in EPSG 11.001

```
$ echo 61.101 4.484  | PROJ_DATA=data:/home/even/proj/PROJ-data/no_kv PROJ_DEBUG=2 bin/cs2cs EPSG:4258+9672 EPSG:4937
pj_open_lib(proj.ini): call fopen(data/proj.ini) - succeeded
pj_open_lib(proj.db): call fopen(data/proj.db) - succeeded
pj_open_lib(ChartDatum_above_Ellipsoid_EUREF89_v2021b.bin): call fopen(/home/even/proj/PROJ-data/no_kv/ChartDatum_above_Ellipsoid_EUREF89_v2021b.bin) - failed
pj_open_lib(no_kv_CD_above_Ell_ETRS89_v2023b.tif): call fopen(/home/even/proj/PROJ-data/no_kv/no_kv_CD_above_Ell_ETRS89_v2023b.tif) - succeeded
pj_open_lib(no_kv_CD_above_Ell_ETRS89_v2021a.tif): call fopen(/home/even/proj/PROJ-data/no_kv/no_kv_CD_above_Ell_ETRS89_v2021a.tif) - succeeded
pj_open_lib(no_kv_CD_above_Ell_ETRS89_v2023b.tif): call fopen(/home/even/proj/PROJ-data/no_kv/no_kv_CD_above_Ell_ETRS89_v2023b.tif) - succeeded
pj_open_lib(no_kv_CD_above_Ell_ETRS89_v2021a.tif): call fopen(/home/even/proj/PROJ-data/no_kv/no_kv_CD_above_Ell_ETRS89_v2021a.tif) - succeeded
Using coordinate operation Inverse of ETRS89 to CD Norway depth (4)
pj_open_lib(no_kv_CD_above_Ell_ETRS89_v2023b.tif): call fopen(/home/even/proj/PROJ-data/no_kv/no_kv_CD_above_Ell_ETRS89_v2023b.tif) - succeeded
61d6'3.6"N	4d29'2.4"E 44.496
```

CC @himsve 