### PR TITLE
[9.5 branch ] Add .github/workflows/auto_tag_stable.yml

### DIFF
--- a/.github/workflows/auto_tag_stable.yml
+++ b/.github/workflows/auto_tag_stable.yml
@@ -1,0 +1,41 @@
+name: Update Stable Tag
+
+on:
+  push:
+    branches:
+      - '**'  # Matches all branches, but we later filter on the one matching the STABLE_BRANCH repository variable
+
+permissions:
+    contents: read
+
+jobs:
+  update-stable-tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'OSGeo/PROJ'
+    permissions:
+        contents: write
+    steps:
+      - name: Check branch match
+        id: check_branch
+        env:
+          STABLE_BRANCH: ${{ vars.STABLE_BRANCH }} # Repository variable
+        run: |
+          echo "Push detected on branch $GITHUB_REF"
+          if [[ "${GITHUB_REF#refs/heads/}" != "${STABLE_BRANCH}" ]]; then
+            echo "This workflow only runs for branch $STABLE_BRANCH. Skipping further steps."
+            echo "run=false" >> $GITHUB_OUTPUT
+          else
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code
+        if: steps.check_branch.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Tag
+        if: steps.check_branch.outputs.run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag -f stable
+          git push -f origin stable


### PR DESCRIPTION
This workflow automatically updates and pushes the 'stable' tag when commits are pushed to the branch pointed by https://github.com/OSGeo/PROJ/settings/variables/actions/STABLE_BRANCH

Workflow experimented in a toy repository in https://github.com/rouault/try_autotag/actions