### PR TITLE
[CI]: avoid failure in mingw_w64_build if .ccache doesn't exist

### DIFF
--- a/.github/workflows/mingw_w64/start.sh
+++ b/.github/workflows/mingw_w64/start.sh
@@ -123,4 +123,4 @@ ccache -s
 
 echo "Saving ccache..."
 rm -f "$WORK_DIR/ccache.tar.gz"
-(cd $HOME && tar czf "$WORK_DIR/ccache.tar.gz" .ccache)
+(cd $HOME && test ! -e .ccache || tar czf "$WORK_DIR/ccache.tar.gz" .ccache)


### PR DESCRIPTION
The job `mingw_w64_build` in the GitHub actions is failing every single time for my user.

https://github.com/jjimenezshaw/PROJ/actions/runs/8307545992/job/22736867676

After checking that also fails for @rouault and it doesn't in master, I did this PR