### PR TITLE
Add new DVR90 grids to grid alternatives

### DIFF
--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -123,7 +123,6 @@ VALUES
 -- dk_sdfe - Danish Agency for Data Supply and Efficiency
 -- Denmark mainland
 ('dnn.gtx','dk_sdfe_dnn.tif','dnn.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_dnn.tif',1,1,NULL),
-('dvr90.gtx','dk_sdfe_dvr90.tif','dvr90.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_dvr90.tif',1,1,NULL),
 --  Faroe islands height models
 ('fvr09.gtx','dk_sdfe_fvr09.tif','fvr09.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_fvr09.tif',1,1,NULL),
 -- Greenland height models

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -138,6 +138,9 @@ VALUES
 ('s34j_2022.gsb','dk_sdfi_s34j_2022.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_s34j_2022.tif',1,1,NULL),
 ('s34s_2022.gsb','dk_sdfi_s34s_2022.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_s34s_2022.tif',1,1,NULL),
 ('s45b_2022.gsb','dk_sdfi_s45b_2022.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_s45b_2022.tif',1,1,NULL),
+('dvr90_2002.tif','dk_sdfi_dvr90_2002.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_dvr90_2002.tif',1,1,NULL),
+('dvr90_2013.tif','dk_sdfi_dvr90_2013.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_dvr90_2013.tif',1,1,NULL),
+('dvr90_2023.tif','dk_sdfi_dvr90_2023.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/dk_sdfi_dvr90_2023.tif',1,1,NULL),
 
 -- es_cat_icgc - Institut Cartogràfic i Geològic de Catalunya (ICGC)
 ('100800401.gsb','es_cat_icgc_100800401.tif','100800401.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/es_cat_icgc_100800401.tif',1,1,NULL),

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -3,26 +3,6 @@
 -- Denmark
 
 INSERT INTO "grid_transformation" VALUES(
-    'PROJ','EPSG_4937_TO_EPSG_5799','ETRS89 to DVR90 height',
-    NULL,
-    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
-    'EPSG','4937', -- source CRS (ETRS89)
-    'EPSG','5799', -- target CRS (DVR90 height)
-    NULL,
-    'EPSG','8666','Geoid (height correction) model file','dvr90.gtx',
-    NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
-
-INSERT INTO "usage" VALUES(
-    'PROJ',
-    'EPSG_4937_TO_EPSG_5799_USAGE',
-    'grid_transformation',
-    'PROJ',
-    'EPSG_4937_TO_EPSG_5799',
-    'EPSG','3237', -- area of use: Denmark onshore
-    'EPSG','1024'  -- unknown
-);
-
-INSERT INTO "grid_transformation" VALUES(
     'PROJ','EPSG_4937_TO_EPSG_5733','ETRS89 to DNN height',
     NULL,
     'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',


### PR DESCRIPTION
Removes old custom DVR90 transformation from the database and adds new grids known by the EPSG-database to the list of grid alternatives.

In relation to https://github.com/OSGeo/PROJ-data/pull/115.

