### PR TITLE
[Backport 9.5] Add grid alternative for de_tlbg_thueringen_NTv2gridTH.tif

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "acf0c8191db62730a6bfc1f611afdc23")
+set(PROJ_DB_SQL_EXPECTED_MD5 "8a4df4be0172ce451325c1e04fb089be")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -123,6 +123,9 @@ VALUES
 -- de_lgvl_saarland - LVGL Saarland
 ('SeTa2016.gsb','de_lgvl_saarland_SeTa2016.tif','SeTa2016.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/de_lgvl_saarland_SeTa2016.tif',1,1,NULL),
 
+-- de_tlbg_thueringen - TLBG Thüringen
+('de_tlbg_thuringen_NTv2gridTH.gsb','de_tlbg_thueringen_NTv2gridTH.tif',NULL,'GTiff','hgridshift',0,NULL,'https://cdn.proj.org/de_tlbg_thueringen_NTv2gridTH.tif',1,1,NULL),
+
 -- dk_sdfe - Danish Agency for Data Supply and Efficiency
 -- Denmark mainland
 ('dnn.gtx','dk_sdfe_dnn.tif','dnn.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_dnn.tif',1,1,NULL),

--- a/data/sql/metadata.sql
+++ b/data/sql/metadata.sql
@@ -18,4 +18,4 @@ INSERT INTO "metadata" VALUES('PROJ.VERSION', '${PROJ_VERSION}');
 
 -- Version of the PROJ-data package with which this database is the most
 -- compatible.
-INSERT INTO "metadata" VALUES('PROJ_DATA.VERSION', '1.19');
+INSERT INTO "metadata" VALUES('PROJ_DATA.VERSION', '1.20');


### PR DESCRIPTION
Backport of https://github.com/OSGeo/PROJ/pull/4301