### PR TITLE
Add more compiler warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     -Wlogical-op
   )
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
-    -Werror=declaration-after-statement
     -Wmissing-prototypes
   )
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     -Wextra-semi
     # -Wold-style-cast
     -Woverloaded-virtual
-    # -Wzero-as-null-pointer-constant
+    -Wzero-as-null-pointer-constant
   )
 elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(PROJ_common_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
@@ -91,7 +91,7 @@ elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     -Woverloaded-virtual
     -Wshorten-64-to-32
     -Wunused-private-field
-    # -Wzero-as-null-pointer-constant
+    -Wzero-as-null-pointer-constant
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   add_definitions(/D_CRT_SECURE_NO_WARNINGS) # Eliminate deprecation warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,30 +44,55 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 # Set warnings as variables, then store as cache options
 set(PROJ_common_WARN_FLAGS  # common only to GNU/Clang C/C++
   -Wall
+  -Wdate-time
+  -Werror=format-security
+  -Werror=vla
   -Wextra
-  -Wswitch
-  -Wshadow
-  -Wunused-parameter
-  -Wmissing-declarations
   -Wformat
-  -Wformat-security
+  -Wmissing-declarations
+  -Wshadow
+  -Wswitch
+  -Wunused-parameter
 )
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(PROJ_common_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    -Wduplicated-cond
+    -Wduplicated-branches
+    -Wlogical-op
+  )
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    # -Werror=declaration-after-statement
+    -Wdeclaration-after-statement
     -Wmissing-prototypes
   )
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Weffc++
+    -Wextra-semi
+    # -Wold-style-cast
+    -Woverloaded-virtual
+    # -Wzero-as-null-pointer-constant
   )
 elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+  set(PROJ_common_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+    -Wcomma
+    -Wdeprecated
+    # -Wdocumentation -Wno-documentation-deprecated-sync
+    -Wfloat-conversion
+    -Wlogical-op-parentheses
+    # -Wweak-vtables
+  )
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Wmissing-prototypes
-    -Wfloat-conversion
     -Wc11-extensions
   )
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
-    -Wfloat-conversion
     -Weffc++
+    -Wextra-semi
+    # -Wold-style-cast
+    -Woverloaded-virtual
+    -Wshorten-64-to-32
+    -Wunused-private-field
+    # -Wzero-as-null-pointer-constant
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   add_definitions(/D_CRT_SECURE_NO_WARNINGS) # Eliminate deprecation warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(PROJ_common_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Wcomma
     -Wdeprecated
-    # -Wdocumentation -Wno-documentation-deprecated-sync
+    -Wdocumentation -Wno-documentation-deprecated-sync
     -Wfloat-conversion
     -Wlogical-op-parentheses
     # -Wweak-vtables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     -Wlogical-op
   )
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
-    # -Werror=declaration-after-statement
-    -Wdeclaration-after-statement
+    -Werror=declaration-after-statement
     -Wmissing-prototypes
   )
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}

--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -1760,8 +1760,7 @@ ConversionNNPtr Conversion::createPopularVisualisationPseudoMercator(
  * sphere at centerLat.
  *
  * This method is defined as
- * <a
- * href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
+ * <a href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
  * EPSG:1026</a>.
  *
  * @param properties See \ref general_properties of the conversion. If the name

--- a/src/tests/geodsigntest.c
+++ b/src/tests/geodsigntest.c
@@ -256,14 +256,14 @@ int main() {
     /* azimuth of geodesic line with points on equator determined by signs of
      * latitude
      * lat1 lat2 azi1/2 */
+    int i = 0;
+    T azi1, azi2;
     T C[2][3] = {
       { +0.0, -0.0, 180 },
       { -0.0, +0.0,   0 }
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
-    T azi1, azi2;
-    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], 0.0, nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][2]) + equiv(azi2, C[k][2]) ) ++i;
@@ -277,14 +277,14 @@ int main() {
   {
     /* Does the nearly antipodal equatorial solution go north or south?
      * lat1 lat2 azi1 azi2 */
+    int i = 0;
+    T azi1, azi2;
     T C[2][4] = {
       { +0.0, +0.0,  56, 124},
       { -0.0, -0.0, 124,  56}
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
-    T azi1, azi2;
-    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], 179.5, nullptr, &azi1, &azi2);
       i += checkEquals(azi1, C[k][2], 1) + checkEquals(azi2, C[k][3], 1);
@@ -299,6 +299,8 @@ int main() {
   {
     /* How does the exact antipodal equatorial path go N/S + E/W
      * lat1 lat2 lon2 azi1 azi2 */
+    int i = 0;
+    T azi1, azi2;
     T C[4][5] = {
       { +0.0, +0.0, +180,   +0.0, +180},
       { -0.0, -0.0, +180, +180,   +0.0},
@@ -307,8 +309,6 @@ int main() {
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
-    T azi1, azi2;
-    int i = 0;
     for (int k = 0; k < 4; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], C[k][2], nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][3]) + equiv(azi2, C[k][4]) ) ++i;
@@ -323,14 +323,14 @@ int main() {
   {
     /* Antipodal points on the equator with prolate ellipsoid
      * lon2 azi1/2 */
+    int i = 0;
+    T azi1, azi2;
     T C[2][2] = {
       { +180, +90 },
       { -180, -90 }
     };
     struct geod_geodesic g;
     geod_init(&g, 6.4e6, -1/300.0);
-    T azi1, azi2;
-    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, 0.0, 0.0, 0.0, C[k][0], nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][1]) + equiv(azi2, C[k][1]) ) ++i;
@@ -345,6 +345,8 @@ int main() {
   {
     /* azimuths = +/-0 and +/-180 for the direct problem
      * azi1, lon2, azi2 */
+    int i = 0;
+    T lon2, azi2;
     T C[4][3] = {
       { +0.0, +180, +180  },
       { -0.0, -180, -180  },
@@ -353,8 +355,6 @@ int main() {
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
-    T lon2, azi2;
-    int i = 0;
     for (int k = 0; k < 4; ++k) {
       geod_gendirect(&g, 0.0, 0.0, C[k][0], GEOD_LONG_UNROLL, 15e6,
                      nullptr, &lon2, &azi2,

--- a/src/tests/geodsigntest.c
+++ b/src/tests/geodsigntest.c
@@ -256,14 +256,14 @@ int main() {
     /* azimuth of geodesic line with points on equator determined by signs of
      * latitude
      * lat1 lat2 azi1/2 */
-    int i = 0;
-    T azi1, azi2;
     T C[2][3] = {
       { +0.0, -0.0, 180 },
       { -0.0, +0.0,   0 }
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
+    T azi1, azi2;
+    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], 0.0, nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][2]) + equiv(azi2, C[k][2]) ) ++i;
@@ -277,14 +277,14 @@ int main() {
   {
     /* Does the nearly antipodal equatorial solution go north or south?
      * lat1 lat2 azi1 azi2 */
-    int i = 0;
-    T azi1, azi2;
     T C[2][4] = {
       { +0.0, +0.0,  56, 124},
       { -0.0, -0.0, 124,  56}
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
+    T azi1, azi2;
+    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], 179.5, nullptr, &azi1, &azi2);
       i += checkEquals(azi1, C[k][2], 1) + checkEquals(azi2, C[k][3], 1);
@@ -299,8 +299,6 @@ int main() {
   {
     /* How does the exact antipodal equatorial path go N/S + E/W
      * lat1 lat2 lon2 azi1 azi2 */
-    int i = 0;
-    T azi1, azi2;
     T C[4][5] = {
       { +0.0, +0.0, +180,   +0.0, +180},
       { -0.0, -0.0, +180, +180,   +0.0},
@@ -309,6 +307,8 @@ int main() {
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
+    T azi1, azi2;
+    int i = 0;
     for (int k = 0; k < 4; ++k) {
       geod_inverse(&g, C[k][0], 0.0, C[k][1], C[k][2], nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][3]) + equiv(azi2, C[k][4]) ) ++i;
@@ -323,14 +323,14 @@ int main() {
   {
     /* Antipodal points on the equator with prolate ellipsoid
      * lon2 azi1/2 */
-    int i = 0;
-    T azi1, azi2;
     T C[2][2] = {
       { +180, +90 },
       { -180, -90 }
     };
     struct geod_geodesic g;
     geod_init(&g, 6.4e6, -1/300.0);
+    T azi1, azi2;
+    int i = 0;
     for (int k = 0; k < 2; ++k) {
       geod_inverse(&g, 0.0, 0.0, 0.0, C[k][0], nullptr, &azi1, &azi2);
       if ( equiv(azi1, C[k][1]) + equiv(azi2, C[k][1]) ) ++i;
@@ -345,8 +345,6 @@ int main() {
   {
     /* azimuths = +/-0 and +/-180 for the direct problem
      * azi1, lon2, azi2 */
-    int i = 0;
-    T lon2, azi2;
     T C[4][3] = {
       { +0.0, +180, +180  },
       { -0.0, -180, -180  },
@@ -355,6 +353,8 @@ int main() {
     };
     struct geod_geodesic g;
     geod_init(&g, wgs84_a, wgs84_f);
+    T lon2, azi2;
+    int i = 0;
     for (int k = 0; k < 4; ++k) {
       geod_gendirect(&g, 0.0, 0.0, C[k][0], GEOD_LONG_UNROLL, 15e6,
                      nullptr, &lon2, &azi2,

--- a/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
+++ b/test/fuzzers/proj_crs_to_crs_fuzzer.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
         return 0;
     } else {
         int nRet = 0;
-        void *buf = NULL;
+        void *buf = nullptr;
         int nLen = 0;
         FILE *f = fopen(argv[1], "rb");
         if (!f) {

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -144,7 +144,7 @@ TEST(gie, cart_selftest) {
     b = proj_trans(P, PJ_FWD, b);
 
     /* Move it back to the default context */
-    proj_context_set(P, 0);
+    proj_context_set(P, nullptr);
     ASSERT_EQ(pj_get_default_ctx(), P->ctx);
 
     proj_context_destroy(ctx);
@@ -168,8 +168,8 @@ TEST(gie, cart_selftest) {
     b = proj_trans(P, PJ_FWD, obs[1]);
 
     n = proj_trans_generic(P, PJ_FWD, &(obs[0].lpz.lam), sz, 2,
-                           &(obs[0].lpz.phi), sz, 2, &(obs[0].lpz.z), sz, 2, 0,
-                           sz, 0);
+                           &(obs[0].lpz.phi), sz, 2, &(obs[0].lpz.z), sz, 2,
+                           nullptr, sz, 0);
     ASSERT_EQ(n, 2U);
 
     ASSERT_EQ(a.lpz.lam, obs[0].lpz.lam);
@@ -264,7 +264,7 @@ class gieTest : public ::testing::Test {
 TEST_F(gieTest, proj_create_crs_to_crs) {
     /* test proj_create_crs_to_crs() */
     auto P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, "epsg:25832", "epsg:25833",
-                                    NULL);
+                                    nullptr);
     ASSERT_TRUE(P != nullptr);
     PJ_COORD a, b;
 
@@ -288,7 +288,7 @@ TEST_F(gieTest, proj_create_crs_to_crs) {
 
     /* we can also allow PROJ strings as a usable PJ */
     P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, "proj=utm +zone=32 +datum=WGS84",
-                               "proj=utm +zone=33 +datum=WGS84", NULL);
+                               "proj=utm +zone=33 +datum=WGS84", nullptr);
     ASSERT_TRUE(P != nullptr);
     proj_destroy(P);
 
@@ -303,7 +303,7 @@ TEST_F(gieTest, proj_create_crs_to_crs) {
 TEST_F(gieTest, proj_create_crs_to_crs_EPSG_4326) {
 
     auto P =
-        proj_create_crs_to_crs(PJ_DEFAULT_CTX, "EPSG:4326", "EPSG:32631", NULL);
+        proj_create_crs_to_crs(PJ_DEFAULT_CTX, "EPSG:4326", "EPSG:32631", nullptr);
     ASSERT_TRUE(P != nullptr);
     PJ_COORD a, b;
 
@@ -327,7 +327,7 @@ TEST_F(gieTest, proj_create_crs_to_crs_EPSG_4326) {
 TEST_F(gieTest, proj_create_crs_to_crs_proj_longlat) {
 
     auto P = proj_create_crs_to_crs(
-        PJ_DEFAULT_CTX, "+proj=longlat +datum=WGS84", "EPSG:32631", NULL);
+        PJ_DEFAULT_CTX, "+proj=longlat +datum=WGS84", "EPSG:32631", nullptr);
     ASSERT_TRUE(P != nullptr);
     PJ_COORD a, b;
 
@@ -729,7 +729,7 @@ static void test_time(const char *args, double tol, double t_in, double t_exp) {
     PJ_COORD in, out;
     PJ *P = proj_create(PJ_DEFAULT_CTX, args);
 
-    ASSERT_TRUE(P != 0);
+    ASSERT_TRUE(P != nullptr);
 
     in = proj_coord(0.0, 0.0, 0.0, t_in);
 
@@ -741,7 +741,7 @@ static void test_time(const char *args, double tol, double t_in, double t_exp) {
 
     proj_destroy(P);
 
-    proj_log_level(NULL, PJ_LOG_NONE);
+    proj_log_level(nullptr, PJ_LOG_NONE);
 }
 
 // ---------------------------------------------------------------------------
@@ -773,7 +773,7 @@ static void test_date(const char *args, double tol, double t_in, double t_exp) {
     PJ_COORD in, out;
     PJ *P = proj_create(PJ_DEFAULT_CTX, args);
 
-    ASSERT_TRUE(P != 0);
+    ASSERT_TRUE(P != nullptr);
 
     in = proj_coord(0.0, 0.0, 0.0, t_in);
 
@@ -782,7 +782,7 @@ static void test_date(const char *args, double tol, double t_in, double t_exp) {
 
     proj_destroy(P);
 
-    proj_log_level(NULL, PJ_LOG_NONE);
+    proj_log_level(nullptr, PJ_LOG_NONE);
 }
 
 TEST(gie, unitconvert_selftest_date) {

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -4223,7 +4223,7 @@ TEST_F(CApi, proj_get_celestial_body_list_from_database) {
 
     {
         auto list =
-            proj_get_celestial_body_list_from_database(nullptr, nullptr, 0);
+            proj_get_celestial_body_list_from_database(nullptr, nullptr, nullptr);
         ASSERT_NE(list, nullptr);
         ASSERT_NE(list[0], nullptr);
         ASSERT_NE(list[0]->auth_name, nullptr);
@@ -4668,7 +4668,7 @@ TEST_F(CApi, proj_context_copy_from_default) {
 
 TEST_F(CApi, proj_context_clone) {
     int new_init_rules =
-        proj_context_get_use_proj4_init_rules(NULL, 0) > 0 ? 0 : 1;
+        proj_context_get_use_proj4_init_rules(nullptr, 0) > 0 ? 0 : 1;
     PJ_CONTEXT *new_ctx = proj_context_create();
     EXPECT_NE(new_ctx, nullptr);
     PjContextKeeper keeper_ctxt(new_ctx);


### PR DESCRIPTION
As discussed [here](https://github.com/OSGeo/PROJ/pull/4059#issuecomment-1955583676), this PR adds more compiler warning flags that were lost from the Autotools -> CMake transition. See the old [configure.ac](https://github.com/OSGeo/PROJ/blob/8.2/configure.ac) file for what was previously used.

A few warnings are resolved in this PR as separate commits.

Warnings that are not-yet enabled or resolved in this PR include:

- [ ] `-Wold-style-cast` - this might take a while to sort-out
- [ ] `-Wweak-vtables` - probably simple, but not obvious