### PR TITLE
Update cct.rst to release pressure on man page formatter

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -28,7 +28,9 @@ by :c:func:`proj_create`, provided it expresses a coordinate operation
     - an object name. e.g. "ITRF2014 to ETRF2014 (1)". In that case as
       uniqueness is not guaranteed, heuristics are applied to determine the appropriate best match.
     - a OGC URN combining references for concatenated operations
-      (e.g. "urn:ogc:def:coordinateOperation,coordinateOperation:EPSG::3895,coordinateOperation:EPSG::1618")
+      (e.g. "urn:ogc:def:coordinateOperation,
+      coordinateOperation:EPSG::3895,
+      coordinateOperation:EPSG::1618")
     - a PROJJSON string. The jsonschema is at https://proj.org/schemas/v0.4/projjson.schema.json
 
     .. versionadded:: 8.0.0


### PR DESCRIPTION
For https://github.com/OSGeo/PROJ/issues/4103

Pssst, I didn't actually test it, in cct nor in man.

I suppose these newlines should be rendered as spaces and allow breaking the line.