### PR TITLE
[Doc] add google-site-verification meta tag in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,3 +31,6 @@ PROJ
     You can download the source code for PROJ on the :ref:`download section<download>`
     and find links to prepackaged executables in the
     :ref:`installation section<install>`.
+
+.. meta::
+   :google-site-verification: MhCjgTBKAzLd1y46INE_vmHIiJ_TLHrDc98XC_jYB14


### PR DESCRIPTION
Trying to investigate #4182 this PR is adding the meta tag in the index file. Let's see if it sufficient for Google.

- [ ] Closes? #4182, ... let' see.
