### PR TITLE
Update proj-docs Docker image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["proj","proj-docs"]
+        container: ["proj","proj-docs-2404"]
         dockerfile: ["./Dockerfile", "./docs/docbuild/Dockerfile"]
         exclude:
           - container: "proj"
             dockerfile: "./docs/docbuild/Dockerfile"
-          - container: "proj-docs"
+          - container: "proj-docs-2404"
             dockerfile: "./Dockerfile"
     env:
       PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/Doxyfile
+++ b/Doxyfile
@@ -2010,7 +2010,8 @@ PREDEFINED             =    DOXYGEN_ENABLED \
                             PROJ_OPAQUE_PRIVATE_DATA= \
                             PROJ_PRIVATE=private \
                             PROJ_PURE_DECL= \
-                            noexceptoverride="noexcept override"
+                            noexceptoverride="noexcept override" \
+                            PROJ_NO_RETURN=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-dev python3-pip g++ doxygen dvipng latexmk \
@@ -6,10 +6,15 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     texlive-latex-extra git latex-cjk-all texlive-lang-all \
     graphviz python3-matplotlib wget unzip enchant-2 locales
 
-RUN python3 -m pip install "Sphinx<7" breathe \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python3 -m pip install Sphinx breathe \
     sphinx_bootstrap_theme sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
-    "sphinxcontrib-spelling!=7.4.0,<8"
+    sphinxcontrib-spelling setuptools
 
 # Set the locale for spelling
 RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -17,16 +22,3 @@ RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_GB.UTF-8
 
 ENV LANG en_GB.UTF-8
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl flex bison && \
-        curl -LOs https://doxygen.nl/files/doxygen-1.9.5.src.tar.gz && \
-        tar xvzf doxygen-1.9.5.src.tar.gz && \
-        rm -rf doxygen-1.9.5.src.tar.gz && \
-        cd doxygen-1.9.5 && \
-        mkdir build && \
-        cd build && \
-        cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
-        make -j$(nproc) && \
-        make install && \
-        cd ../.. && \
-        rm -rf doxygen-1.9.5

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -1541,6 +1541,7 @@ void WKTParser::Private::emitRecoverableWarning(const std::string &errorMsg) {
         warningList_.push_back(errorMsg);
     }
 }
+//! @endcond
 
 // ---------------------------------------------------------------------------
 
@@ -1552,6 +1553,7 @@ void WKTParser::Private::emitGrammarError(const std::string &errorMsg) {
         grammarErrorList_.push_back(errorMsg);
     }
 }
+//! @endcond
 
 // ---------------------------------------------------------------------------
 
@@ -1597,6 +1599,7 @@ static ParsingException buildRethrow(const char *funcName,
 
 // ---------------------------------------------------------------------------
 
+//! @cond Doxygen_Suppress
 std::string WKTParser::Private::stripQuotes(const WKTNodeNNPtr &node) {
     return ::stripQuotes(node->GP()->value());
 }
@@ -5705,9 +5708,11 @@ BaseObjectNNPtr WKTParser::Private::build(const WKTNodeNNPtr &node) {
 
     throw ParsingException(concat("unhandled keyword: ", name));
 }
+//! @endcond
 
 // ---------------------------------------------------------------------------
 
+//! @cond Doxygen_Suppress
 class JSONParser {
     DatabaseContextPtr dbContext_{};
     std::string deformationModelName_{};
@@ -7103,7 +7108,11 @@ EllipsoidNNPtr JSONParser::buildEllipsoid(const json &j) {
     throw ParsingException("Missing semi_major_axis or radius");
 }
 
+//! @endcond
+
 // ---------------------------------------------------------------------------
+
+//! @cond Doxygen_Suppress
 
 // import a CRS encoded as OGC Best Practice document 11-135.
 


### PR DESCRIPTION
- Fixes to make doc building work with Doxygen 1.9.8
- docbuild/Dockerfile: update to Ubuntu 24.04, and remove no longer pins of a few packages
- .github/workflows/docker.yml: (temporarily?) build proj-docs as proj-docs-2404

I believe the only user of proj-docs now is GDAL docs. I've succesfully tested the proposed update with the changes in https://github.com/OSGeo/gdal/pull/9784. I've also run PROJ doc building within the updated Docker image, although we only use readthedocs right now.
