### PR TITLE
Remove "-dev" from release version in Sphinx config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = "PROJ contributors"
 version = "9.5"
 
 # The full project version, used as the replacement for |release|
-release = "9.5.0-dev"
+release = "9.5.0"
 
 # PROJ-data version
 data_version = "1.19"


### PR DESCRIPTION
It is show as the title of the proj.org, which sends a wrong message since this is in fact a proper released version.

