### PR TITLE
CMake: for Windows builds, defaults PROJ DLL to be just 'proj_${PROJ_MAJOR_VERSION}.dll'

### DIFF
--- a/cmake/ProjUtilities.cmake
+++ b/cmake/ProjUtilities.cmake
@@ -35,34 +35,6 @@ function(print_variable NAME)
 endfunction()
 
 #
-# Generates output name for given target depending on platform and version.
-# For instance, on Windows, dynamic link libraries get ABI version suffix
-# proj_X_Y.dll.
-#
-
-function(proj_target_output_name TARGET_NAME OUTPUT_NAME)
-  if(NOT DEFINED TARGET_NAME)
-    message(SEND_ERROR "Error, the variable TARGET_NAME is not defined!")
-  endif()
-
-  if(NOT DEFINED ${PROJECT_NAME}_VERSION)
-    message(SEND_ERROR
-      "Error, the variable ${${PROJECT_NAME}_VERSION} is not defined!")
-  endif()
-
-  # On Windows, ABI version is specified using binary file name suffix.
-  # On Unix, suffix is empty and SOVERSION is used instead.
-  if(WIN32)
-    string(LENGTH "${${PROJECT_NAME}_ABI_VERSION}" abilen)
-    if(abilen GREATER 0)
-      set(SUFFIX "_${${PROJECT_NAME}_ABI_VERSION}")
-    endif()
-  endif()
-
-  set(${OUTPUT_NAME} ${TARGET_NAME}${SUFFIX} PARENT_SCOPE)
-endfunction()
-
-#
 # Configure a pkg-config file proj.pc
 # See also ProjInstallPath.cmake
 #

--- a/cmake/ProjVersion.cmake
+++ b/cmake/ProjVersion.cmake
@@ -37,16 +37,5 @@ macro(proj_version)
 ${${PROJECT_NAME}_VERSION_MINOR}.\
 ${${PROJECT_NAME}_VERSION_PATCH}")
 
-  # Set ABI version string used to name binary output
-  # On Windows, ABI version is specified using binary file name suffix.
-  if(WIN32)
-    set(${PROJECT_NAME}_ABI_VERSION
-      "${${PROJECT_NAME}_VERSION_MAJOR}_\
-${${PROJECT_NAME}_VERSION_MINOR}")
-  endif()
-
   print_variable(${PROJECT_NAME}_VERSION)
-  if(WIN32)
-    print_variable(${PROJECT_NAME}_ABI_VERSION)
-  endif()
 endmacro()

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -287,6 +287,26 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
         or by specifying ``--config Release`` with CMake
         multi-configuration build tools (see example below).
 
+.. option:: PROJ_OUTPUT_NAME
+
+    .. versionadded:: 9.5
+
+    Sets the name of the PROJ library (excluding extension).
+    This generally defaults to "proj", except on Windows, where this defaults to
+    "proj_${PROJ_MAJOR_VERSION}" if APPEND_SOVERSION is OFF.
+
+    .. note::
+        For PROJ >= 6.0 and up to 9.4.1, on Windows, this was hardcoded to
+        "proj_${PROJ_MAJOR_VERSION}_${PROJ_MINOR_VERSION}".
+
+.. option:: APPEND_SOVERSION=OFF
+
+    .. versionadded:: 9.5
+
+    This variable can be set to ON for MinGW builds where BUILD_SHARED_LIBS=ON,
+    to add a "-${PROJ_SOVERSION}" suffix to the PROJ shared library name.
+    When this variable is set, PROJ_OUTPUT_NAME defaults to "proj"
+
 .. option:: CMAKE_C_COMPILER
 
     C compiler. Ignored for some generators, such as Visual Studio.


### PR DESCRIPTION
Fixes #4151 . Aligns with GDAL PR https://github.com/OSGeo/gdal/pull/5701

@hobu Any opinion regarding that ? Current behaviour of having 'proj_X_Y.dll' comes from the initial CMake commit of yours 532a0f5408 from 10 years ago.