### PR TITLE
proj_clone(): properly propagate errorIfBestTransformationNotAvailable and other flags from source object

### DIFF
--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -115,6 +115,19 @@ PJconsts::PJconsts() : destructor(pj_default_destructor) {}
 /*****************************************************************************/
 
 /*****************************************************************************/
+/*              void PJconsts::copyStateFrom(const PJconsts& other)          */
+/*****************************************************************************/
+
+void PJconsts::copyStateFrom(const PJconsts &other) {
+    over = other.over;
+    errorIfBestTransformationNotAvailable =
+        other.errorIfBestTransformationNotAvailable;
+    warnIfBestTransformationNotAvailable =
+        other.warnIfBestTransformationNotAvailable;
+    skipNonInstantiable = other.skipNonInstantiable;
+}
+
+/*****************************************************************************/
 PJ *pj_new() {
     /*****************************************************************************/
     return new (std::nothrow) PJ();

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -687,6 +687,8 @@ struct PJconsts {
     PJconsts();
     PJconsts(const PJconsts &) = delete;
     PJconsts &operator=(const PJconsts &) = delete;
+
+    void copyStateFrom(const PJconsts &);
 };
 
 /* Parameter list (a copy of the +proj=... etc. parameters) */


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/11650
