### PR TITLE
Connect + and - option documentation

### DIFF
--- a/docs/source/apps/cct.rst
+++ b/docs/source/apps/cct.rst
@@ -76,7 +76,7 @@ The following control parameters can appear in any order:
 
 .. option:: -I
 
-    Do the inverse transformation.
+    Do the inverse transformation. (``+`` style option: ``+inv``).
 
 .. option:: -o <output file name>, --output=<output file name>
 

--- a/docs/source/apps/proj.rst
+++ b/docs/source/apps/proj.rst
@@ -127,7 +127,8 @@ The following control parameters can appear in any order
     in a forward projection mode the cartesian output values are multiplied by
     *mult* otherwise the input cartesian values are divided by *mult* before inverse
     projection. If the first two characters of *mult* are 1/ or 1: then the
-    reciprocal value of *mult* is employed.
+    reciprocal value of *mult* is employed. ``-m 1/mult`` is the same as
+    ``+to_meter=mult``.
 
 .. option:: -f <format>
 


### PR DESCRIPTION
Here we show users the vital bridges between + and - style options.
As cs2cs and cct don't have -m, and cct doesn't allow mixing + and - options.