### PR TITLE
GeographicBoundingBox::create(): accept degenerate bounding box reduced to a point or a line

### DIFF
--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -448,9 +449,23 @@ int main(int argc, char **argv) {
                 std::exit(1);
             }
             try {
-                bboxFilter = Extent::createFromBBOX(
-                                 c_locale_stod(bbox[0]), c_locale_stod(bbox[1]),
-                                 c_locale_stod(bbox[2]), c_locale_stod(bbox[3]))
+                std::vector<double> bboxValues = {
+                    c_locale_stod(bbox[0]), c_locale_stod(bbox[1]),
+                    c_locale_stod(bbox[2]), c_locale_stod(bbox[3])};
+                const double west = bboxValues[0];
+                const double south = bboxValues[1];
+                const double east = bboxValues[2];
+                const double north = bboxValues[3];
+                constexpr double SOME_MARGIN = 10;
+                if (south < -90 - SOME_MARGIN && std::fabs(west) <= 90 &&
+                    std::fabs(east) <= 90)
+                    std::cerr << "Warning: suspicious south latitude: " << south
+                              << std::endl;
+                if (north > 90 + SOME_MARGIN && std::fabs(west) <= 90 &&
+                    std::fabs(east) <= 90)
+                    std::cerr << "Warning: suspicious north latitude: " << north
+                              << std::endl;
+                bboxFilter = Extent::createFromBBOX(west, south, east, north)
                                  .as_nullable();
             } catch (const std::exception &e) {
                 std::cerr << "Invalid value for option --bbox: " << bboxStr

--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -238,6 +238,27 @@ GeographicBoundingBoxNNPtr GeographicBoundingBox::create(double west,
         throw InvalidValueTypeException(
             "GeographicBoundingBox::create() does not accept NaN values");
     }
+    if (south > north) {
+        throw InvalidValueTypeException(
+            "GeographicBoundingBox::create() does not accept south > north");
+    }
+    // Avoid creating a degenerate bounding box if reduced to a point or a line
+    if (west == east) {
+        if (west > -180)
+            west =
+                std::nextafter(west, -std::numeric_limits<double>::infinity());
+        if (east < 180)
+            east =
+                std::nextafter(east, std::numeric_limits<double>::infinity());
+    }
+    if (south == north) {
+        if (south > -90)
+            south =
+                std::nextafter(south, -std::numeric_limits<double>::infinity());
+        if (north < 90)
+            north =
+                std::nextafter(north, std::numeric_limits<double>::infinity());
+    }
     return GeographicBoundingBox::nn_make_shared<GeographicBoundingBox>(
         west, south, east, north);
 }


### PR DESCRIPTION
by extending it by the minimal amount to form a non-degenerate one. Also throws when south > north
Fixes #4236

and:
cs2cs and projinfo: emit warning when it looks like longitude and latitudes have been switched in --bbox


