### PR TITLE
Backport NKG unique names

### DIFF
--- a/data/sql/nkg.sql
+++ b/data/sql/nkg.sql
@@ -1,6 +1,6 @@
 INSERT INTO "metadata" VALUES('NKG.SOURCE', 'https://github.com/NordicGeodesy/NordicTransformations');
-INSERT INTO "metadata" VALUES('NKG.VERSION', '1.0.0');
-INSERT INTO "metadata" VALUES('NKG.DATE', '2020-12-21');
+INSERT INTO "metadata" VALUES('NKG.VERSION', '1.0.1');
+INSERT INTO "metadata" VALUES('NKG.DATE', '2024-04-02');
 
 -- extent for NKG2008 transformations
 INSERT INTO "extent" VALUES(
@@ -687,7 +687,7 @@ INSERT INTO "usage" VALUES (
 -- NO
 INSERT INTO "helmert_transformation" VALUES (
     'NKG','PAR_2020_NO', -- operation auth+code
-    'NKG_ETRF14 to ETRF93@2000.0', -- name
+    'NKG_ETRF14 to ETRF93@2000.0 (Helmert)', -- name
     'Transformation from NKG_ETRF14 to ETRF93, at transformation reference epoch 2000.0', -- description / remark
     'EPSG','1033',  -- method auth+code
     'Position Vector transformation (geocentric domain)',
@@ -735,9 +735,9 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'NKG_ETRF14_ETRF93_2000', -- object auth+code
-    'NKG_ETRF14 to ETRF93@2000.0', -- name
+    'NKG_ETRF14 to ETRF93@2000.0 (Gridshift)', -- name
     'Transformation from NKG_ETRF14 to ETRF93, at transformation reference epoch 2000.0', -- description / remark
-    'PROJ', 'PROJString', 
+    'PROJ', 'PROJString',
     '+proj=xyzgridshift +grids=no_kv_NKGETRF14_EPSG7922_2000.tif',
     'NKG','ETRF14',  -- source auth+code
     'EPSG','7922',   -- target auth+code
@@ -812,7 +812,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF92_2000_TO_ETRF92_1994',-- object auth+code
-    'ETRF92@2000.0 to ETRF92@1994.704', -- name
+    'ETRF92@2000.0 to ETRF92@1994.704 using nkgrf03vel_realigned', -- name
     NULL, -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-5.296 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -917,7 +917,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF96_2000_TO_ETRF96_1997_56',-- object auth+code
-    'ETRF96@2000.0 to ETRF96@1997.56', -- name
+    'ETRF96@2000.0 to ETRF96@1997.56 using nkgrf03vel_realigned', -- name
     NULL, -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-2.44 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1025,7 +1025,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF96_2000_TO_ETRF96_1997',-- object auth+code
-    'ETRF96@2000.0 to ETRF96@1997.0',     -- name
+    'ETRF96@2000.0 to ETRF96@1997.0 using nkgrf03vel_realigned',     -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-3.0 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1133,7 +1133,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF89_2000_TO_ETRF89_1992',-- object auth+code
-    'ETRF89@2000.0 to ETRF89@1992.75',  -- name
+    'ETRF89@2000.0 to ETRF89@1992.75 using nkgrf03vel_realigned',  -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-7.25 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1240,7 +1240,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF2000_2000_TO_ETRF_2000_2003',-- object auth+code
-    'ETRF2000@2000.0 to ETRF2000@2003.75',  -- name
+    'ETRF2000@2000.0 to ETRF2000@2003.75 using nkgrf03vel_realigned',  -- name
     NULL,                                   -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=3.75 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1347,7 +1347,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF93_2000_TO_ETRF93_1995',-- object auth+code
-    'ETRF93@2000.0 to ETRF93@1995.0',   -- name
+    'ETRF93@2000.0 to ETRF93@1995.0 using nkgrf03vel_realigned',   -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-5 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1454,7 +1454,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'ETRF97_2000_TO_ETRF97_1999',-- object auth+code
-    'ETRF97@2000.0 to ETRF97@1999.5',   -- name
+    'ETRF97@2000.0 to ETRF97@1999.5 using nkgrf03vel_realigned',   -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-0.5 +grids=eur_nkg_nkgrf03vel_realigned.tif',
@@ -1559,7 +1559,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'DK_2020_INTRAPLATE',        -- object auth+code
-    'ETRF92@2000.0 to ETRF92@1994.704', -- name
+    'ETRF92@2000.0 to ETRF92@1994.704 using nkgrf17vel', -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=15.829 +grids=eur_nkg_nkgrf17vel.tif',
@@ -1673,7 +1673,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'EE_2020_INTRAPLATE',-- object auth+code
-    'ETRF96@2000.0 to ETRF96@1997.56', -- name
+    'ETRF96@2000.0 to ETRF96@1997.56 using nkgrf17vel', -- name
     NULL, -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-2.44 +grids=eur_nkg_nkgrf17vel.tif',
@@ -1789,7 +1789,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'FI_2020_INTRAPLATE',-- object auth+code
-    'ETRF96@2000.0 to ETRF96@1997.0', -- name
+    'ETRF96@2000.0 to ETRF96@1997.0 using nkgrf17vel', -- name
     NULL, -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-3 +grids=eur_nkg_nkgrf17vel.tif',
@@ -1905,7 +1905,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'LV_2020_INTRAPLATE',        -- object auth+code
-    'ETRF89@2000.0 to ETRF89@1992.75 (LKS-92)',  -- name
+    'ETRF89@2000.0 to ETRF89@1992.75 (LKS-92) using nkgrf17vel',  -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-7.25 +grids=eur_nkg_nkgrf17vel.tif',
@@ -2021,7 +2021,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'LT_2020_INTRAPLATE',            -- object auth+code
-    'ETRF2000@2000.0 to ETRF2000@2003.75 (LKS94)',  -- name
+    'ETRF2000@2000.0 to ETRF2000@2003.75 (LKS94) using nkgrf17vel',  -- name
     NULL,                                   -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=3.75 +grids=eur_nkg_nkgrf17vel.tif',
@@ -2137,7 +2137,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'NO_2020_INTRAPLATE',        -- object auth+code
-    'ETRF93@2000.0 to ETRF93@1995.0',   -- name
+    'ETRF93@2000.0 to ETRF93@1995.0 using nkgrf17vel',   -- name
     NULL,                               -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-5 +grids=eur_nkg_nkgrf17vel.tif',
@@ -2202,7 +2202,7 @@ INSERT INTO "concatenated_operation_step" (
     operation_auth_name, operation_code, step_number, step_auth_name, step_code
 ) VALUES
     ('NKG', 'ITRF2014_TO_NO', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_NO', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'), 
+    ('NKG', 'ITRF2014_TO_NO', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
     ('NKG', 'ITRF2014_TO_NO', 3, 'NKG', 'NKG_ETRF14_ETRF93_2000'),
     ('NKG', 'ITRF2014_TO_NO', 4, 'NKG', 'NO_2020_INTRAPLATE')
 ;
@@ -2247,7 +2247,7 @@ INSERT INTO "other_transformation" (
 )
 VALUES(
     'NKG', 'SE_2020_INTRAPLATE',-- object auth+code
-    'ETRF97@2000.0 to ETRF97@1999.5', -- name
+    'ETRF97@2000.0 to ETRF97@1999.5 using nkgrf17vel', -- name
     NULL, -- description
     'PROJ', 'PROJString',               -- method auth+cod
     '+proj=deformation +dt=-0.5 +grids=eur_nkg_nkgrf17vel.tif',

--- a/data/sql/nkg.sql
+++ b/data/sql/nkg.sql
@@ -311,7 +311,7 @@ INSERT INTO "usage" VALUES (
 -- EE
 INSERT INTO "helmert_transformation" VALUES (
     'NKG','P1_2008_EE', -- operation auth+code
-    'NKG_ETRF00 to ETRF96@2000.0', -- name
+    'NKG_ETRF00 to ETRF96@2000.0 (Estonia)', -- name
     'Transformation from NKG_ETRF00 to ETRF96, at transformation reference epoch 2000.0', -- description / remark
     'EPSG','1033',  -- method auth+code
     'Position Vector transformation (geocentric domain)',
@@ -345,7 +345,7 @@ INSERT INTO "usage" VALUES (
 -- FI
 INSERT INTO "helmert_transformation" VALUES (
     'NKG','P1_2008_FI', -- operation auth+code
-    'NKG_ETRF00 to ETRF96@2000.0', -- name
+    'NKG_ETRF00 to ETRF96@2000.0 (Finland)', -- name
     'Transformation from NKG_ETRF00 to ETRF96, at transformation reference epoch 2000.0', -- description / remark
     'EPSG','1033',  -- method auth+code
     'Position Vector transformation (geocentric domain)',
@@ -553,7 +553,7 @@ INSERT INTO "usage" VALUES (
 -- EE
 INSERT INTO "helmert_transformation" VALUES (
     'NKG','PAR_2020_EE', -- operation auth+code
-    'NKG_ETRF14 to ETRF96@2000.0', -- name
+    'NKG_ETRF14 to ETRF96@2000.0 (Estonia)', -- name
     'Transformation from NKG_ETRF14 to ETRF96, at transformation reference epoch 2000.0', -- description / remark
     'EPSG','1033',  -- method auth+code
     'Position Vector transformation (geocentric domain)',
@@ -587,7 +587,7 @@ INSERT INTO "usage" VALUES (
 -- FI
 INSERT INTO "helmert_transformation" VALUES (
     'NKG','PAR_2020_FI', -- operation auth+code
-    'NKG_ETRF14 to ETRF96@2000.0', -- name
+    'NKG_ETRF14 to ETRF96@2000.0 (Finland)', -- name
     'Transformation from NKG_ETRF14 to ETRF96, at transformation reference epoch 2000.0', -- description / remark
     'EPSG','1033',  -- method auth+code
     'Position Vector transformation (geocentric domain)',

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -1970,7 +1970,7 @@ TEST(operation, geogCRS_to_geogCRS_with_intermediate_no_ids) {
             "Conversion from ITRF2014 (geog3D) to ITRF2014 (geocentric) + "
             "ITRF2014 to ETRF2014 (1) + "
             "Inverse of NKG_ETRF14 to ETRF2014 + "
-            "NKG_ETRF14 to ETRF96@2000.0 + "
+            "NKG_ETRF14 to ETRF96@2000.0 (Estonia) + "
             "ETRF96@2000.0 to ETRF96@1997.56 using nkgrf17vel + "
             "Conversion from ETRS89 (geocentric) to ETRS89 (geog2D) + "
             "Inverse of EST97 to ETRS89 (1) + "

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -1971,7 +1971,7 @@ TEST(operation, geogCRS_to_geogCRS_with_intermediate_no_ids) {
             "ITRF2014 to ETRF2014 (1) + "
             "Inverse of NKG_ETRF14 to ETRF2014 + "
             "NKG_ETRF14 to ETRF96@2000.0 + "
-            "ETRF96@2000.0 to ETRF96@1997.56 + "
+            "ETRF96@2000.0 to ETRF96@1997.56 using nkgrf17vel + "
             "Conversion from ETRS89 (geocentric) to ETRS89 (geog2D) + "
             "Inverse of EST97 to ETRS89 (1) + "
             "Null geographic offset from EST97 (geog2D) to EST97 (geog3D) + "


### PR DESCRIPTION
Backport of #4098 and 92de8aa956fffdd75f1d. I guess this could be omitted since the name consistency checks have not been backported (yet?) but it may as well be kept up to date.

@rouault let me know if you disagree with this backport.