### PR TITLE
CMake: use enable_testing() instead of include(CTest)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,9 +341,10 @@ set(PROJ_DATA_PATH "${CMAKE_INSTALL_FULL_DATADIR}/proj")
 ################################################################################
 # Tests
 ################################################################################
-include(CTest)
 
+option(BUILD_TESTING "Build the testing tree." ON)
 if(BUILD_TESTING)
+  enable_testing()
   include(ProjTest)
 else()
   message(STATUS "Testing disabled")


### PR DESCRIPTION
According to Craig Scott in https://discourse.cmake.org/t/is-there-any-reason-to-prefer-include-ctest-or-enable-testing-over-the-other/1905/2 , using include(CTest) adds unnecessary clutter that is only needed for dashboard submission. enable_testing() is enough otherwise

"Port" of https://github.com/OSGeo/shapelib/pull/162
