### PR TITLE
Fix: not apply -Wextra-semi for gcc version<8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,13 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Wmissing-prototypes
   )
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
+	  set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+		-Wextra-semi
+	  )
+  endif()
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Weffc++
-    -Wextra-semi
     # -Wold-style-cast
     -Woverloaded-virtual
     -Wzero-as-null-pointer-constant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     -Wmissing-prototypes
   )
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
-	  set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
-		-Wextra-semi
-	  )
+        set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS} -Wextra-semi)
   endif()
   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Weffc++


### PR DESCRIPTION
I use vcpkg to get PROJ library, but error occurs due to this compiling argument "-Wextra-semi" is not avaliable at gcc which version is less than 8.

My environment:
Ubuntu 18.04
GCC 7.5.0
