### PR TITLE
projinfo: 2 args equivalent to usage of -s and -t

### DIFF
--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -35,7 +35,8 @@ Synopsis
     |    --list-crs [list-crs-filter] |
     |    --dump-db-structure [{object_definition} | {object_reference}] |
     |    {object_definition} | {object_reference} |
-    |    (-s {srs_def} [--s_epoch {epoch}] -t {srs_def} [--t_epoch {epoch}])
+    |    (-s {srs_def} [--s_epoch {epoch}] -t {srs_def} [--t_epoch {epoch}]) |
+    |    ({srs_def} {srs_def})
     |
 
     where {object_definition} or {srs_def} is one of the possibilities accepted
@@ -65,6 +66,8 @@ Synopsis
     {object_reference} is a filename preceded by the '@' character.  The
     file referenced by the {object_reference} must contain a valid
     {object_definition}.
+
+    The usage of "{srs_def} {srs_def}" is equivalent to "-s {srs_def} -t {srs_def}".
 
 Description
 ***********

--- a/docs/source/apps/projinfo.rst
+++ b/docs/source/apps/projinfo.rst
@@ -67,7 +67,7 @@ Synopsis
     file referenced by the {object_reference} must contain a valid
     {object_definition}.
 
-    The usage of "{srs_def} {srs_def}" is equivalent to "-s {srs_def} -t {srs_def}".
+    The usage of "{srs_def} {srs_def}" is equivalent to "-s {srs_def} -t {srs_def}" (*added in 9.5*).
 
 Description
 ***********

--- a/test/cli/test_projinfo.yaml
+++ b/test/cli/test_projinfo.yaml
@@ -315,7 +315,81 @@ tests:
 
     WKT2:2019 string:
     CONVERSION["UTM zone 31N",METHOD["Transverse Mercator",ID["EPSG",9807]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.9996,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",500000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]],ID["EPSG",16031]]
+- args: EPSG:4326 EPSG:32631 --single-line
+  out: |
+    Candidate operations found: 1
+    -------------------------------------
+    Operation No. 1:
+
+    EPSG:16031, UTM zone 31N, 0 m, Between 0°E and 6°E, northern hemisphere between equator and 84°N, onshore and offshore.
+
+    PROJ string:
+    +proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=utm +zone=31 +ellps=WGS84
+
+    WKT2:2019 string:
+    CONVERSION["UTM zone 31N",METHOD["Transverse Mercator",ID["EPSG",9807]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.9996,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",500000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]],ID["EPSG",16031]]
+- args: EPSG:4326 EPSG:32631 EPSG:4327
+  grep: Too many parameters
+  stderr: |
+    Too many parameters: EPSG:32631
+  exitcode: 1
 - args: --source-crs NAD27 --target-crs NAD83
+  out: |
+    Candidate operations found: 1
+    Note: using '--spatial-test intersects' would bring more results (10)
+    -------------------------------------
+    Operation No. 1:
+
+    unknown id, Ballpark geographic offset from NAD27 to NAD83, unknown accuracy, World, has ballpark transformation
+
+    PROJ string:
+    +proj=noop
+
+    WKT2:2019 string:
+    COORDINATEOPERATION["Ballpark geographic offset from NAD27 to NAD83",
+        SOURCECRS[
+            GEOGCRS["NAD27",
+                DATUM["North American Datum 1927",
+                    ELLIPSOID["Clarke 1866",6378206.4,294.978698213898,
+                        LENGTHUNIT["metre",1]]],
+                PRIMEM["Greenwich",0,
+                    ANGLEUNIT["degree",0.0174532925199433]],
+                CS[ellipsoidal,2],
+                    AXIS["geodetic latitude (Lat)",north,
+                        ORDER[1],
+                        ANGLEUNIT["degree",0.0174532925199433]],
+                    AXIS["geodetic longitude (Lon)",east,
+                        ORDER[2],
+                        ANGLEUNIT["degree",0.0174532925199433]],
+                ID["EPSG",4267]]],
+        TARGETCRS[
+            GEOGCRS["NAD83",
+                DATUM["North American Datum 1983",
+                    ELLIPSOID["GRS 1980",6378137,298.257222101,
+                        LENGTHUNIT["metre",1]]],
+                PRIMEM["Greenwich",0,
+                    ANGLEUNIT["degree",0.0174532925199433]],
+                CS[ellipsoidal,2],
+                    AXIS["geodetic latitude (Lat)",north,
+                        ORDER[1],
+                        ANGLEUNIT["degree",0.0174532925199433]],
+                    AXIS["geodetic longitude (Lon)",east,
+                        ORDER[2],
+                        ANGLEUNIT["degree",0.0174532925199433]],
+                ID["EPSG",4269]]],
+        METHOD["Geographic2D offsets",
+            ID["EPSG",9619]],
+        PARAMETER["Latitude offset",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8601]],
+        PARAMETER["Longitude offset",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8602]],
+        USAGE[
+            SCOPE["unknown"],
+            AREA["World"],
+            BBOX[-90,-180,90,180]]]
+- args: NAD27 NAD83
   out: |
     Candidate operations found: 1
     Note: using '--spatial-test intersects' would bring more results (10)


### PR DESCRIPTION
From
https://lists.osgeo.org/pipermail/proj/2024-May/011388.html

Some times when I am using cs2cs I want to do also a projinfo, to see the
transformation(s) that is may apply.

It is always bothering me that I have to add "-s" and "-t".

Does it make sense that if there are two args without option identifier, it
assumes that the second is "-t"? Am I missing some corner-cases? (if you
like the idea, I am happy to do the PR)
I do not mean to remove "-t" completely, but to make the arg parser more
flexible.

- [x] Tests added
- [x] Added clear title that can be used to generate release notes
- [x] Fully documented, including updating `docs/source/*.rst` for new API
