### PR TITLE
[Backport 9.5] WKT importer: fix nullptr dereference on invalid VERTCS[]

### DIFF
--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -4786,14 +4786,15 @@ VerticalReferenceFrameNNPtr WKTParser::Private::buildVerticalReferenceFrame(
     const auto *nodeP = node->GP();
     const std::string &name(nodeP->value());
     auto &props = buildProperties(node);
+    const auto &children = nodeP->children();
 
-    if (esriStyle_ && dbContext_) {
+    if (esriStyle_ && dbContext_ && !children.empty()) {
         std::string outTableName;
         std::string authNameFromAlias;
         std::string codeFromAlias;
         auto authFactory =
             AuthorityFactory::create(NN_NO_CHECK(dbContext_), std::string());
-        const std::string datumName = stripQuotes(nodeP->children()[0]);
+        const std::string datumName = stripQuotes(children[0]);
         auto officialName = authFactory->getOfficialNameFromAlias(
             datumName, "vertical_datum", "ESRI", false, outTableName,
             authNameFromAlias, codeFromAlias);
@@ -4803,7 +4804,6 @@ VerticalReferenceFrameNNPtr WKTParser::Private::buildVerticalReferenceFrame(
     }
 
     if (ci_equal(name, WKTConstants::VERT_DATUM)) {
-        const auto &children = nodeP->children();
         if (children.size() >= 2) {
             props.set("VERT_DATUM_TYPE", children[1]->GP()->value());
         }

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -8877,6 +8877,22 @@ TEST(wkt_parse, invalid_VERTCRS) {
 
 // ---------------------------------------------------------------------------
 
+TEST(wkt_parse, invalid_esri_VERTCS) {
+
+    // VDATUM without child
+    EXPECT_THROW(WKTParser().createFromWKT(
+                     "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\","
+                     "SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],"
+                     "PRIMEM[\"Greenwich\",0.0],"
+                     "UNIT[\"Degree\",0.0174532925199433]],"
+                     "VERTCS[\"EGM96_Geoid\",VDATUM,"
+                     "PARAMETER[\"Vertical_Shift\",0.0],"
+                     "PARAMETER[\"Direction\",1.0],UNIT[\"Meter\",1.0]]"),
+                 ParsingException);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(wkt_parse, invalid_VERT_CS) {
 
     EXPECT_NO_THROW(WKTParser().createFromWKT(


### PR DESCRIPTION
Backport #4266
 **Authored by:** @rouault