### PR TITLE
Doc: fix typo in Peirce Quincuncial projection

### DIFF
--- a/docs/source/operations/projections/peirce_q.rst
+++ b/docs/source/operations/projections/peirce_q.rst
@@ -79,7 +79,7 @@ Parameters
 
     *Defaults to diamond.*
 
-    .. warning:: This option was wrongly introduced introduced in 8.2.1 with the
+    .. warning:: This option was wrongly introduced in 8.2.1 with the
                  ``type`` name, which was inappropriate as it conflicted with
                  the ``+type=crs`` general hint.
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
