### PR TITLE
Fix wrong EPSG conversion code for UTM south

### DIFF
--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -1752,6 +1752,8 @@ ConversionNNPtr Conversion::createPopularVisualisationPseudoMercator(
 
 // ---------------------------------------------------------------------------
 
+// clang-format off
+
 /** \brief Instantiate a conversion based on the
  * <a href="../../../operations/projections/merc.html">
  * Mercator</a> projection method, using its spherical formulation
@@ -1760,8 +1762,7 @@ ConversionNNPtr Conversion::createPopularVisualisationPseudoMercator(
  * sphere at centerLat.
  *
  * This method is defined as
- * <a
- * href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
+ * <a href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
  * EPSG:1026</a>.
  *
  * @param properties See \ref general_properties of the conversion. If the name
@@ -1781,6 +1782,8 @@ ConversionNNPtr Conversion::createMercatorSpherical(
         properties, EPSG_CODE_METHOD_MERCATOR_SPHERICAL,
         createParams(centerLat, centerLong, falseEasting, falseNorthing));
 }
+
+// clang-format on
 
 // ---------------------------------------------------------------------------
 

--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -251,7 +251,7 @@ getUTMConversionProperty(const util::PropertyMap &properties, int zone,
         conversionName += (north ? 'N' : 'S');
 
         return createMapNameEPSGCode(conversionName,
-                                     (north ? 16000 : 17000) + zone);
+                                     (north ? 16000 : 16100) + zone);
     } else {
         return properties;
     }
@@ -1760,7 +1760,8 @@ ConversionNNPtr Conversion::createPopularVisualisationPseudoMercator(
  * sphere at centerLat.
  *
  * This method is defined as
- * <a href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
+ * <a
+ * href="https://epsg.org/coord-operation-method_1026/Mercator-Spherical.html">
  * EPSG:1026</a>.
  *
  * @param properties See \ref general_properties of the conversion. If the name

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -4244,6 +4244,36 @@ TEST(wkt_parse, conversion_proj_based) {
 
 // ---------------------------------------------------------------------------
 
+TEST(wkt_parse, conversion_utm_zone_south_wrong_id) {
+
+    auto wkt = "CONVERSION[\"UTM zone 55S\","
+               "    METHOD[\"Transverse Mercator\","
+               "        ID[\"EPSG\",9807]],"
+               "    PARAMETER[\"Latitude of natural origin\",0,"
+               "        ANGLEUNIT[\"Degree\",0.0174532925199433],"
+               "        ID[\"EPSG\",8801]],"
+               "    PARAMETER[\"Longitude of natural origin\",147,"
+               "        ANGLEUNIT[\"Degree\",0.0174532925199433],"
+               "        ID[\"EPSG\",8802]],"
+               "    PARAMETER[\"Scale factor at natural origin\",0.9996,"
+               "        SCALEUNIT[\"unity\",1],"
+               "        ID[\"EPSG\",8805]],"
+               "    PARAMETER[\"False easting\",500000,"
+               "        LENGTHUNIT[\"metre\",1],"
+               "        ID[\"EPSG\",8806]],"
+               "    PARAMETER[\"False northing\",10000000,"
+               "        LENGTHUNIT[\"metre\",1],"
+               "        ID[\"EPSG\",8807]],"
+               "    ID[\"EPSG\",17055]]"; // wrong code
+
+    auto obj = WKTParser().createFromWKT(wkt);
+    auto conv = nn_dynamic_pointer_cast<Conversion>(obj);
+    ASSERT_TRUE(conv != nullptr);
+    EXPECT_EQ(conv->getEPSGCode(), 16155); // code fixed on import
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(wkt_parse, CONCATENATEDOPERATION) {
 
     auto transf_1 = Transformation::create(
@@ -14900,6 +14930,87 @@ TEST(json_import, projected_crs) {
     ASSERT_TRUE(pcrs != nullptr);
     EXPECT_EQ(pcrs->exportToJSON(&(JSONFormatter::create()->setSchema("foo"))),
               json);
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(json_import, conversion_utm_zone_south_wrong_id) {
+
+    auto json = "{\n"
+                "  \"type\": \"Conversion\",\n"
+                "  \"name\": \"UTM zone 55S\",\n"
+                "  \"method\": {\n"
+                "    \"name\": \"Transverse Mercator\",\n"
+                "    \"id\": {\n"
+                "      \"authority\": \"EPSG\",\n"
+                "      \"code\": 9807\n"
+                "    }\n"
+                "  },\n"
+                "  \"parameters\": [\n"
+                "    {\n"
+                "      \"name\": \"Latitude of natural origin\",\n"
+                "      \"value\": 0,\n"
+                "      \"unit\": {\n"
+                "        \"type\": \"AngularUnit\",\n"
+                "        \"name\": \"Degree\",\n"
+                "        \"conversion_factor\": 0.0174532925199433\n"
+                "      },\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 8801\n"
+                "      }\n"
+                "    },\n"
+                "    {\n"
+                "      \"name\": \"Longitude of natural origin\",\n"
+                "      \"value\": 147,\n"
+                "      \"unit\": {\n"
+                "        \"type\": \"AngularUnit\",\n"
+                "        \"name\": \"Degree\",\n"
+                "        \"conversion_factor\": 0.0174532925199433\n"
+                "      },\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 8802\n"
+                "      }\n"
+                "    },\n"
+                "    {\n"
+                "      \"name\": \"Scale factor at natural origin\",\n"
+                "      \"value\": 0.9996,\n"
+                "      \"unit\": \"unity\",\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 8805\n"
+                "      }\n"
+                "    },\n"
+                "    {\n"
+                "      \"name\": \"False easting\",\n"
+                "      \"value\": 500000,\n"
+                "      \"unit\": \"metre\",\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 8806\n"
+                "      }\n"
+                "    },\n"
+                "    {\n"
+                "      \"name\": \"False northing\",\n"
+                "      \"value\": 10000000,\n"
+                "      \"unit\": \"metre\",\n"
+                "      \"id\": {\n"
+                "        \"authority\": \"EPSG\",\n"
+                "        \"code\": 8807\n"
+                "      }\n"
+                "    }\n"
+                "  ],\n"
+                "  \"id\": {\n"
+                "    \"authority\": \"EPSG\",\n"
+                "    \"code\": 17055\n" // wrong code
+                "  }\n"
+                "}";
+
+    auto obj = createFromUserInput(json, nullptr);
+    auto conv = nn_dynamic_pointer_cast<Conversion>(obj);
+    ASSERT_TRUE(conv != nullptr);
+    EXPECT_EQ(conv->getEPSGCode(), 16155); // code fixed on import
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -1241,7 +1241,7 @@ TEST(operation, utm_export) {
               "    PARAMETER[\"False northing\",10000000,\n"
               "        LENGTHUNIT[\"metre\",1],\n"
               "        ID[\"EPSG\",8807]],\n"
-              "    ID[\"EPSG\",17001]]");
+              "    ID[\"EPSG\",16101]]");
 
     EXPECT_EQ(
         conv->exportToWKT(


### PR DESCRIPTION
When generating a Conversion object for a UTM south conversion (for example when importing from PROJ.4 or WKT1), we currently use a wrong offset.

Fixes https://gis.stackexchange.com/questions/482037/what-is-epsg17056
