### PR TITLE
Removed leftover setting of CMAKE_REQUIRED_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,14 +289,6 @@ if(Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
     "${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
-include(CheckCSourceCompiles)
-if(MSVC)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX /W4")
-else()
-  set(CMAKE_REQUIRED_LIBRARIES m)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
-endif()
-
 # Set a default build type for single-configuration cmake generators if
 # no build type is set.
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Back in 88d91f709c86fad6c0cc8b1f15706216cba81ffe I removed a `check_c_source_compiles` to detect some pthread stuff and converted to std::mutex instead.

This stuff I believe I should have removed back then too.

The -Werror caused a problem in VTK, which still has the `check_c_source_compiles`, because a totally unrelated warning made the try-compile fail when it should have passed.
