### PR TITLE
Update omerc.rst to add vital caveat about the two-point method

### DIFF
--- a/docs/source/operations/projections/omerc.rst
+++ b/docs/source/operations/projections/omerc.rst
@@ -182,3 +182,20 @@ Optional
 .. include:: ../options/x_0.rst
 
 .. include:: ../options/y_0.rst
+
+Caveats
+#######
+
+Note for the two-point method no rectification is done,
+
+::
+
+    echo 0 0|proj -I +proj=omerc +R=6400000 +lonc=-87 +lat_0=42 +alpha=0
+    87dW	42dN
+    echo 0 0|proj -I +proj=omerc +R=6400000 +lonc=-87 +lat_0=42 +alpha=0 +no_rot
+    87dW	0dS
+    echo 0 0|proj -I +proj=omerc +R=6400000 +lon_1=-87 +lat_1=42 +lon_2=-87 +lat_2=43
+    87dW	0dN
+
+Thus, just as was noted above regarding +no_rot, the two-point method
+itself is also probably only marginally useful.


### PR DESCRIPTION
It is imperative that users be informed about the vast difference of output of the two point method vs. one-point, undocumented till today!

See also
https://gis.stackexchange.com/questions/323570/proj-oblique-mercator-specifying-two-points-on-central-line/337169#337169
