### PR TITLE
Update cct.rst warning of DMS dangers

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -57,6 +57,8 @@ performs transformation coordinate systems on a set of input points. The
 coordinate system transformation can include translation between projected
 and geographic coordinates as well as the application of datum shifts.
 
+Note however that unlike the :program:`proj`, angular input must be in decimal degrees.
+Any minutes and seconds given will be silently dropped.
 
 The following control parameters can appear in any order:
 


### PR DESCRIPTION
Proof:
```
echo 12.5 55       | cct -z0 -t0 +proj=utm +zone=32 +ellps=GRS80
echo 12d30\'0\" 55 | cct -z0 -t0 +proj=utm +zone=32 +ellps=GRS80
echo 12 55         | cct -z0 -t0 +proj=utm +zone=32 +ellps=GRS80
  723842.2602   6100394.7568        0.0000        0.0000
  691875.6321   6098907.8250        0.0000        0.0000
  691875.6321   6098907.8250        0.0000        0.0000
```
