### PR TITLE
[Backport 9.5] Removed leftover setting of CMAKE_REQUIRED_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,14 +289,6 @@ if(Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
     "${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
-include(CheckCSourceCompiles)
-if(MSVC)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} /WX /W4")
-else()
-  set(CMAKE_REQUIRED_LIBRARIES m)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
-endif()
-
 # Set a default build type for single-configuration cmake generators if
 # no build type is set.
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Backport #4322
 **Authored by:** @seanm