### PR TITLE
createObjectsFromName(): be more tolerant about N/S vs North/South, absence of zone or height

### DIFF
--- a/include/proj/metadata.hpp
+++ b/include/proj/metadata.hpp
@@ -397,11 +397,15 @@ class PROJ_GCC_DLL Identifier : public util::BaseObject,
 
     PROJ_DLL static bool isEquivalentName(const char *a,
                                           const char *b) noexcept;
+    PROJ_DLL static bool
+    isEquivalentName(const char *a, const char *b,
+                     bool biggerDifferencesAllowed) noexcept;
 
     PROJ_PRIVATE :
         //! @cond Doxygen_Suppress
         PROJ_INTERNAL static std::string
-        canonicalizeName(const std::string &str);
+        canonicalizeName(const std::string &str,
+                         bool biggerDifferencesAllowed = true);
 
     PROJ_INTERNAL void _exportToWKT(io::WKTFormatter *formatter)
         const override; // throw(io::FormattingException)

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -523,6 +523,7 @@ osgeo::proj::metadata::Identifier::description() const
 osgeo::proj::metadata::Identifier::~Identifier()
 osgeo::proj::metadata::Identifier::Identifier(osgeo::proj::metadata::Identifier const&)
 osgeo::proj::metadata::Identifier::isEquivalentName(char const*, char const*)
+osgeo::proj::metadata::Identifier::isEquivalentName(char const*, char const*, bool)
 osgeo::proj::metadata::Identifier::uri() const
 osgeo::proj::metadata::Identifier::version() const
 osgeo::proj::metadata::PositionalAccuracy::create(std::string const&)

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -370,6 +370,7 @@ static BaseObjectNNPtr buildObject(
                         limitResultCount);
                     if (res.size() == 1) {
                         obj = res.front().as_nullable();
+                        break;
                     } else {
                         for (const auto &l_obj : res) {
                             if (Identifier::isEquivalentName(

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -7966,20 +7966,23 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
 
                 // If there's exactly only one object whose name is equivalent
                 // to the user input, return it.
-                IdentifiedObjectPtr identifiedObj;
-                for (const auto &obj : res) {
-                    if (Identifier::isEquivalentName(obj->nameStr().c_str(),
-                                                     objectName.c_str())) {
-                        if (identifiedObj == nullptr) {
-                            identifiedObj = obj.as_nullable();
-                        } else {
-                            identifiedObj = nullptr;
-                            break;
+                for (int pass = 0; pass <= 1; ++pass) {
+                    IdentifiedObjectPtr identifiedObj;
+                    for (const auto &obj : res) {
+                        if (Identifier::isEquivalentName(
+                                obj->nameStr().c_str(), objectName.c_str(),
+                                /* biggerDifferencesAllowed = */ pass == 1)) {
+                            if (identifiedObj == nullptr) {
+                                identifiedObj = obj.as_nullable();
+                            } else {
+                                identifiedObj = nullptr;
+                                break;
+                            }
                         }
                     }
-                }
-                if (identifiedObj) {
-                    return identifiedObj;
+                    if (identifiedObj) {
+                        return identifiedObj;
+                    }
                 }
 
                 std::string msg("several objects matching this name: ");

--- a/test/unit/test_io.cpp
+++ b/test/unit/test_io.cpp
@@ -13689,12 +13689,37 @@ TEST(io, createFromUserInput) {
         auto obj = createFromUserInput("NGF IGN69 height", dbContext);
         auto crs = nn_dynamic_pointer_cast<VerticalCRS>(obj);
         EXPECT_TRUE(crs != nullptr);
-        EXPECT_EQ(crs->nameStr(), "NGF-IGN69 height");
+        EXPECT_EQ(crs->nameStr(), "NGF-IGN69 height"); // EPSG:5720
+    }
+
+    {
+        // Approximate match of a vertical CRS
+        auto obj = createFromUserInput("NGF IGN1969", dbContext);
+        auto crs = nn_dynamic_pointer_cast<VerticalCRS>(obj);
+        EXPECT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "NGF-IGN 1969"); // IGNF69:IGN69
+    }
+
+    {
+        // Approximate match of a vertical CRS
+        auto obj = createFromUserInput("NGF IGN69", dbContext);
+        auto crs = nn_dynamic_pointer_cast<VerticalCRS>(obj);
+        EXPECT_TRUE(crs != nullptr);
+        // Questionnable if we shouldn't match EPSG:5720 instead
+        EXPECT_EQ(crs->nameStr(), "NGF-IGN 1969"); // IGNF69:IGN69
     }
 
     {
         // Exact match on each piece of the compound CRS
         auto obj = createFromUserInput("WGS 84 + EGM96 height", dbContext);
+        auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "WGS 84 + EGM96 height");
+    }
+
+    {
+        // Approximate match
+        auto obj = createFromUserInput("WGS 84 + EGM96", dbContext);
         auto crs = nn_dynamic_pointer_cast<CompoundCRS>(obj);
         ASSERT_TRUE(crs != nullptr);
         EXPECT_EQ(crs->nameStr(), "WGS 84 + EGM96 height");
@@ -13783,6 +13808,18 @@ TEST(io, createFromUserInput) {
         ASSERT_TRUE(coordinateMetadata != nullptr);
         EXPECT_EQ(coordinateMetadata->coordinateEpochAsDecimalYear(), 2025.1);
     }
+
+    {
+        // Approximate match involving using "north" instead of N and lacking
+        // "zone"
+        auto obj = createFromUserInput("WGS 84 UTM 31 north", dbContext);
+        auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        EXPECT_EQ(crs->nameStr(), "WGS 84 / UTM zone 31N");
+    }
+
+    // Should not match WGS84 or IGM85
+    EXPECT_THROW(createFromUserInput("WGS 85", dbContext), ParsingException);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
We want the following matches to be possible:

```
user entry            official name
------------------    ----------------
EGM96                 EGM96 height
WGS84 UTM31 north     WGS 84 / UTM zone 31N
```