### PR TITLE
CMake: add option EMBED_PROJ_DATA_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,8 @@ endif()
 
 ################################################################################
 
+option(EMBED_PROJ_DATA_PATH "Whether the PROJ_DATA_PATH should be embedded" ON)
+
 if(DEFINED PROJ_LIB_ENV_VAR_TRIED_LAST)
   set(PROJ_DATA_ENV_VAR_TRIED_LAST ${PROJ_LIB_ENV_VAR_TRIED_LAST})
   message(WARNING "PROJ_LIB_ENV_VAR_TRIED_LAST option has been renamed to PROJ_DATA_ENV_VAR_TRIED_LAST. PROJ_LIB_ENV_VAR_TRIED_LAST is still working for now, but may be completely replaced by PROJ_DATA_ENV_VAR_TRIED_LAST in a future release")

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -414,6 +414,12 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
     Path to an existing directory used to cache :file:`proj.db` to speed-up
     subsequent builds without modifications to source SQL files.
 
+.. option:: EMBED_PROJ_DATA_PATH
+
+    .. versionadded:: 9.4
+
+    Embed ``PROJ_DATA_PATH`` data files location, default ON.
+
 
 Building on Windows with vcpkg and Visual Studio 2017 or 2019
 --------------------------------------------------------------------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -418,9 +418,7 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
 
     .. versionadded:: 9.5
 
-    Embed ``PROJ_DATA_PATH`` data files location as an alternative paths for
-    external libraries. Disable to avoid setting this non-relocatable hardcoded
-    paths. Default ON.
+    Embed ``PROJ_DATA`` hard-coded alternative path for data files location. Disable to avoid setting this non-relocatable hard-coded path. Default ON.
 
 
 Building on Windows with vcpkg and Visual Studio 2017 or 2019

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -416,9 +416,11 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
 
 .. option:: EMBED_PROJ_DATA_PATH
 
-    .. versionadded:: 9.4
+    .. versionadded:: 9.5
 
-    Embed ``PROJ_DATA_PATH`` data files location, default ON.
+    Embed ``PROJ_DATA_PATH`` data files location as an alternative paths for
+    external libraries. Disable to avoid setting this non-relocatable hardcoded
+    paths. Default ON.
 
 
 Building on Windows with vcpkg and Visual Studio 2017 or 2019

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -303,7 +303,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 source_group("CMake Files" FILES CMakeLists.txt)
 
 # Embed PROJ_DATA data files location
-add_definitions(-DPROJ_DATA="${PROJ_DATA_PATH}")
+if(EMBED_PROJ_DATA_PATH)
+  add_definitions(-DPROJ_DATA="${PROJ_DATA_PATH}")
+endif()
 
 
 ###########################################################


### PR DESCRIPTION
Add an option `EMBED_PROJ_DATA_PATH` to allow `PROJ_DATA_PATH` not to be hardcoded. Defaults to `ON`, does not change existing behavior.

There are many ways to get the path, and the existing code allows macros not to be defined, for example [src/filemanager.cpp#L1390-L1394](https://github.com/OSGeo/PROJ/blob/9.4.1/src/filemanager.cpp#L1390-L1394).

There are many situations where you have to concern about hard coding path which might be fragile and breaks easily, or just want file path independent in build time. So, the option is added.