### PR TITLE
Retry "Connection reset by peer"

### DIFF
--- a/src/networkfilemanager.cpp
+++ b/src/networkfilemanager.cpp
@@ -1675,6 +1675,7 @@ static double GetNewRetryDelay(int response_code, double dfOldDelay,
         // S3 sends some client timeout errors as 400 Client Error
         (response_code == 400 && pszErrBuf &&
          strstr(pszErrBuf, "RequestTimeout")) ||
+        (pszCurlError && strstr(pszCurlError, "Connection reset by peer")) ||
         (pszCurlError && strstr(pszCurlError, "Connection timed out"))) {
         // Use an exponential backoff factor of 2 plus some random jitter
         // We don't care about cryptographic quality randomness, hence:


### PR DESCRIPTION
Building the GDAL image can fail with:

Downloading https://cdn.proj.org/fr_ign_RAF18b.tif... (132 / 423)
Downloading https://cdn.proj.org/fr_ign_RAF20.tif... (133 / 423)
Downloading https://cdn.proj.org/fr_ign_RAGTBT2016.tif... (134 / 423)
Cannot open https://cdn.proj.org/fr_ign_RAGTBT2016.tif: OpenSSL SSL_read: Connection reset by peer, errno 104

so add the connection reset by peer
to the list of things that get a retry
time.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Tests added
- [X] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
