### PR TITLE
CI: add support for Conda osx_arm64 builds

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: ['ubuntu-latest','windows-latest','macos-latest']
+        platform: ['ubuntu-latest','windows-latest','macos-latest','macos-14']
 
     env:
       PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
Now that
https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.2 has been released with support for them.
