### PR TITLE
Fail consistently on network error and grid transformations

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -210,11 +210,13 @@ PJ *pj_obj_create(PJ_CONTEXT *ctx, const BaseObjectNNPtr &objIn) {
                     PROJStringFormatter::Convention::PROJ_5,
                     std::move(dbContext));
                 auto projString = coordop->exportToPROJString(formatter.get());
-                if (proj_context_is_network_enabled(ctx)) {
+                const bool defer_grid_opening_backup = ctx->defer_grid_opening;
+                if (!defer_grid_opening_backup &&
+                    proj_context_is_network_enabled(ctx)) {
                     ctx->defer_grid_opening = true;
                 }
                 auto pj = pj_create_internal(ctx, projString.c_str());
-                ctx->defer_grid_opening = false;
+                ctx->defer_grid_opening = defer_grid_opening_backup;
                 if (pj) {
                     pj->iso_obj = objIn;
                     pj->iso_obj_is_coordinate_operation = true;

--- a/src/transformations/gridshift.cpp
+++ b/src/transformations/gridshift.cpp
@@ -80,6 +80,7 @@ struct GridInfo {
 struct gridshiftData {
     ListOfGenericGrids m_grids{};
     bool m_defer_grid_opening = false;
+    int m_error_code_in_defer_grid_opening = 0;
     bool m_bHasHorizontalOffset = false;
     bool m_bHasGeographic3DOffset = false;
     bool m_bHasEllipsoidalHeightOffset = false;
@@ -724,12 +725,16 @@ PJ_XYZ gridshiftData::grid_apply_internal(
 // ---------------------------------------------------------------------------
 
 bool gridshiftData::loadGridsIfNeeded(PJ *P) {
-    if (m_defer_grid_opening) {
+    if (m_error_code_in_defer_grid_opening) {
+        proj_errno_set(P, m_error_code_in_defer_grid_opening);
+        return false;
+    } else if (m_defer_grid_opening) {
+        m_defer_grid_opening = false;
         m_grids = pj_generic_grid_init(P, "grids");
-        if (proj_errno(P)) {
+        m_error_code_in_defer_grid_opening = proj_errno(P);
+        if (m_error_code_in_defer_grid_opening) {
             return false;
         }
-        m_defer_grid_opening = false;
         bool isProjectedCoord;
         if (!checkGridTypes(P, isProjectedCoord)) {
             return false;

--- a/src/transformations/gridshift.cpp
+++ b/src/transformations/gridshift.cpp
@@ -725,11 +725,11 @@ PJ_XYZ gridshiftData::grid_apply_internal(
 
 bool gridshiftData::loadGridsIfNeeded(PJ *P) {
     if (m_defer_grid_opening) {
-        m_defer_grid_opening = false;
         m_grids = pj_generic_grid_init(P, "grids");
         if (proj_errno(P)) {
             return false;
         }
+        m_defer_grid_opening = false;
         bool isProjectedCoord;
         if (!checkGridTypes(P, isProjectedCoord)) {
             return false;

--- a/src/transformations/hgridshift.cpp
+++ b/src/transformations/hgridshift.cpp
@@ -22,6 +22,7 @@ struct hgridshiftData {
     double t_epoch = 0;
     ListOfHGrids grids{};
     bool defer_grid_opening = false;
+    int error_code_in_defer_grid_opening = 0;
 };
 } // anonymous namespace
 
@@ -31,11 +32,13 @@ static PJ_XYZ pj_hgridshift_forward_3d(PJ_LPZ lpz, PJ *P) {
     point.lpz = lpz;
 
     if (Q->defer_grid_opening) {
-        Q->grids = pj_hgrid_init(P, "grids");
-        if (proj_errno(P)) {
-            return proj_coord_error().xyz;
-        }
         Q->defer_grid_opening = false;
+        Q->grids = pj_hgrid_init(P, "grids");
+        Q->error_code_in_defer_grid_opening = proj_errno(P);
+    }
+    if (Q->error_code_in_defer_grid_opening) {
+        proj_errno_set(P, Q->error_code_in_defer_grid_opening);
+        return proj_coord_error().xyz;
     }
 
     if (!Q->grids.empty()) {
@@ -53,11 +56,13 @@ static PJ_LPZ pj_hgridshift_reverse_3d(PJ_XYZ xyz, PJ *P) {
     point.xyz = xyz;
 
     if (Q->defer_grid_opening) {
-        Q->grids = pj_hgrid_init(P, "grids");
-        if (proj_errno(P)) {
-            return proj_coord_error().lpz;
-        }
         Q->defer_grid_opening = false;
+        Q->grids = pj_hgrid_init(P, "grids");
+        Q->error_code_in_defer_grid_opening = proj_errno(P);
+    }
+    if (Q->error_code_in_defer_grid_opening) {
+        proj_errno_set(P, Q->error_code_in_defer_grid_opening);
+        return proj_coord_error().lpz;
     }
 
     if (!Q->grids.empty()) {

--- a/src/transformations/hgridshift.cpp
+++ b/src/transformations/hgridshift.cpp
@@ -31,11 +31,11 @@ static PJ_XYZ pj_hgridshift_forward_3d(PJ_LPZ lpz, PJ *P) {
     point.lpz = lpz;
 
     if (Q->defer_grid_opening) {
-        Q->defer_grid_opening = false;
         Q->grids = pj_hgrid_init(P, "grids");
         if (proj_errno(P)) {
             return proj_coord_error().xyz;
         }
+        Q->defer_grid_opening = false;
     }
 
     if (!Q->grids.empty()) {
@@ -53,11 +53,11 @@ static PJ_LPZ pj_hgridshift_reverse_3d(PJ_XYZ xyz, PJ *P) {
     point.xyz = xyz;
 
     if (Q->defer_grid_opening) {
-        Q->defer_grid_opening = false;
         Q->grids = pj_hgrid_init(P, "grids");
         if (proj_errno(P)) {
             return proj_coord_error().lpz;
         }
+        Q->defer_grid_opening = false;
     }
 
     if (!Q->grids.empty()) {

--- a/src/transformations/vgridshift.cpp
+++ b/src/transformations/vgridshift.cpp
@@ -57,12 +57,12 @@ static PJ_XYZ pj_vgridshift_forward_3d(PJ_LPZ lpz, PJ *P) {
     point.lpz = lpz;
 
     if (Q->defer_grid_opening) {
-        Q->defer_grid_opening = false;
         Q->grids = pj_vgrid_init(P, "grids");
         deal_with_vertcon_gtx_hack(P);
         if (proj_errno(P)) {
             return proj_coord_error().xyz;
         }
+        Q->defer_grid_opening = false;
     }
 
     if (!Q->grids.empty()) {
@@ -81,12 +81,12 @@ static PJ_LPZ pj_vgridshift_reverse_3d(PJ_XYZ xyz, PJ *P) {
     point.xyz = xyz;
 
     if (Q->defer_grid_opening) {
-        Q->defer_grid_opening = false;
         Q->grids = pj_vgrid_init(P, "grids");
         deal_with_vertcon_gtx_hack(P);
         if (proj_errno(P)) {
             return proj_coord_error().lpz;
         }
+        Q->defer_grid_opening = false;
     }
 
     if (!Q->grids.empty()) {

--- a/src/transformations/xyzgridshift.cpp
+++ b/src/transformations/xyzgridshift.cpp
@@ -54,11 +54,11 @@ struct xyzgridshiftData {
 static bool get_grid_values(PJ *P, xyzgridshiftData *Q, const PJ_LP &lp,
                             double &dx, double &dy, double &dz) {
     if (Q->defer_grid_opening) {
-        Q->defer_grid_opening = false;
         Q->grids = pj_generic_grid_init(P, "grids");
         if (proj_errno(P)) {
             return false;
         }
+        Q->defer_grid_opening = false;
     }
 
     GenericShiftGridSet *gridset = nullptr;

--- a/src/transformations/xyzgridshift.cpp
+++ b/src/transformations/xyzgridshift.cpp
@@ -45,6 +45,7 @@ struct xyzgridshiftData {
     bool grid_ref_is_input = true;
     ListOfGenericGrids grids{};
     bool defer_grid_opening = false;
+    int error_code_in_defer_grid_opening = 0;
     double multiplier = 1.0;
 };
 } // anonymous namespace
@@ -54,11 +55,13 @@ struct xyzgridshiftData {
 static bool get_grid_values(PJ *P, xyzgridshiftData *Q, const PJ_LP &lp,
                             double &dx, double &dy, double &dz) {
     if (Q->defer_grid_opening) {
-        Q->grids = pj_generic_grid_init(P, "grids");
-        if (proj_errno(P)) {
-            return false;
-        }
         Q->defer_grid_opening = false;
+        Q->grids = pj_generic_grid_init(P, "grids");
+        Q->error_code_in_defer_grid_opening = proj_errno(P);
+    }
+    if (Q->error_code_in_defer_grid_opening) {
+        proj_errno_set(P, Q->error_code_in_defer_grid_opening);
+        return false;
     }
 
     GenericShiftGridSet *gridset = nullptr;


### PR DESCRIPTION
Currently when we need to use a remote grid that can't be opened, we return HUGE_VAL coordinates values and a proj_errno = PROJ_ERR_OTHER_NETWORK_ERROR, (I guess) as expected... But if we do following proj_trans() calls on the same transformation object, the grid transformation is ignored and we fallback to other methods (Helmert, ballpark, etc.). Fix that by consistently returning the same error values as the initial failed call.

Fixes https://github.com/pyproj4/pyproj/issues/705

@snowman2 @jjimenezshaw @kbevers Thoughts?  I guess this wins on consistency. The potential downside is that if you transform a batch of one million points using the same grid and the network timeout is 1second, you'll spend 1 million seconds, as the current implementation (as modified by this PR) retries to open the grid each time a point is transformed  if it didn't manage to open it previously