### PR TITLE
+proj=push/pop: add a +bank=<name> parameter to interleave push/pop operations

### DIFF
--- a/docs/source/operations/conversions/pop.rst
+++ b/docs/source/operations/conversions/pop.rst
@@ -86,6 +86,13 @@ Parameters
 
    Retrieves the fourth coordinate component from the pipeline stack
 
+.. option:: +bank=<bank_name>
+
+   .. versionadded:: 9.4.0
+
+   Restore the above components from a named "bank" instead of the pipeline
+   stack. This must be paired with a corresponding :ref:`push <push>` with the same bank name.
+
 
 Further reading
 ################################################################################

--- a/docs/source/operations/conversions/push.rst
+++ b/docs/source/operations/conversions/push.rst
@@ -85,6 +85,32 @@ Parameters
 
    Stores the fourth coordinate component on the pipeline stack
 
+.. option:: +bank=<bank_name>
+
+   .. versionadded:: 9.4.0
+
+   Store the above saved components into a named "bank" instead of the pipeline
+   stack. They will be restored when using :ref:`pop <pop>` with the same bank name.
+   Push/pop operations with bank names can be interleaved with other push/pop
+   operations with or without bank names.
+
+   The following example shows a ETRS89 to S-JTSK/05 + Baltic 1957 height
+   transformation that chains a geoid model registered against ETRS89 with a
+   Helmert transformation.
+
+   ::
+
+       +proj=pipeline \
+            +step +proj=push +v_3 +omit_inv \                               # Save ETRS89 ellipsoidal height
+            +step +inv +proj=vgridshift +grids=CR2005.tif +multiplier=1 \   # Apply geoid
+            +step +proj=push +v_3 +bank=baltic_height \                     # Save Baltic 1957 height
+            +step +proj=pop +v_3 +omit_inv \                                # Restore ETRS89 ellipsoidal height
+            +step +proj=cart +ellps=GRS80 \                                 # Helmert transformation
+            +step +inv +proj=helmert +x=572.213 +y=85.334 +z=461.94 \
+                +rx=-4.9732 +ry=-1.529 +rz=-5.2484 +s=3.5378 +convention=coordinate_frame \
+            +step +inv +proj=cart +ellps=bessel \
+            +step +proj=pop +v_3 +bank=baltic_height                        # Restore Baltic 1957 height
+
 
 Further reading
 ################################################################################

--- a/test/gie/4D-API_cs2cs-style.gie
+++ b/test/gie/4D-API_cs2cs-style.gie
@@ -394,6 +394,55 @@ accept      12 56 0 0
 expect      12 56 0 0
 
 -------------------------------------------------------------------------------
+# Test push/pop named banks
+-------------------------------------------------------------------------------
+
+# Simulate ETRS89 to S-JTSK/05 + Baltic 1957 height
+operation  +proj=pipeline \
+            +step +proj=push +v_3 +omit_inv \
+            +step +proj=affine +zoff=-50 \  # Simulate geoid grid
+            +step +proj=push +v_3 +bank=my_bank \
+            +step +proj=pop +v_3 +omit_inv \
+            +step +proj=cart +ellps=GRS80 \
+            +step +inv +proj=helmert +x=572.213 +y=85.334 +z=461.94 \
+                +rx=-4.9732 +ry=-1.529 +rz=-5.2484 +s=3.5378 +convention=coordinate_frame \
+            +step +inv +proj=cart +ellps=bessel \
+            +step +proj=pop +v_3 +bank=my_bank
+tolerance   1 mm
+
+accept      15              50                 1000
+expect      15.0011679017   50.0007533757      950.0000
+roundtrip   1
+
+# Show that all v_x work
+operation  +proj=pipeline \
+            +step +proj=push +v_1   +v_2   +v_3   +v_4    +bank=bank1 \
+            +step +proj=set  +v_1=0 +v_2=0 +v_3=0 +v_4=0              \
+            +step +proj=pop  +v_1   +v_2   +v_3   +v_4    +bank=bank1
+accept      1 2 3 4
+expect      1 2 3 4
+roundtrip   1
+
+# Several banks
+operation  +proj=pipeline \
+            +step +proj=push +v_1 +v_3 +bank=bank1 \
+            +step +proj=set +v_3=1000 \
+            +step +proj=push +v_1 +v_3 +bank=bank2 \
+            +step +proj=set +v_1=10 \
+            +step +proj=pop +v_1 +v_3 +bank=bank1 \
+            +step +proj=pop +v_3 +bank=bank2
+accept      1 2 3
+expect      1 2 1000
+
+
+# Error case: wrong bank name in pop
+operation  +proj=pipeline \
+            +step +proj=push +v_3 +bank=some_bank \
+            +step +proj=pop +v_3 +bank=unknown_bank
+accept      0 0 0
+expect      failure errno invalid_op_illegal_arg_value
+
+-------------------------------------------------------------------------------
 # Test Pipeline +omit_inv
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The motivation is to be able to do transformation that first do a geoid transformation followed by a Helmert one.

The following example shows a ETRS89 to S-JTSK/05 + Baltic 1957 height transformation that chains a geoid model registered against ETRS89 with a Helmert transformation.

```
       +proj=pipeline \
            +step +proj=push +v_3 +omit_inv \                         # Save ETRS89 ellipsoidal height
            +step +inv +proj=vgridshift +grids=CR2005.tif +multiplier=1 \  # Apply geoid
            +step +proj=push +v_3 +bank=baltic_height \               # Save Baltic 1957 height
            +step +proj=pop +v_3 +omit_inv \                          # Restore ETRS89 ellipsoidal height
            +step +proj=cart +ellps=GRS80 \                           # Helmert transformation
            +step +inv +proj=helmert +x=572.213 +y=85.334 +z=461.94 \
                +rx=-4.9732 +ry=-1.529 +rz=-5.2484 +s=3.5378 +convention=coordinate_frame \
            +step +inv +proj=cart +ellps=bessel \
            +step +proj=pop +v_3 +bank=baltic_height                  # Restore Baltic 1957 height
```

Without that, the current alternative is a ugly workaround involving using the v_4 component and axisswap
```
       +proj=pipeline \
            +step +proj=push +v_4 \                                   # Save v_4 as we are going to use it as a temp variable
            +step +proj=push +v_3 +omit_inv \                         # Save ETRS89 ellipsoidal height
            +step +inv +proj=vgridshift +grids=CR2005.tif +multiplier=1 \  # Apply geoid
            +step +proj=push +v_3 +omit_fwd \                         # On reverse path, restore initial Baltic height
            +step +proj=axisswap +order=1,2,4,3 +omit_inv \           # On forward path, save Baltic height in v_4 component...
            +step +proj=pop +v_3 +omit_inv \                          # On forward parth, restore initial ellipsoidal height
            +step +proj=cart +ellps=GRS80 \                           # Helmert transformation
            +step +inv +proj=helmert +x=572.213 +y=85.334 +z=461.94 \
                +rx=-4.9732 +ry=-1.529 +rz=-5.2484 +s=3.5378 +convention=coordinate_frame \
            +step +inv +proj=cart +ellps=bessel \
            +step +proj=axisswap +order=1,2,4,3 +omit_inv \           # On forward path, restore Baltic height from v_4 component...
            +step +proj=pop +v_3 +omit_fwd \                          # On reverse path, save initial Baltic height
            +step +proj=pop +v_4
```
