### PR TITLE
More strict syntax for test/gigs/5110.gie.failing (LAEA)

### DIFF
--- a/test/gigs/5110.gie.failing
+++ b/test/gigs/5110.gie.failing
@@ -4,19 +4,13 @@ Test 5110, Lambert Azimuthal Equal Area, v2-0_2011-06-28.
 
 --------------------------------------------------------------------------------
 
-# ETRS89
-<4258> +proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0  <>
+<gie-strict>
 
-# ETRS89 / LAEA Europe
-<3035> +proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000
-       +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m  <>
-
-
-<gie>
+use_proj4_init_rules true
 
 --------------------------------------------------------------------------------
-operation  +proj=pipeline
-           +step +init=epsg:4258 +inv
+operation  +proj=pipeline \
+           +step +init=epsg:4258 +inv \
            +step +init=epsg:3035
 --------------------------------------------------------------------------------
 tolerance  0.05 m
@@ -64,8 +58,8 @@ accept    10.0 50.0
 expect    4321000.0 2987510.567
 
 --------------------------------------------------------------------------------
-operation  +proj=pipeline
-           +step +init=epsg:3035 +inv
+operation  +proj=pipeline \
+           +step +init=epsg:3035 +inv \
            +step +init=epsg:4258
 --------------------------------------------------------------------------------
 tolerance  0.05 m
@@ -113,8 +107,8 @@ accept    4321000.0 2987510.567
 expect    10.0 50.0
 
 --------------------------------------------------------------------------------
-operation  +proj=pipeline
-           +step +init=epsg:4258 +inv
+operation  +proj=pipeline \
+           +step +init=epsg:4258 +inv \
            +step +init=epsg:3035
 --------------------------------------------------------------------------------
 tolerance  0.006 m
@@ -161,4 +155,4 @@ tolerance  0.006 m
 accept    10.0 50.0
 roundtrip 1000
 
-</gie>
+</gie-strict>


### PR DESCRIPTION
Current results are that we pass the simple one-time forward / reverse tests, but not repeated 1000 times:

```
$ bin/gie ../test/gigs/5110.gie.failing
-------------------------------------------------------------------------------
Reading file '../test/gigs/5110.gie.failing'
-------------------------------------------------------------------------------
proj=pipeline step init=epsg:4258 inv step init=epsg:3035
-------------------------------------------------------------------------------
     FAILURE in 5110.gie.failing(116):
     roundtrip deviation: 105.138717 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(120):
     roundtrip deviation: 168.120679 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(124):
     roundtrip deviation: 344.822744 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(128):
     roundtrip deviation: 759.297462 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(132):
     roundtrip deviation: 1311.809746 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(140):
     roundtrip deviation: 344.822713 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(144):
     roundtrip deviation: 344.822789 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(148):
     roundtrip deviation: 344.822744 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(152):
     roundtrip deviation: 344.822853 mm, expected: 6.000000 mm
     -----
     FAILURE in 5110.gie.failing(156):
     roundtrip deviation: 344.822747 mm, expected: 6.000000 mm
-------------------------------------------------------------------------------
total: 23 tests succeeded,  0 tests skipped, 10 tests FAILED!
-------------------------------------------------------------------------------
```
