### PR TITLE
CI: use travis_wait to avoid build timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 
 before_install: ./travis/${BUILD_NAME}/before_install.sh
 
-install: ./travis/${BUILD_NAME}/install.sh
+install: travis_wait 20 ./travis/${BUILD_NAME}/install.sh
 
 script:
   - echo "done"


### PR DESCRIPTION
Commands that take longer than 10 minutes on TravisCI raise a timeout error:

> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
> Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
> 

The suggested solution is to prefix the long-running command with `travis_wait` or `travis_wait n`, where _n_ is the number of minutes, with a default of 20 mins.

Another question is if Travis CI builds are recently taking longer than 10 minutes? These errors started around 2 weeks ago.