### PR TITLE
Update migration.rst

### DIFF
--- a/docs/source/development/migration.rst
+++ b/docs/source/development/migration.rst
@@ -62,7 +62,7 @@ The same program implemented using PROJ 6:
         /* engine" used by PROJ to determine the best transformation(s) between */
         /* two CRS. */
         P = proj_create_crs_to_crs(PJ_DEFAULT_CTX,
-                                   "+proj=longlat +ellps=clrs66",
+                                   "+proj=longlat +ellps=clrk66",
                                    "+proj=merc +ellps=clrk66 +lat_ts=33",
                                    NULL);
         if (P==0)


### PR DESCRIPTION
Typo in "reimplemented in PROJ 6" example used "clrs66" in one case instead of "clrk66" so example didn't actually work.

I'd recommend #include <cmath> for the top too to pick up HUGE_VAL, but that isn't vital.

Thanks!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Added clear title that can be used to generate release notes
 - [ ] Fully documented, including updating `docs/source/*.rst` for new API