### PR TITLE
[doc] add k_0 to sterea projection

### DIFF
--- a/docs/source/operations/projections/sterea.rst
+++ b/docs/source/operations/projections/sterea.rst
@@ -51,3 +51,5 @@ Parameters
 .. include:: ../options/x_0.rst
 
 .. include:: ../options/y_0.rst
+
+.. include:: ../options/k_0.rst


### PR DESCRIPTION
As you can see in https://proj.org/en/9.5/operations/projections/sterea.html `k` is in the proj-string, but not documented.
This PR simply adds `k_0` to the list of parameters in `sterea.rst`.

- [x] Added clear title that can be used to generate release notes
- [x] Fully documented, including updating `docs/source/*.rst` for new API
