### PR TITLE
PROJ_DB_SQL_EXPECTED_MD5: do not make it sensitive to PROJ_VERSION or…

### DIFF
--- a/HOWTO-RELEASE.md
+++ b/HOWTO-RELEASE.md
@@ -216,11 +216,6 @@ version numbers in the files.
 - CMakeLists.txt:       Update proj_version()
 - docs/source/conf.py:  Update version number
 
-Given the update of the PROJ_VERSION number, the expected MD5SUM of the database
-SQL files will be modified. Run a build, and update the PROJ_DB_SQL_EXPECTED_MD5
-variable in data/CMakeLists.txt with the value that CMake will provide in an
-error message.
-
 *Commit changes. Either to master or maintenance branch depending on the nature
 of the release.*
 

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "78cbab972fc752d68dc92e1ecba5240e")
+set(PROJ_DB_SQL_EXPECTED_MD5 "3d51445a31ba6980332fa8e2348f7b16")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/generate_proj_db.cmake
+++ b/data/generate_proj_db.cmake
@@ -14,14 +14,14 @@ function(generate_all_sql_in ALL_SQL_IN_FILENAME EXTRA_VALIDATION OUT_MD5)
       cat(${SQL_FILE} "${ALL_SQL_IN_FILENAME}")
     endforeach()
 
-    # Compute the MD5 before PROJ_VERSION substitution to avoid updating the
-    # expected MD5 if we just bump the PROJ_VERSION
-    configure_file("${ALL_SQL_IN_FILENAME}" "${ALL_SQL_IN_FILENAME}.tmp" NEWLINE_STYLE UNIX)
-    file(MD5 "${ALL_SQL_IN_FILENAME}.tmp" OUT_MD5_LOCAL)
+    # Compute the MD5 before any records in the metadata table, to avoid
+    # refreshing the MD5 if we bump PROJ_VERSION or PROJ_DATA.VERSION
+    file(READ ${ALL_SQL_IN_FILENAME} CONTENTS)
+    string(REGEX REPLACE "INSERT INTO \\\"metadata\\\"[^\n]*\n?" "" CONTENTS_WITHOUT_METADATA "${CONTENTS}")
+    string(MD5 OUT_MD5_LOCAL "${CONTENTS_WITHOUT_METADATA}")
     set(${OUT_MD5} "${OUT_MD5_LOCAL}" PARENT_SCOPE)
 
     # Do ${PROJ_VERSION} substitution
-    file(READ ${ALL_SQL_IN_FILENAME} CONTENTS)
     string(REPLACE "\${PROJ_VERSION}" "${PROJ_VERSION}" CONTENTS_MOD "${CONTENTS}")
     file(WRITE "${ALL_SQL_IN_FILENAME}" "${CONTENTS_MOD}")
 endfunction()


### PR DESCRIPTION
… other records in the metadata table

The intent was actually already to avoid making the md5sum sensitive to PROJ_VERSION changes, but this was broken. Generalize that also to other records in the metadata table, such as PROJ_DATA.VERSION, to simplify the release process.
