### PR TITLE
[Backport master] Fix `projsync --system-directory` command in install guide

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -187,10 +187,10 @@ Tests are run with::
 
     ctest
 
-With a successful install of PROJ we can now install data files using the
+With a successful install of PROJ, we can now install data files using the
 :program:`projsync` utility::
 
-    projsync --system-directory
+    projsync --system-directory --all
 
 which will download all resource files currently available for PROJ. If less than
 the entire collection of resource files is needed the call to :program:`projsync`


### PR DESCRIPTION
Backport #3981
 **Authored by:** @DeflateAwning