### PR TITLE
CMake: update output name summary (useful for Windows builds)

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -536,6 +536,6 @@ endif()
 ##############################################
 # Core configuration summary
 ##############################################
-print_variable(PROJ_CORE_TARGET_OUTPUT_NAME)
+print_variable(PROJ_OUTPUT_NAME)
 print_variable(BUILD_SHARED_LIBS)
 print_variable(PROJ_LIBRARIES)


### PR DESCRIPTION
- enhances the[ recent PR](https://github.com/OSGeo/PROJ/pull/4167) 
- to also output the variable `PROJ_OUTPUT_NAME` in the CMake summary
  - otherwise, CMake tries to use the old `PROJ_CORE_TARGET_OUTPUT_NAME` variable, which no longer exists, resulting in the new name not showing in the CMake summary, such as:
    ```
        -- PROJ_CORE_TARGET_OUTPUT_NAME  =
        -- BUILD_SHARED_LIBS             = ON
        -- PROJ_LIBRARIES                = proj
    ```
