### PR TITLE
Add bash completion script for projinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,6 +415,8 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
+add_subdirectory(scripts)
+
 set(docfiles COPYING NEWS.md AUTHORS.md)
 install(FILES ${docfiles}
         DESTINATION ${CMAKE_INSTALL_DOCDIR})
@@ -459,7 +461,6 @@ set(CPACK_SOURCE_IGNORE_FILES
   /m4/libtool*
   /media/
   /schemas/
-  /scripts/
   /test/fuzzers/
   /test/gigs/.*gie\\.failing
   /test/postinstall/

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_BASH_COMPLETION QUIET bash-completion)
+  if (PC_BASH_COMPLETION_FOUND)
+    pkg_get_variable(BASH_COMPLETIONS_FULL_DIR bash-completion completionsdir)
+    pkg_get_variable(BASH_COMPLETIONS_PREFIX bash-completion prefix)
+    if (BASH_COMPLETIONS_FULL_DIR
+        AND BASH_COMPLETIONS_PREFIX
+        AND BASH_COMPLETIONS_FULL_DIR MATCHES "^${BASH_COMPLETIONS_PREFIX}/")
+      string(REGEX REPLACE "^${BASH_COMPLETIONS_PREFIX}/" "" BASH_COMPLETIONS_DIR_DEFAULT ${BASH_COMPLETIONS_FULL_DIR})
+    endif ()
+  endif ()
+endif ()
+
+if (NOT DEFINED BASH_COMPLETIONS_DIR_DEFAULT)
+  include(GNUInstallDirs)
+  set(BASH_COMPLETIONS_DIR_DEFAULT ${CMAKE_INSTALL_DATADIR}/bash-completion/completions)
+endif ()
+
+set(BASH_COMPLETIONS_DIR
+    "${BASH_COMPLETIONS_DIR_DEFAULT}"
+    CACHE PATH "Installation sub-directory for bash completion scripts")
+
+if (NOT BASH_COMPLETIONS_DIR STREQUAL "")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/install_bash_completions.cmake.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/install_bash_completions.cmake @ONLY)
+  install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/install_bash_completions.cmake)
+endif ()

--- a/scripts/install_bash_completions.cmake.in
+++ b/scripts/install_bash_completions.cmake.in
@@ -1,0 +1,13 @@
+set(PROGRAMS
+    projinfo
+)
+
+set(INSTALL_DIR "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@BASH_COMPLETIONS_DIR@")
+
+file(MAKE_DIRECTORY "${INSTALL_DIR}")
+
+foreach (program IN LISTS PROGRAMS)
+  message(STATUS "Installing ${INSTALL_DIR}/${program}")
+  configure_file("@CMAKE_CURRENT_SOURCE_DIR@/${program}-bash-completion.sh" "${INSTALL_DIR}/${program}" COPYONLY)
+  file(APPEND "@PROJECT_BINARY_DIR@/install_manifest_extra.txt" "${INSTALL_DIR}/${program}\n")
+endforeach ()

--- a/scripts/projinfo-bash-completion.sh
+++ b/scripts/projinfo-bash-completion.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+function_exists() {
+    declare -f -F "$1" > /dev/null
+    return $?
+}
+
+# Checks that bash-completion is recent enough
+function_exists _get_comp_words_by_ref || return 0
+
+_projinfo()
+{
+  local cur prev
+  COMPREPLY=()
+  _get_comp_words_by_ref cur prev
+  choices=$(projinfo completion ${COMP_LINE})
+  if [[ "$cur" == "=" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "$cur" == ":" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "${cur: -1}" == "/" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "${cur: -2}" == "/ " ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "${cur: -1}" == "+" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "${cur: -2}" == "+ " ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" --)
+  elif [[ "$cur" == "!" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$choices" -P "! " --)
+  else
+    mapfile -t COMPREPLY < <(compgen -W "$choices" -- "$cur")
+  fi
+  for element in "${COMPREPLY[@]}"; do
+    if [[ $element == */ ]]; then
+      # Do not add a space if one of the suggestion ends with slash
+      compopt -o nospace
+      break
+    elif [[ $element == *= ]]; then
+      # Do not add a space if one of the suggestion ends with equal
+      compopt -o nospace
+      break
+    elif [[ $element == *: ]]; then
+      # Do not add a space if one of the suggestion ends with colon
+      compopt -o nospace
+      break
+    fi
+  done
+}
+complete -o default -F _projinfo projinfo
+

--- a/test/cli/test_projinfo.yaml
+++ b/test/cli/test_projinfo.yaml
@@ -1922,3 +1922,9 @@ tests:
 - args: completion projinfo "\"RGF93" v1 "/"
   out: |
      Lambert-93 CC42 CC43 CC44 CC45 CC46 CC47 CC48 CC49 CC50 Lambert-93\ +\ NGF-IGN69\ height Lambert-93\ +\ NGF-IGN78\ height
+- args: completion projinfo "\"NAD83(HARN) / California Albers" "+"
+  out: |
+    NGVD29\ height\ (ftUS) NAVD88\ depth\ (ftUS) NGVD29\ depth\ (ftUS) NAVD88\ height\ (ftUS) NGVD29\ height\ (m) MSL\ height\ (ftUS) MSL\ depth\ (ftUS) NAVD88\ height\ (ft)
+- args: completion projinfo "\"Mauritania 1999" "/" UTM zone 29N "+"
+  out: |
+    EGM2008\ height MSL\ height MSL\ depth EGM96\ height EGM84\ height Instantaneous\ Water\ Level\ height Instantaneous\ Water\ Level\ depth LAT\ depth LLWLT\ depth ISLW\ depth MLLWS\ depth MLWS\ depth MLLW\ depth MLW\ depth MHW\ height MHHW\ height MHWS\ height HHWLT\ height HAT\ height Low\ Water\ depth High\ Water\ height MSL\ height\ (ft) MSL\ depth\ (ft)

--- a/test/cli/test_projinfo.yaml
+++ b/test/cli/test_projinfo.yaml
@@ -1890,3 +1890,35 @@ tests:
   out: |
     Candidate operations found: 1
     unknown id, Conversion from WGS 84 (G1150) (geog2D) to WGS 84 (G1150) (geocentric) + WGS 84 (G1150) to WGS 84 (G1762) (1) + WGS 84 (G1762) to WGS 84 (G2139) (1) + WGS 84 (G2139) to WGS 84 (G2296) (1) + Conversion from WGS 84 (G2296) (geocentric) to WGS 84 (G2296) (geog2D), 0.04 m, World
+- args: completion projinfo -
+  out: |
+     -o -k --summary -q --area --bbox --spatial-test --crs-extent-use --grid-check --pivot-crs --show-superseded --hide-ballpark --accuracy --allow-ellipsoidal-height-as-vertical-crs --boundcrs-to-wgs84 --authority --main-db-path --aux-db-path --identify --3d --output-id --c-ify --single-line --searchpaths --remote-data --list-crs --dump-db-structure -s --s_epoch -t --t_epoch
+- args: completion projinfo -o
+  out: all PROJ WKT2:2019 WKT2:2015 WKT1:GDAL WKT1:ESRI PROJJSON SQL
+- args: completion projinfo -o "WKT2:"
+  out: 2019 2015
+- args: completion projinfo -o "WKT1:"
+  out: GDAL ESRI
+- args: completion projinfo --pivot-crs
+  out: |
+     always if_no_direct_transformation never EPSG: ESRI: IAU_2015: IGNF: NKG: NRCAN: OGC: PROJ:
+- args: completion projinfo
+  out: |
+     EPSG: ESRI: IAU_2015: IGNF: NKG: NRCAN: OGC: PROJ:
+- args: completion projinfo NKG
+  out: "NKG:"
+- args: completion projinfo "OGC:"
+  out: |
+     CRS27\ --\ NAD27\ (CRS27) CRS83\ --\ NAD83\ (CRS83) CRS84\ --\ WGS\ 84\ (CRS84) CRS84h\ --\ WGS\ 84\ longitude-latitude-height
+- args: completion projinfo EPSG:432
+  out: |
+     4322\ --\ WGS\ 72 4324\ --\ WGS\ 72BE 4326\ --\ WGS\ 84
+- args: completion projinfo EPSG:4326
+  out: |
+     4326
+- args: completion projinfo EGM
+  out: |
+     EGM2008\ height EGM96\ height EGM84\ height
+- args: completion projinfo "\"RGF93" v1 "/"
+  out: |
+     Lambert-93 CC42 CC43 CC44 CC45 CC46 CC47 CC48 CC49 CC50 Lambert-93\ +\ NGF-IGN69\ height Lambert-93\ +\ NGF-IGN78\ height


### PR DESCRIPTION
and install it in standard ${prefix}/share/bash-completion/completions directory

Demo:

```
source ./scripts/projinfo-bash-completion.sh
```

```
$ projinfo <TAB><TAB>
EPSG:      ESRI:      IAU_2015:  IGNF:      NKG:       NRCAN:     OGC:       PROJ:
```

```
$ projinfo -<TAB><TAB>
-3d                                        --boundcrs-to-wgs84                         --list-crs                                  --searchpaths
--accuracy                                  --c-ify                                     --main-db-path                              --show-superseded
--allow-ellipsoidal-height-as-vertical-crs  --crs-extent-use--grid-check                -o                                          --single-line
--area                                      --dump-db-structure                         --output-id                                 --spatial-test
--authority                                 --hide-ballpark                             --pivot-crs                                 --summary
--aux-db-path                               --identify                                  -q
--bbox                                      -k                                          --remote-data
```

```
$ projinfo -o <TAB><TAB>
all        PROJ       PROJJSON   SQL        WKT1:ESRI  WKT1:GDAL  WKT2:2015  WKT2:2019
```

```
$ projinfo "NAD83(2011) <TAB><TAB>
NAD83(2011)                                                                NAD83(2011) / New Mexico West
NAD83(2011) / Adjusted Jackson (ftUS)                                      NAD83(2011) / New Mexico West (ftUS)
NAD83(2011) / Alabama East                                                 NAD83(2011) / New York Central
[ ... snip ... ]
```

```
$ projinfo EPSG:43<TAB><TAB>
4322 -- WGS 72    4324 -- WGS 72BE  4326 -- WGS 84
```
