### PR TITLE
CI: update 'other_checks' to ubuntu-24.04

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -33,15 +33,16 @@ jobs:
         run: ./scripts/cppcheck.sh
 
   other_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Requirements
         run: |
-            sudo apt-get install python3-pip
-            sudo pip3 install cffconvert
+            sudo apt-get install -y --no-install-recommends python3-pip
+            sudo apt-get remove -y python3-jsonschema
+            sudo pip3 install --break-system-packages cffconvert
 
       - name: Validate citation file
         run: |


### PR DESCRIPTION
It seems ubuntu-latest is progressively rolled out by GitHub to be updated to ubuntu-24.04 (in my forks at least), and currently 'pip3 install cffconvert' fails on it.
