### PR TITLE
cct: emit error message and return error code when not being able to open input file

### DIFF
--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -442,7 +442,8 @@ int main(int argc, char **argv) {
 
     /* Loop over all records of all input files */
     int previous_index = -1;
-    while (opt_input_loop(o, optargs_file_format_text)) {
+    bool gotError = false;
+    while (opt_input_loop(o, optargs_file_format_text, &gotError)) {
         int err;
         char *bufptr = fgets(buf, BUFFER_SIZE - 1, o->input);
         if (opt_eof(o)) {
@@ -547,7 +548,7 @@ int main(int argc, char **argv) {
         fclose(fout);
     free(o);
     free(buf);
-    return 0;
+    return gotError ? 1 : 0;
 }
 
 /* return a pointer to the n'th column of buf */

--- a/test/cli/test_cct.yaml
+++ b/test/cli/test_cct.yaml
@@ -151,3 +151,7 @@ tests:
   args: +proj=noop input_file1_with_utf8_bom.txt
   # no BOM with output
   out: "       0.0000         3.0000        0.0000           inf"
+- comment: Test cct with non existing input file
+  args: +proj=noop i_do_not_exist.txt
+  stderr: "Cannot open file i_do_not_exist.txt"
+  exitcode: 1


### PR DESCRIPTION
Fixes #4198

CC @busstoptaktik I believe it is better to explicitly fail when the/an input file is missing than silently going on