### PR TITLE
projinfo.rst: re-add '-s' 

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -35,7 +35,7 @@ Synopsis
     |    --list-crs [list-crs-filter] |
     |    --dump-db-structure [{object_definition} | {object_reference}] |
     |    {object_definition} | {object_reference} |
-    |    [--s_epoch {epoch}] -t {srs_def} [--t_epoch {epoch}])
+    |    (-s {srs_def} [--s_epoch {epoch}] -t {srs_def} [--t_epoch {epoch}])
     |
 
     where {object_definition} or {srs_def} is one of the possibilities accepted


### PR DESCRIPTION
accidentally removed in 4ac2cfb25e3c613bb0f0853ba7ec9f7df690776e