### PR TITLE
[doc]: remove unneeded or broken links in resource_files.rst

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -254,16 +254,6 @@ Portugal
 
 `Portuguese grids <http://www.fc.up.pt/pessoas/jagoncal/coordenadas/index.htm>`__ for ED50, Lisbon 1890, Lisbon 1937 and Datum 73
 
-South Africa
-................................................................................
-
-`South African grid <http://eepublishers.co.za/article/datum-transformations-using-the-ntv2-grid.html>`__ (Cape to Hartebeesthoek94 or WGS84)
-
-Spain
-................................................................................
-
-`Spanish grids <http://www.ign.es/ign/layoutIn/herramientas.do#DATUM>`__ for ED50.
-
 
 HTDP
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Spanish transformation from ED50 to ETRS89 was already in PROJ-data.

The link to "South African grid" is broken. Asked people from "Department of Agriculture, Land Reform and Rural Development" , they answered:

"This link points to an article published by EE Publishers.
I am aware that EE Publishers published geospatially related articles in a publication named Position IT.
EE Publishers closed on 29 November 2019, therefore the broken link (see https://www.eebi.co.za/chris-yelland)
I am not aware of an officially published NTV2 grid for South Africa, so I would propose that you remove the link."