### PR TITLE
CI: Fix ReadTheDocs test for [ci skip] with multiline commit messages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
 
   jobs:
     post_checkout:
-      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viqP "skip ci|ci skip") || exit 183
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | paste -s -d " " | grep -viqP "skip ci|ci skip") || exit 183
     pre_build:
       - ./docs/rtd/pre_build.sh
       - ./scripts/doxygen.sh


### PR DESCRIPTION
git log will emit a blank line which passes the grep -v test and prevents exiting.

Ported from GDAL https://github.com/OSGeo/gdal/pull/10802