### PR TITLE
Dockerfile: fix warnings and other clean-ups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,45 @@
 ##
 # OSGeo/PROJ
 
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS builder
 
-MAINTAINER Howard Butler <howard@hobu.co>
+LABEL maintainer="Howard Butler <howard@hobu.co>"
 
 ARG DESTDIR="/build"
 
 # Setup build env
-RUN apt-get update -y \
+RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
-            software-properties-common build-essential ca-certificates \
-            cmake wget unzip \
-            zlib1g-dev libsqlite3-dev sqlite3 libcurl4-gnutls-dev \
-            libtiff5-dev
+        software-properties-common build-essential ca-certificates \
+        cmake wget unzip \
+        zlib1g-dev libsqlite3-dev sqlite3 libcurl4-gnutls-dev \
+        libtiff5-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . /PROJ
 
-RUN cd /PROJ \
-    && mkdir build \
-    && cd build \
-    && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
-    && make -j$(nproc) \
-    && make install
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -S /PROJ -B _build
+RUN cmake --build _build -j $(nproc)
+RUN cmake --install _build
+RUN rm -rfv _build
 
-
-
-
-FROM ubuntu:22.04 as runner
+FROM ubuntu:22.04 AS runner
 
 RUN date
 
-RUN apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libsqlite3-0 libtiff5 libcurl4 libcurl3-gnutls \
-        wget ca-certificates
+        wget ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Put this first as this is rarely changing
-RUN \
-    mkdir -p /usr/share/proj; \
-    wget --no-verbose --mirror https://cdn.proj.org/; \
-    rm -f cdn.proj.org/*.js; \
-    rm -f cdn.proj.org/*.css; \
-    mv cdn.proj.org/* /usr/share/proj/; \
-    rmdir cdn.proj.org
+WORKDIR /usr/share/proj
+RUN wget --no-verbose --mirror https://cdn.proj.org/ || true
+RUN cd cdn.proj.org && rm -fv *.js *.css *.html favicon* && mv * .. && cd .. && rmdir cdn.proj.org
+WORKDIR /
 
 COPY --from=builder  /build/usr/share/proj/ /usr/share/proj/
 COPY --from=builder  /build/usr/include/ /usr/include/
 COPY --from=builder  /build/usr/bin/ /usr/bin/
 COPY --from=builder  /build/usr/lib/ /usr/lib/
-

--- a/docs/docbuild/Dockerfile
+++ b/docs/docbuild/Dockerfile
@@ -1,17 +1,19 @@
 FROM ubuntu:24.04
 
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3-dev python3-pip g++ doxygen dvipng latexmk \
-    cmake libjpeg8-dev zlib1g-dev texlive-latex-base \
-    texlive-latex-extra git latex-cjk-all texlive-lang-all \
-    graphviz python3-matplotlib wget unzip enchant-2 locales
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-dev python3-pip python3-venv g++ doxygen dvipng latexmk \
+        cmake libjpeg8-dev zlib1g-dev texlive-latex-base \
+        texlive-latex-extra git latex-cjk-all texlive-lang-all \
+        graphviz python3-matplotlib wget unzip enchant-2 locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN python3 -m pip install Sphinx breathe \
+RUN python3 -m pip install --no-cache-dir \
+    Sphinx breathe \
     sphinx_bootstrap_theme sphinxcontrib-bibtex \
     sphinx_rtd_theme recommonmark sphinx-markdown-tables \
     sphinxcontrib-spelling setuptools
@@ -21,4 +23,4 @@ RUN sed -i -e 's/# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_GB.UTF-8
 
-ENV LANG en_GB.UTF-8
+ENV LANG=en_GB.UTF-8


### PR DESCRIPTION
This tidies a few warnings / deprecation messages (see [Annotations](https://github.com/OSGeo/PROJ/actions/runs/10374059329)) with Dockerfiles.

Some other chanages:
- Delete the apt-get lists after installing something ([DL3009](https://github.com/hadolint/hadolint/wiki/DL3009))
- Similarly use `pip install --no-cache-dir ...` ([ref](https://www.data-mining.co.nz/docker-for-data-scientists/best_practices/))
- Split a few chained commands into separate RUN statements, as these are cached where possible.
- Try to avoid "chdir ..." where possible (see lint [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003)).
- Some of the cmake commands are upgraded to use `-S` source and `-B` build directory paths to avoid chdir.
- Clean-up index.html and favicon.png from /usr/share/proj