### PR TITLE
proj_normalize_for_visualization: check other left-handed orders, not…

### DIFF
--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -870,8 +870,14 @@ static bool mustAxisOrderBeSwitchedForVisualizationInternal(
     const std::vector<cs::CoordinateSystemAxisNNPtr> &axisList) {
     const auto &dir0 = axisList[0]->direction();
     const auto &dir1 = axisList[1]->direction();
-    if (&dir0 == &cs::AxisDirection::NORTH &&
-        &dir1 == &cs::AxisDirection::EAST) {
+    if ((&dir0 == &cs::AxisDirection::NORTH &&
+         &dir1 == &cs::AxisDirection::EAST) ||
+        (&dir0 == &cs::AxisDirection::EAST &&
+         &dir1 == &cs::AxisDirection::SOUTH) ||
+        (&dir0 == &cs::AxisDirection::SOUTH &&
+         &dir1 == &cs::AxisDirection::WEST) ||
+        (&dir0 == &cs::AxisDirection::WEST &&
+         &dir1 == &cs::AxisDirection::NORTH)) {
         return true;
     }
 

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -4456,6 +4456,29 @@ TEST_F(CApi, proj_normalize_for_visualization_on_crs) {
 
 // ---------------------------------------------------------------------------
 
+TEST_F(CApi, proj_normalize_for_visualization_on_crs_westing_southing) {
+
+    auto P = proj_create(m_ctxt, "EPSG:5513");
+    ObjectKeeper keeper_P(P);
+    ASSERT_NE(P, nullptr);
+    auto Pnormalized = proj_normalize_for_visualization(m_ctxt, P);
+    ObjectKeeper keeper_Pnormalized(Pnormalized);
+    ASSERT_NE(Pnormalized, nullptr);
+    EXPECT_EQ(proj_get_id_code(Pnormalized, 0), nullptr);
+
+    auto cs = proj_crs_get_coordinate_system(m_ctxt, Pnormalized);
+    ASSERT_NE(cs, nullptr);
+    ObjectKeeper keeperCs(cs);
+
+    const char *name = nullptr;
+    ASSERT_TRUE(proj_cs_get_axis_info(m_ctxt, cs, 0, &name, nullptr, nullptr,
+                                      nullptr, nullptr, nullptr, nullptr));
+    ASSERT_NE(name, nullptr);
+    EXPECT_EQ(std::string(name), "Westing");
+}
+
+// ---------------------------------------------------------------------------
+
 TEST_F(CApi, proj_coordoperation_create_inverse) {
 
     auto P = proj_create(


### PR DESCRIPTION
… only N-E

A few CRSs use left-handed orders other than N-E, like S-W in [EPSG:5513](https://spatialreference.org/ref/epsg/5513/)

 - [x] Closes https://github.com/qgis/QGIS/issues/56802
 - [x] Tests added
 - [x] Added clear title that can be used to generate release notes
