### PR TITLE
bindings.rst: Add link to Perl bindings

### DIFF
--- a/docs/source/development/bindings.rst
+++ b/docs/source/development/bindings.rst
@@ -40,6 +40,11 @@ MySQL
 `fProj4 <https://sourceforge.net/projects/mysqlscientific/files/fPROJ4/>`_:
 Bindings for PROJ in MySQL
 
+Perl
+====
+`Geo::LibProj::FFI <https://metacpan.org/pod/Geo::LibProj::FFI>`_:
+Foreign function interface for PROJ (version 6 and newer) in Perl
+
 Python
 ======
 `pyproj <https://pypi.python.org/pypi/pyproj>`_:

--- a/docs/source/development/bindings.rst
+++ b/docs/source/development/bindings.rst
@@ -6,10 +6,22 @@ Language bindings
 
 PROJ bindings are available for a number of different development platforms.
 
-Python
-======
-`pyproj <https://pypi.python.org/pypi/pyproj>`_:
-Python interface (wrapper for PROJ)
+Excel
+=====
+
+`proj.xll <https://github.com/jbuonagurio/proj.xll>`_:
+Excel add-in for PROJ map projections
+
+Fortran
+=======
+
+`Fortran-Proj <https://gitlab.com/likeno/fortran-proj>`_:
+Bindings for PROJ in Fortran (By João Macedo @likeno)
+
+Go (Golang)
+===========
+`go-proj <https://github.com/twpayne/go-proj>`_:
+Go bindings for PROJ.
 
 Java
 ====
@@ -17,32 +29,10 @@ Java
 `PROJ-JNI <https://github.com/OSGeo/PROJ-JNI>`_:
 Java Native Interface for PROJ
 
-Ruby
-=======
-
-`proj4rb <https://github.com/cfis/proj4rb>`_:
-Bindings for PROJ in ruby
-
-Rust
-=======
-
-`proj <https://github.com/georust/proj>`_:
-Rust bindings for the latest stable version of PROJ
-
-Go (Golang)
-===========
-`go-proj <https://github.com/twpayne/go-proj>`_:
-Go bindings for PROJ.
-
 Julia
 =====
 `Proj.jl <https://github.com/JuliaGeo/Proj.jl>`_:
 Julia bindings and idiomatic wrapper for PROJ.
-
-TCL
-========
-`proj4tcl <http://wiki.tcl.tk/41270>`_:
-Bindings for PROJ in tcl (critcl source)
 
 MySQL
 =====
@@ -50,20 +40,30 @@ MySQL
 `fProj4 <https://sourceforge.net/projects/mysqlscientific/files/fPROJ4/>`_:
 Bindings for PROJ in MySQL
 
-Excel
-========
+Python
+======
+`pyproj <https://pypi.python.org/pypi/pyproj>`_:
+Python interface (wrapper for PROJ)
 
-`proj.xll <https://github.com/jbuonagurio/proj.xll>`_:
-Excel add-in for PROJ map projections
+Ruby
+====
+
+`proj4rb <https://github.com/cfis/proj4rb>`_:
+Bindings for PROJ in ruby
+
+Rust
+====
+
+`proj <https://github.com/georust/proj>`_:
+Rust bindings for the latest stable version of PROJ
+
+TCL
+===
+`proj4tcl <http://wiki.tcl.tk/41270>`_:
+Bindings for PROJ in tcl (critcl source)
 
 Visual Basic
-==================
+============
 
 `PROJ VB Wrappers <http://ftp.dfg.ca.gov/Public/BDB/Tools/proj4/proj_api.zip>`_:
 By Eric G. Miller.
-
-Fortran
-=======
-
-`Fortran-Proj <https://gitlab.com/likeno/fortran-proj>`_:
-Bindings for PROJ in Fortran (By João Macedo @likeno)


### PR DESCRIPTION
The Perl module [Geo::LibProj::FFI](https://metacpan.org/pod/Geo::LibProj::FFI) works with PROJ 6.2.0 and newer, including PROJ 9.4.0.

This change also sorts the language bindings alphabetically. Any other sort order tends to confuse readers, unless the order is explained.