### PR TITLE
[Backport 9.5] Fix clang-19 'warning: empty paragraph passed to '@throw' command [-Wdocumentation]'

### DIFF
--- a/include/proj/coordinateoperation.hpp
+++ b/include/proj/coordinateoperation.hpp
@@ -196,7 +196,8 @@ class PROJ_GCC_DLL CoordinateOperation : public common::ObjectUsage,
     coordinateTransformer(PJ_CONTEXT *ctx) const;
 
     /** \brief Return the inverse of the coordinate operation.
-     * @throw util::UnsupportedOperationException
+     *
+     * \throw util::UnsupportedOperationException if inverse is not available
      */
     PROJ_DLL virtual CoordinateOperationNNPtr inverse() const = 0;
 

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -720,7 +720,7 @@ class PROJ_GCC_DLL IPROJStringExportable {
      *
      * @param formatter PROJ string formatter.
      * @return a PROJ string.
-     * @throw FormattingException */
+     * @throw FormattingException if cannot be exported as a PROJ string */
     PROJ_DLL std::string exportToPROJString(
         PROJStringFormatter *formatter) const; // throw(FormattingException)
 

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -5197,7 +5197,7 @@ CompoundCRS::componentReferenceSystems() PROJ_PURE_DEFN {
  * At minimum the name should be defined.
  * @param components the component CRS of the CompoundCRS.
  * @return new CompoundCRS.
- * @throw InvalidCompoundCRSException
+ * @throw InvalidCompoundCRSException if the object cannot be constructed.
  */
 CompoundCRSNNPtr CompoundCRS::create(const util::PropertyMap &properties,
                                      const std::vector<CRSNNPtr> &components) {
@@ -5299,7 +5299,7 @@ CompoundCRSNNPtr CompoundCRS::create(const util::PropertyMap &properties,
  * At minimum the name should be defined.
  * @param components the component CRS of the CompoundCRS.
  * @return new CRS.
- * @throw InvalidCompoundCRSException
+ * @throw InvalidCompoundCRSException if the object cannot be constructed.
  */
 CRSNNPtr CompoundCRS::createLax(const util::PropertyMap &properties,
                                 const std::vector<CRSNNPtr> &components,

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -2004,7 +2004,7 @@ void DatumEnsemble::_exportToJSON(
  * @param datumsIn Array of at least 2 datums.
  * @param accuracy Accuracy of the datum ensemble
  * @return new DatumEnsemble.
- * @throw util::Exception
+ * @throw util::Exception in case of error.
  */
 DatumEnsembleNNPtr DatumEnsemble::create(
     const util::PropertyMap &properties,

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2905,7 +2905,7 @@ DatabaseContext::DatabaseContext() : d(internal::make_unique<Private>()) {}
  * provided, they must be separated by the colon (:) character on Unix, and
  * on Windows, by the semi-colon (;) character.
  * @param ctx Context used for file search.
- * @throw FactoryException
+ * @throw FactoryException if the database cannot be opened.
  */
 DatabaseContextNNPtr
 DatabaseContext::create(const std::string &databasePath,
@@ -2990,7 +2990,7 @@ const char *DatabaseContext::getMetadata(const char *key) const {
  *
  * Only one session may be active at a time for a given database context.
  *
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  * @since 8.1
  */
 void DatabaseContext::startInsertStatementsSession() {
@@ -3052,7 +3052,7 @@ void DatabaseContext::startInsertStatementsSession() {
  * @return the suggested code, that is guaranteed to not conflict with an
  * existing one.
  *
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  * @since 8.1
  */
 std::string
@@ -3138,7 +3138,7 @@ DatabaseContext::suggestsCodeFor(const common::IdentifiedObjectNNPtr &object,
  *                           added to it. Note that unit, coordinate
  *                           systems, projection methods and parameters will in
  *                           any case be allowed to refer to EPSG.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  * @since 8.1
  */
 std::vector<std::string> DatabaseContext::getInsertStatementsFor(
@@ -3502,7 +3502,7 @@ static std::string getUniqueEsriAlias(const std::list<std::string> &l) {
  *                  column of the "geodetic_crs" table.
  * @param source Source of the alias. Mandatory
  * @return Alias name (or empty if not found).
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::string
 DatabaseContext::getAliasFromOfficialName(const std::string &officialName,
@@ -3645,7 +3645,7 @@ std::list<std::string> DatabaseContext::getAliases(
  * @param authName Authority name of the object.
  * @param code Code of the object
  * @return Name (or empty)
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::string DatabaseContext::getName(const std::string &tableName,
                                      const std::string &authName,
@@ -3668,7 +3668,7 @@ std::string DatabaseContext::getName(const std::string &tableName,
  * @param authName Authority name of the object.
  * @param code Code of the object
  * @return Text definition (or empty)
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::string DatabaseContext::getTextDefinition(const std::string &tableName,
                                                const std::string &authName,
@@ -3688,7 +3688,7 @@ std::string DatabaseContext::getTextDefinition(const std::string &tableName,
 /** \brief Return the allowed authorities when researching transformations
  * between different authorities.
  *
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::vector<std::string> DatabaseContext::getAllowedAuthorities(
     const std::string &sourceAuthName,
@@ -4304,8 +4304,8 @@ AuthorityFactory::CRSInfo::CRSInfo()
  *
  * @param code Object code allocated by authority. (e.g. "4326")
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 util::BaseObjectNNPtr
@@ -4412,8 +4412,8 @@ static FactoryException buildFactoryException(const char *type,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 metadata::ExtentNNPtr
@@ -4467,8 +4467,8 @@ AuthorityFactory::createExtent(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 UnitOfMeasureNNPtr
@@ -4569,8 +4569,8 @@ static double normalizeMeasure(const std::string &uom_code,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::PrimeMeridianNNPtr
@@ -4621,7 +4621,7 @@ AuthorityFactory::createPrimeMeridian(const std::string &code) const {
  * @param semi_major_axis Approximate semi-major axis.
  * @param tolerance Relative error allowed.
  * @return celestial body name if one single match found.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 
 std::string
@@ -4660,8 +4660,8 @@ AuthorityFactory::identifyBodyFromSemiMajorAxis(double semi_major_axis,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::EllipsoidNNPtr
@@ -4729,8 +4729,8 @@ AuthorityFactory::createEllipsoid(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::GeodeticReferenceFrameNNPtr
@@ -4860,8 +4860,8 @@ void AuthorityFactory::createGeodeticDatumOrEnsemble(
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::VerticalReferenceFrameNNPtr
@@ -4959,8 +4959,8 @@ void AuthorityFactory::createVerticalDatumOrEnsemble(
  * @param code Object code allocated by authority.
  * @param type "geodetic_datum", "vertical_datum" or empty string if unknown
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::DatumEnsembleNNPtr
@@ -5014,8 +5014,8 @@ AuthorityFactory::createDatumEnsemble(const std::string &code,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 datum::DatumNNPtr AuthorityFactory::createDatum(const std::string &code) const {
@@ -5062,8 +5062,8 @@ static cs::MeridianPtr createMeridian(const std::string &val) {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 cs::CoordinateSystemNNPtr
@@ -5197,8 +5197,8 @@ AuthorityFactory::createCoordinateSystem(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::GeodeticCRSNNPtr
@@ -5212,8 +5212,8 @@ AuthorityFactory::createGeodeticCRS(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::GeographicCRSNNPtr
@@ -5367,8 +5367,8 @@ AuthorityFactory::createGeodeticCRS(const std::string &code,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::VerticalCRSNNPtr
@@ -5432,8 +5432,8 @@ AuthorityFactory::createVerticalCRS(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 operation::ConversionNNPtr
@@ -5548,8 +5548,8 @@ AuthorityFactory::createConversion(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::ProjectedCRSNNPtr
@@ -5687,8 +5687,8 @@ AuthorityFactory::Private::createProjectedCRSEnd(const std::string &code,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::CompoundCRSNNPtr
@@ -5734,8 +5734,8 @@ AuthorityFactory::createCompoundCRS(const std::string &code) const {
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 crs::CRSNNPtr AuthorityFactory::createCoordinateReferenceSystem(
@@ -5857,8 +5857,8 @@ AuthorityFactory::createCoordinateReferenceSystem(const std::string &code,
  *
  * @param code Object code allocated by authority.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  * @since 9.4
  */
 
@@ -5949,8 +5949,8 @@ static operation::ParameterValueNNPtr createAngle(const std::string &value,
  * @param usePROJAlternativeGridNames Whether PROJ alternative grid names
  * should be substituted to the official grid names.
  * @return object.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 operation::CoordinateOperationNNPtr AuthorityFactory::createCoordinateOperation(
@@ -6631,8 +6631,8 @@ operation::CoordinateOperationNNPtr AuthorityFactory::createCoordinateOperation(
  * @param sourceCRSCode Source CRS code allocated by authority.
  * @param targetCRSCode Source CRS code allocated by authority.
  * @return list of coordinate operations
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 std::vector<operation::CoordinateOperationNNPtr>
@@ -6652,7 +6652,7 @@ AuthorityFactory::createFromCoordinateReferenceSystemCodes(
  *
  * @param code crs code allocated by authority.
  * @return list of geoid model names
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 
 std::list<std::string>
@@ -6764,8 +6764,8 @@ AuthorityFactory::getGeoidModels(const std::string &code) const {
  * @param intersectingExtent2 Optional extent that the resulting operations
  * must intersect.
  * @return list of coordinate operations
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 std::vector<operation::CoordinateOperationNNPtr>
@@ -7186,8 +7186,8 @@ static bool useIrrelevantPivot(const operation::CoordinateOperationNNPtr &op,
  * @param intersectingExtent2 Optional extent that the resulting operations
  * must intersect.
  * @return list of coordinate operations
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 
 std::vector<operation::CoordinateOperationNNPtr>
@@ -8281,7 +8281,7 @@ const std::string &AuthorityFactory::getAuthority() PROJ_PURE_DEFN {
  * @param allowDeprecated whether we should return deprecated objects as well.
  * @return the set of authority codes for spatial reference objects of the given
  * type
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::set<std::string>
 AuthorityFactory::getAuthorityCodes(const ObjectType &type,
@@ -8389,8 +8389,8 @@ AuthorityFactory::getAuthorityCodes(const ObjectType &type,
  *
  * @param code Object code allocated by authority. (e.g. "4326")
  * @return description.
- * @throw NoSuchAuthorityCodeException
- * @throw FactoryException
+ * @throw NoSuchAuthorityCodeException if there is no matching object.
+ * @throw FactoryException in case of other errors.
  */
 std::string
 AuthorityFactory::getDescriptionText(const std::string &code) const {
@@ -8423,7 +8423,7 @@ AuthorityFactory::getDescriptionText(const std::string &code) const {
  * a CRS object for each of them and getting the information from this CRS
  * object, but this implementation has much less overhead.
  *
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::list<AuthorityFactory::CRSInfo> AuthorityFactory::getCRSInfoList() const {
 
@@ -8564,7 +8564,7 @@ AuthorityFactory::CelestialBodyInfo::CelestialBodyInfo() : authName{}, name{} {}
 // ---------------------------------------------------------------------------
 
 /** \brief Return the list of units.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  *
  * @since 7.1
  */
@@ -8614,7 +8614,7 @@ std::list<AuthorityFactory::UnitInfo> AuthorityFactory::getUnitList() const {
 // ---------------------------------------------------------------------------
 
 /** \brief Return the list of celestial bodies.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  *
  * @since 8.1
  */
@@ -8656,7 +8656,7 @@ AuthorityFactory::getCelestialBodyList() const {
  * @param outAuthName Authority name of the official name that has been found.
  * @param outCode Code of the official name that has been found.
  * @return official name (or empty if not found).
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::string AuthorityFactory::getOfficialNameFromAlias(
     const std::string &aliasedName, const std::string &tableName,
@@ -8764,7 +8764,7 @@ std::string AuthorityFactory::getOfficialNameFromAlias(
  * @param limitResultCount Maximum number of results to return.
  * Or 0 for unlimited.
  * @return list of matched objects.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::list<common::IdentifiedObjectNNPtr>
 AuthorityFactory::createObjectsFromName(
@@ -8797,7 +8797,7 @@ AuthorityFactory::createObjectsFromName(
  * @param limitResultCount Maximum number of results to return.
  * Or 0 for unlimited.
  * @return list of matched objects.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::list<AuthorityFactory::PairObjectName>
 AuthorityFactory::createObjectsFromNameEx(
@@ -9300,7 +9300,7 @@ AuthorityFactory::createObjectsFromNameEx(
  * @param name Searched name.
  * @param approximateMatch Whether approximate name identification is allowed.
  * @return list of (auth_name, code) of matched objects.
- * @throw FactoryException
+ * @throw FactoryException in case of error.
  */
 std::list<std::pair<std::string, std::string>>
 AuthorityFactory::listAreaOfUseFromName(const std::string &name,

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -1208,7 +1208,7 @@ WKTNodeNNPtr WKTNode::createFrom(const std::string &wkt, size_t indexStart,
  *
  * @param wkt the WKT string to parse.
  * @param indexStart the start index in the wkt string.
- * @throw ParsingException
+ * @throw ParsingException if the string cannot be parsed.
  */
 WKTNodeNNPtr WKTNode::createFrom(const std::string &wkt, size_t indexStart) {
     size_t indexEnd;
@@ -8132,7 +8132,7 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
  * easting, northing axis order (except the ones with Transverse Mercator South
  * Orientated projection). In that mode, the epsg:XXXX syntax will be also
  * interpreted the same way.
- * @throw ParsingException
+ * @throw ParsingException if the string cannot be parsed.
  */
 BaseObjectNNPtr createFromUserInput(const std::string &text,
                                     const DatabaseContextPtr &dbContext,
@@ -8179,7 +8179,7 @@ BaseObjectNNPtr createFromUserInput(const std::string &text,
  *
  * @param text One of the above mentioned text format
  * @param ctx PROJ context
- * @throw ParsingException
+ * @throw ParsingException if the string cannot be parsed.
  */
 BaseObjectNNPtr createFromUserInput(const std::string &text, PJ_CONTEXT *ctx) {
     DatabaseContextPtr dbContext;
@@ -8211,7 +8211,7 @@ BaseObjectNNPtr createFromUserInput(const std::string &text, PJ_CONTEXT *ctx) {
  * in warningList(). This does not prevent more severe errors to cause an
  * exception to be thrown.
  *
- * @throw ParsingException
+ * @throw ParsingException if the string cannot be parsed.
  */
 BaseObjectNNPtr WKTParser::createFromWKT(const std::string &wkt) {
 
@@ -12183,7 +12183,7 @@ struct PJContextHolder {
  * The projString must contain +type=crs for the object to be detected as a
  * CRS instead of a CoordinateOperation.
  *
- * @throw ParsingException
+ * @throw ParsingException if the string cannot be parsed.
  */
 BaseObjectNNPtr
 PROJStringParser::createFromPROJString(const std::string &projString) {

--- a/src/iso19111/operation/concatenatedoperation.cpp
+++ b/src/iso19111/operation/concatenatedoperation.cpp
@@ -161,7 +161,7 @@ static bool areCRSMoreOrLessEquivalent(const crs::CRS *a, const crs::CRS *b) {
  * @param operationsIn Vector of the CoordinateOperation steps.
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 ConcatenatedOperationNNPtr ConcatenatedOperation::create(
     const util::PropertyMap &properties,
@@ -659,7 +659,7 @@ void ConcatenatedOperation::fixStepsDirection(
  * @param checkExtent Whether we should check the non-emptiness of the
  * intersection
  * of the extents of the operations
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 CoordinateOperationNNPtr ConcatenatedOperation::createComputeMetadata(
     const std::vector<CoordinateOperationNNPtr> &operationsIn,

--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -183,7 +183,7 @@ Conversion::alterParametersLinearUnit(const common::UnitOfMeasure &unit,
  * @param methodIn the operation method.
  * @param values the values.
  * @return a new Conversion.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 ConversionNNPtr Conversion::create(const util::PropertyMap &properties,
                                    const OperationMethodNNPtr &methodIn,
@@ -212,7 +212,7 @@ ConversionNNPtr Conversion::create(const util::PropertyMap &properties,
  * @param values the operation values. Constraint:
  * values.size() == parameters.size()
  * @return a new Conversion.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 ConversionNNPtr Conversion::create(
     const util::PropertyMap &propertiesConversion,

--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -4780,7 +4780,7 @@ PointMotionOperation::~PointMotionOperation() = default;
  * @param values Vector of GeneralOperationParameterNNPtr.
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new PointMotionOperation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 PointMotionOperationNNPtr PointMotionOperation::create(
     const util::PropertyMap &properties, const crs::CRSNNPtr &crsIn,
@@ -4833,7 +4833,7 @@ PointMotionOperationNNPtr PointMotionOperation::create(
  * values.size() == parameters.size()
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new PointMotionOperation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 PointMotionOperationNNPtr PointMotionOperation::create(
     const util::PropertyMap &propertiesOperation, const crs::CRSNNPtr &crsIn,

--- a/src/iso19111/operation/transformation.cpp
+++ b/src/iso19111/operation/transformation.cpp
@@ -188,7 +188,8 @@ Transformation::demoteTo2D(const std::string &,
  * otherwise an empty vector is returned in case of failure.
  * @return a vector of 7 values if valid, otherwise a io::FormattingException
  * is thrown.
- * @throws io::FormattingException
+ * @throws io::FormattingException in case of error, if canThrowException is
+ * true
  */
 std::vector<double> Transformation::getTOWGS84Parameters(
     bool canThrowException) const // throw(io::FormattingException)
@@ -345,7 +346,7 @@ std::vector<double> Transformation::getTOWGS84Parameters(
  * @param values Vector of GeneralOperationParameterNNPtr.
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr Transformation::create(
     const util::PropertyMap &properties, const crs::CRSNNPtr &sourceCRSIn,
@@ -388,7 +389,7 @@ TransformationNNPtr Transformation::create(
  * values.size() == parameters.size()
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr
 Transformation::create(const util::PropertyMap &propertiesTransformation,
@@ -849,7 +850,7 @@ TransformationNNPtr Transformation::createTimeDependentPositionVector(
  * @param referenceEpochYear Parameter reference epoch (in decimal year)
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr Transformation::createTimeDependentCoordinateFrameRotation(
     const util::PropertyMap &properties, const crs::CRSNNPtr &sourceCRSIn,
@@ -938,7 +939,7 @@ static TransformationNNPtr _createMolodensky(
  * the ellipsoids used in the target and source CRS.
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr Transformation::createMolodensky(
     const util::PropertyMap &properties, const crs::CRSNNPtr &sourceCRSIn,
@@ -975,7 +976,7 @@ TransformationNNPtr Transformation::createMolodensky(
  * the ellipsoids used in the target and source CRS.
  * @param accuracies Vector of positional accuracy (might be empty).
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr Transformation::createAbridgedMolodensky(
     const util::PropertyMap &properties, const crs::CRSNNPtr &sourceCRSIn,
@@ -1002,7 +1003,7 @@ TransformationNNPtr Transformation::createAbridgedMolodensky(
  * or 7 double values (Translation_X,_Y,_Z, Rotation_X,_Y,_Z, Scale_Difference)
  * passed to createPositionVector()
  * @return new Transformation.
- * @throws InvalidOperation
+ * @throws InvalidOperation if the object cannot be constructed.
  */
 TransformationNNPtr Transformation::createTOWGS84(
     const crs::CRSNNPtr &sourceCRSIn,

--- a/src/transformations/defmodel.hpp
+++ b/src/transformations/defmodel.hpp
@@ -67,7 +67,7 @@ class SpatialExtent {
   public:
     /** Parse the provided object as an extent.
      *
-     * @throws ParsingException
+     * @throws ParsingException in case of error.
      */
     static SpatialExtent parse(const json &j);
 
@@ -131,7 +131,7 @@ class Component {
   public:
     /** Parse the provided object as a component.
      *
-     * @throws ParsingException
+     * @throws ParsingException in case of error.
      */
     static Component parse(const json &j);
 
@@ -292,7 +292,7 @@ class MasterFile {
   public:
     /** Parse the provided serialized JSON content and return an object.
      *
-     * @throws ParsingException
+     * @throws ParsingException in case of error.
      */
     static std::unique_ptr<MasterFile> parse(const std::string &text);
 

--- a/src/transformations/tinshift.hpp
+++ b/src/transformations/tinshift.hpp
@@ -68,7 +68,7 @@ class TINShiftFile {
   public:
     /** Parse the provided serialized JSON content and return an object.
      *
-     * @throws ParsingException
+     * @throws ParsingException in case of error.
      */
     static std::unique_ptr<TINShiftFile> parse(const std::string &text);
 


### PR DESCRIPTION
Backport #4263
 **Authored by:** @rouault