### PR TITLE
Optimization: createOperations(): avoid database lookups for CRS (typically PROJ strings) using unknown datums

### DIFF
--- a/include/proj/internal/datum_internal.hpp
+++ b/include/proj/internal/datum_internal.hpp
@@ -42,4 +42,6 @@ constexpr const char *NON_EARTH_BODY = "Non-Earth body";
 // which is a 0.59% relative difference.
 constexpr double REL_ERROR_FOR_SAME_CELESTIAL_BODY = 0.007;
 
+constexpr const char *UNKNOWN_BASED_ON = "Unknown based on ";
+
 #endif // DATUM_INTERNAL_HH_INCLUDED

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -913,6 +913,8 @@ class PROJ_GCC_DLL DatabaseContext {
                                   bool &directDownload, bool &openLicense,
                                   bool &gridAvailable) const;
 
+    PROJ_DLL unsigned int getQueryCounter() const;
+
     PROJ_INTERNAL std::string
     getProjGridName(const std::string &oldProjGridName);
 

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -394,6 +394,7 @@ osgeo::proj::io::DatabaseContext::getDatabaseStructure() const
 osgeo::proj::io::DatabaseContext::getInsertStatementsFor(dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::common::IdentifiedObject> > const&, std::string const&, std::string const&, bool, std::vector<std::string, std::allocator<std::string> > const&)
 osgeo::proj::io::DatabaseContext::getMetadata(char const*) const
 osgeo::proj::io::DatabaseContext::getPath() const
+osgeo::proj::io::DatabaseContext::getQueryCounter() const
 osgeo::proj::io::DatabaseContext::getSqliteHandle() const
 osgeo::proj::io::DatabaseContext::getVersionedAuthoritiesFromName(std::string const&)
 osgeo::proj::io::DatabaseContext::lookForGridInfo(std::string const&, bool, std::string&, std::string&, std::string&, bool&, bool&, bool&) const

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1557,8 +1557,13 @@ bool GeodeticReferenceFrame::_isEquivalentTo(
 bool GeodeticReferenceFrame::hasEquivalentNameToUsingAlias(
     const IdentifiedObject *other,
     const io::DatabaseContextPtr &dbContext) const {
-    if (nameStr() == "unknown" || other->nameStr() == "unknown") {
+    if (nameStr() == other->nameStr() || nameStr() == "unknown" ||
+        other->nameStr() == "unknown") {
         return true;
+    }
+    if (ci_starts_with(nameStr(), UNKNOWN_BASED_ON) ||
+        ci_starts_with(other->nameStr(), UNKNOWN_BASED_ON)) {
+        return false;
     }
     if (dbContext) {
         if (!identifiers().empty()) {

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -847,6 +847,7 @@ struct DatabaseContext::Private {
     std::string databasePath_{};
     std::vector<std::string> auxiliaryDatabasePaths_{};
     std::shared_ptr<SQLiteHandle> sqlite_handle_{};
+    unsigned int queryCounter_ = 0;
     std::map<std::string, sqlite3_stmt *> mapSqlToStatement_{};
     PJ_CONTEXT *pjCtxt_ = nullptr;
     int recLevel_ = 0;
@@ -1417,6 +1418,8 @@ SQLResultSet DatabaseContext::Private::run(const std::string &sql,
         mapSqlToStatement_.insert(
             std::pair<std::string, sqlite3_stmt *>(sql, stmt));
     }
+
+    ++queryCounter_;
 
     return l_handle->run(stmt, sql, parameters, useMaxFloatPrecision);
 }
@@ -3486,6 +3489,15 @@ bool DatabaseContext::lookForGridInfo(
     info.found = ret;
     d->cache(key, info);
     return ret;
+}
+
+// ---------------------------------------------------------------------------
+
+/** Returns the number of queries to the database since the creation of this
+ * instance.
+ */
+unsigned int DatabaseContext::getQueryCounter() const {
+    return d->queryCounter_;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -10888,7 +10888,7 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
             } else {
                 return GeodeticReferenceFrame::create(
                     PropertyMap().set(IdentifiedObject::NAME_KEY,
-                                      "Unknown based on " +
+                                      UNKNOWN_BASED_ON +
                                           grf->ellipsoid()->nameStr() +
                                           " ellipsoid" + datumNameSuffix),
                     grf->ellipsoid(), grf->anchorDefinition(), pm);
@@ -10961,18 +10961,18 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
             if (ellpsStr == "WGS84") {
                 return GeodeticReferenceFrame::create(
                     grfMap.set(IdentifiedObject::NAME_KEY,
-                               title.empty()
-                                   ? "Unknown based on WGS 84 ellipsoid" +
-                                         datumNameSuffix
-                                   : title),
+                               title.empty() ? std::string(UNKNOWN_BASED_ON)
+                                                   .append("WGS 84 ellipsoid")
+                                                   .append(datumNameSuffix)
+                                             : title),
                     Ellipsoid::WGS84, optionalEmptyString, pm);
             } else if (ellpsStr == "GRS80") {
                 return GeodeticReferenceFrame::create(
                     grfMap.set(IdentifiedObject::NAME_KEY,
-                               title.empty()
-                                   ? "Unknown based on GRS 1980 ellipsoid" +
-                                         datumNameSuffix
-                                   : title),
+                               title.empty() ? std::string(UNKNOWN_BASED_ON)
+                                                   .append("GRS 1980 ellipsoid")
+                                                   .append(datumNameSuffix)
+                                             : title),
                     Ellipsoid::GRS1980, optionalEmptyString, pm);
             } else {
                 auto proj_ellps = proj_list_ellps();
@@ -11006,9 +11006,10 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
                         return GeodeticReferenceFrame::create(
                             grfMap.set(IdentifiedObject::NAME_KEY,
                                        title.empty()
-                                           ? std::string("Unknown based on ") +
-                                                 proj_ellps[i].name +
-                                                 " ellipsoid" + datumNameSuffix
+                                           ? std::string(UNKNOWN_BASED_ON)
+                                                 .append(proj_ellps[i].name)
+                                                 .append(" ellipsoid")
+                                                 .append(datumNameSuffix)
                                            : title),
                             NN_NO_CHECK(ellipsoid), optionalEmptyString, pm);
                     }
@@ -11041,7 +11042,7 @@ PROJStringParser::Private::buildDatum(Step &step, const std::string &title) {
         std::string datumName(title);
         if (title.empty()) {
             if (ellipsoid->nameStr() != "unknown") {
-                datumName = "Unknown based on ";
+                datumName = UNKNOWN_BASED_ON;
                 datumName += ellipsoid->nameStr();
                 datumName += " ellipsoid";
             } else {


### PR DESCRIPTION
Fixes #4319

With that improvement, the runtime of the following snippet goes from
25.4 second to 0.9 second:
```c
    for(int i = 0; i < 2000; ++i)
    {
        PJ_CONTEXT *C = proj_context_create();
        PJ *P = proj_create_crs_to_crs(C,
           "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs",
           "+proj=utm +zone=31 +ellps=GRS80 +units=m +no_defs", NULL);
        proj_destroy(P);
        proj_context_destroy(C);
    }
```
