### PR TITLE
[Backport 9.4] [doc] add missing var name for PJ_GRID_INFO.filename

### DIFF
--- a/docs/source/development/reference/datatypes.rst
+++ b/docs/source/development/reference/datatypes.rst
@@ -737,7 +737,7 @@ Info structures
 
         Name of grid, e.g. "*BETA2007.gsb*".
 
-    .. c:member:: char PJ_GRID_INFO
+    .. c:member:: char PJ_GRID_INFO.filename[260]
 
         Full path of grid file, e.g. *"C:\\OSGeo4W64\\share\\proj\\BETA2007.gsb"*
 


### PR DESCRIPTION
Backport #4163
 **Authored by:** @jjimenezshaw