### PR TITLE
NKG.sql: Add support for EUREF-FIN in Finish transformations

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "ee3ada25f320aa404531246a942c074d")
+set(PROJ_DB_SQL_EXPECTED_MD5 "6488d04f52652b2a7214ea6cb1caf62c")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "6488d04f52652b2a7214ea6cb1caf62c")
+set(PROJ_DB_SQL_EXPECTED_MD5 "d5e48d79a5938158915c39144ec86f99")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/nkg.sql
+++ b/data/sql/nkg.sql
@@ -1023,7 +1023,8 @@ INSERT INTO "other_transformation" (
     operation_version,
     deprecated
 )
-VALUES(
+VALUES
+(
     'NKG', 'ETRF96_2000_TO_ETRF96_1997',-- object auth+code
     'ETRF96@2000.0 to ETRF96@1997.0 using nkgrf03vel_realigned',     -- name
     NULL,                               -- description
@@ -1034,40 +1035,85 @@ VALUES(
     0.005,          -- accuracy
     'NKG 2008',     -- operation_version
     0               -- deprecated
+),
+(
+    'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN',-- object auth+code
+    'ETRF96@2000.0 to ETRF96@1997.0 (EUREF-FIN) using nkgrf03vel_realigned',     -- name
+    NULL,                               -- description
+    'PROJ', 'PROJString',               -- method auth+cod
+    '+proj=deformation +dt=-3.0 +grids=eur_nkg_nkgrf03vel_realigned.tif',
+    'EPSG','7926',  -- source_crs:  ETRF96@2000.0
+    'EPSG','10688', -- target_crs:  EUREF-FIN
+    0.005,          -- accuracy
+    'NKG 2008',     -- operation_version
+    0               -- deprecated
 );
 
-INSERT INTO "usage" VALUES (
+INSERT INTO "usage"
+VALUES
+(
     'NKG', '5018',          -- usage auth+code
     'other_transformation', -- object_table_name
     'NKG', 'ETRF96_2000_TO_ETRF96_1997', -- object auth+code
     'EPSG', '1095',         -- extent: Finland - onshore and offshore
     'NKG',  'SCOPE_GENERIC' -- scope
+),
+(
+    'NKG', '50181',          -- usage auth+code
+    'other_transformation', -- object_table_name
+    'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN', -- object auth+code
+    'EPSG', '1095',         -- extent: Finland - onshore and offshore
+    'NKG',  'SCOPE_GENERIC' -- scope
 );
 
-INSERT INTO "concatenated_operation" VALUES(
+INSERT INTO "concatenated_operation"
+VALUES
+(
     'NKG', 'ETRF00_TO_FI', -- operation auth+code
-    'NKG_ETRF00 to ETRS89 (EUREF-FIN)', -- name
+    'NKG_ETRF00 to ETRS89 (FI)', -- name
     'Transformation from NKG_ETRF00@2000.0 to ETRF96@1997.0', -- description
     'NKG', 'ETRF00',-- source_crs:  NKG_ETRF00
     'EPSG','4936',  -- target_crs:  ETRS89 (FI)
     0.01,           -- accuracy
     'NKG 2008',     -- operation_version
     0               -- deprecated
-);
+),
+(
+    'NKG', 'ETRF00_TO_EUREF-FIN', -- operation auth+code
+    'NKG_ETRF00 to ETRS89 (EUREF-FIN)', -- name
+    'Transformation from NKG_ETRF00@2000.0 to ETRF96@1997.0 (EUREF-FIN)', -- description
+    'NKG', 'ETRF00',-- source_crs:  NKG_ETRF00
+    'EPSG','10688', -- target_crs:  EUREF-FIN
+    0.01,           -- accuracy
+    'NKG 2008',     -- operation_version
+    0               -- deprecated
+)
+;
 
 
 INSERT INTO "concatenated_operation_step" (
     operation_auth_name, operation_code, step_number, step_auth_name, step_code
 ) VALUES
     ('NKG', 'ETRF00_TO_FI', 1, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ETRF00_TO_FI', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997')
+    ('NKG', 'ETRF00_TO_FI', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997'),
+    ('NKG', 'ETRF00_TO_EUREF-FIN', 1, 'NKG', 'P1_2008_FI'),
+    ('NKG', 'ETRF00_TO_EUREF-FIN', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN')
 ;
 
 
-INSERT INTO "usage" VALUES (
+INSERT INTO "usage"
+VALUES
+(
     'NKG', '5019',              -- usage auth+code
     'concatenated_operation',   -- object_table_name
     'NKG', 'ETRF00_TO_FI',      -- object auth+code
+    'EPSG', '1095',             -- extent: Finland - onshore and offshore
+    'NKG', 'SCOPE_GENERIC'      -- scope auth+code
+),
+(
+    'NKG', '50191',              -- usage auth+code
+    'concatenated_operation',   -- object_table_name
+    'NKG', 'ETRF00_TO_EUREF-FIN',      -- object auth+code
     'EPSG', '1095',             -- extent: Finland - onshore and offshore
     'NKG', 'SCOPE_GENERIC'      -- scope auth+code
 );
@@ -1078,7 +1124,8 @@ INSERT INTO "usage" VALUES (
 -- Transformation: ITRF2000 -> ETRF96@1997.0 (FI)
 -------------------------------------------------------
 
-INSERT INTO "concatenated_operation"  VALUES (
+INSERT INTO "concatenated_operation" VALUES
+(
     'NKG', 'ITRF2000_TO_FI',  -- operation auth+code
     'ITRF2000 to ETRS89 (EUREF-FIN)', -- name
     'Time-dependent transformation from ITRF2014 to ETRS89 (EUREF-FIN)', -- description
@@ -1087,7 +1134,16 @@ INSERT INTO "concatenated_operation"  VALUES (
     0.01,           -- accuracy
     'NKG 2008',     -- operation_version
     0               -- deprecated
-
+),
+(
+    'NKG', 'ITRF2000_TO_FI_EUREF-FIN',  -- operation auth+code
+    'ITRF2000 to EUREF-FIN (ETRS89)', -- name
+    'Time-dependent transformation from ITRF2014 to EUREF-FIN (ETRS89)', -- description
+    'EPSG', '4919', -- source_crs:  ITRF2000
+    'EPSG', '10688',-- target_crs:  EUREF-FIN
+    0.01,           -- accuracy
+    'NKG 2008',     -- operation_version
+    0               -- deprecated
 );
 
 INSERT INTO "concatenated_operation_step" (
@@ -1096,17 +1152,30 @@ INSERT INTO "concatenated_operation_step" (
     ('NKG', 'ITRF2000_TO_FI', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
     ('NKG', 'ITRF2000_TO_FI', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
     ('NKG', 'ITRF2000_TO_FI', 3, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ITRF2000_TO_FI', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997')
+    ('NKG', 'ITRF2000_TO_FI', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 3, 'NKG', 'P1_2008_FI'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN')
 ;
 
 
-INSERT INTO "usage" VALUES (
+INSERT INTO "usage" VALUES
+(
     'NKG', '5020',              -- usage auth+code
     'concatenated_operation',   -- object_table_name
     'NKG', 'ITRF2000_TO_FI',    -- object auth+code
     'EPSG', '1095',             -- extent: Finland - onshore and offshore
     'NKG', 'SCOPE_GENERIC'      -- scope auth+code
+),
+(
+    'NKG', '50201',              -- usage auth+code
+    'concatenated_operation',   -- object_table_name
+    'NKG', 'ITRF2000_TO_FI_EUREF-FIN',    -- object auth+code
+    'EPSG', '1095',             -- extent: Finland - onshore and offshore
+    'NKG', 'SCOPE_GENERIC'      -- scope auth+code
 );
+
 
 
 
@@ -1798,6 +1867,18 @@ VALUES(
     0.005,          -- accuracy
     'NKG 2020',     -- operation_version
     0               -- deprecated
+),
+(
+    'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN',-- object auth+code
+    'ETRF96@2000.0 to ETRF96@1997.0 using nkgrf17vel (EUREF-FIN)', -- name
+    NULL, -- description
+    'PROJ', 'PROJString',               -- method auth+cod
+    '+proj=deformation +dt=-3 +grids=eur_nkg_nkgrf17vel.tif',
+    'EPSG','7926',  -- source_crs:  ETRF96@2000.0
+    'EPSG','10688', -- target_crs:  EUREF-FIN
+    0.005,          -- accuracy
+    'NKG 2020',     -- operation_version
+    0               -- deprecated
 );
 
 INSERT INTO "usage" VALUES (
@@ -1806,14 +1887,31 @@ INSERT INTO "usage" VALUES (
     'NKG', 'FI_2020_INTRAPLATE', -- object auth+code
     'EPSG', '1095',         -- extent: Finland - onshore and offshore
     'NKG',  'SCOPE_GENERIC' -- scope
+),
+(
+    'NKG', '50491',          -- usage auth+code
+    'other_transformation', -- object_table_name
+    'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN', -- object auth+code
+    'EPSG', '1095',         -- extent: Finland - onshore and offshore
+    'NKG',  'SCOPE_GENERIC' -- scope
 );
 
 INSERT INTO "concatenated_operation" VALUES(
     'NKG', 'ETRF14_TO_FI', -- operation auth+code
-    'NKG_ETRF14 to ETRS89 (EUREF-FIN)', -- name
+    'NKG_ETRF14 to ETRS89 (FI)', -- name
     'Transformation from NKG_ETRF14@2000.0 to ETRF96@1997.0', -- description
     'NKG', 'ETRF14',-- source_crs:  NKG_ETRF00
     'EPSG','4936',  -- target_crs:  ETRS89 (FI)
+    0.01,           -- accuracy
+    'NKG 2020',     -- operation_version
+    0               -- deprecated
+),
+(
+    'NKG', 'ETRF14_TO_FI_EUREF-FIN', -- operation auth+code
+    'NKG_ETRF14 to ETRS89 (EUREF-FIN)', -- name
+    'Transformation from NKG_ETRF14@2000.0 to ETRF96@1997.0 (EUREF-FIN)', -- description
+    'NKG', 'ETRF14',-- source_crs:  NKG_ETRF00
+    'EPSG','10688', -- target_crs:  EUREF-FIN
     0.01,           -- accuracy
     'NKG 2020',     -- operation_version
     0               -- deprecated
@@ -1824,7 +1922,9 @@ INSERT INTO "concatenated_operation_step" (
     operation_auth_name, operation_code, step_number, step_auth_name, step_code
 ) VALUES
     ('NKG', 'ETRF14_TO_FI', 1, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ETRF14_TO_FI', 2, 'NKG', 'FI_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_FI', 2, 'NKG', 'FI_2020_INTRAPLATE'),
+    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 1, 'NKG', 'PAR_2020_FI'),
+    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 2, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN')
 ;
 
 
@@ -1832,6 +1932,13 @@ INSERT INTO "usage" VALUES (
     'NKG', '5050',              -- usage auth+code
     'concatenated_operation',   -- object_table_name
     'NKG', 'ETRF14_TO_FI',      -- object auth+code
+    'EPSG', '1095',             -- extent: Finland - onshore and offshore
+    'NKG', 'SCOPE_GENERIC'      -- scope auth+code
+),
+(
+    'NKG', '50501',              -- usage auth+code
+    'concatenated_operation',   -- object_table_name
+    'NKG', 'ETRF14_TO_FI_EUREF-FIN',      -- object auth+code
     'EPSG', '1095',             -- extent: Finland - onshore and offshore
     'NKG', 'SCOPE_GENERIC'      -- scope auth+code
 );
@@ -1844,15 +1951,26 @@ INSERT INTO "usage" VALUES (
 
 INSERT INTO "concatenated_operation"  VALUES (
     'NKG', 'ITRF2014_TO_FI',  -- operation auth+code
-    'ITRF2014 to ETRS89 (EUREF-FIN)', -- name
-    'Time-dependent transformation from ITRF2014 to ETRS89 (EUREF-FIN)', -- description
+    'ITRF2014 to ETRS89(FI))', -- name
+    'Time-dependent transformation from ITRF2014 to ETRS89', -- description
     'EPSG', '7789', -- source_crs:  ITRF2014
     'EPSG', '4936', -- target_crs:  ETRS89(FI)
     0.01,           -- accuracy
     'NKG 2020',     -- operation_version
     0               -- deprecated
+),
+(
+    'NKG', 'ITRF2014_TO_FI_EUREF-FIN',  -- operation auth+code
+    'ITRF2014 to ETRS89 (EUREF-FIN)', -- name
+    'Time-dependent transformation from ITRF2014 to ETRS89 (EUREF-FIN)', -- description
+    'EPSG', '7789', -- source_crs:  ITRF2014
+    'EPSG', '10688',-- target_crs:  EUREF-FIN
+    0.01,           -- accuracy
+    'NKG 2020',     -- operation_version
+    0               -- deprecated
 
 );
+
 
 INSERT INTO "concatenated_operation_step" (
     operation_auth_name, operation_code, step_number, step_auth_name, step_code
@@ -1860,14 +1978,24 @@ INSERT INTO "concatenated_operation_step" (
     ('NKG', 'ITRF2014_TO_FI', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
     ('NKG', 'ITRF2014_TO_FI', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
     ('NKG', 'ITRF2014_TO_FI', 3, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ITRF2014_TO_FI', 4, 'NKG', 'FI_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_FI', 4, 'NKG', 'FI_2020_INTRAPLATE'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 3, 'NKG', 'PAR_2020_FI'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 4, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN')
 ;
-
 
 INSERT INTO "usage" VALUES (
     'NKG', '5051',              -- usage auth+code
     'concatenated_operation',   -- object_table_name
     'NKG', 'ITRF2014_TO_FI',    -- object auth+code
+    'EPSG', '1095',             -- extent: Finland - onshore and offshore
+    'NKG', 'SCOPE_GENERIC'      -- scope auth+code
+),
+(
+    'NKG', '50511',             -- usage auth+code
+    'concatenated_operation',   -- object_table_name
+    'NKG', 'ITRF2014_TO_FI_EUREF-FIN',    -- object auth+code
     'EPSG', '1095',             -- extent: Finland - onshore and offshore
     'NKG', 'SCOPE_GENERIC'      -- scope auth+code
 );
@@ -1880,8 +2008,15 @@ INSERT INTO "supersession" VALUES (
     'NKG', 'ITRF2014_TO_FI',
     'NKG',
     0
+),
+(
+    'concatenated_operation',
+    'NKG', 'ITRF2000_TO_FI_EUREF-FIN',
+    'concatenated_operation',
+    'NKG', 'ITRF2014_TO_FI_EUREF-FIN',
+    'NKG',
+    0
 );
-
 
 -------------------------------------------------------
 -- Transformation: NKG_ETRF14 -> ETRF89@1992.75 (LV)
@@ -2339,5 +2474,3 @@ INSERT INTO "supersession" VALUES (
     'NKG',
     0
 );
-
-

--- a/data/sql/nkg.sql
+++ b/data/sql/nkg.sql
@@ -1,6 +1,6 @@
 INSERT INTO "metadata" VALUES('NKG.SOURCE', 'https://github.com/NordicGeodesy/NordicTransformations');
-INSERT INTO "metadata" VALUES('NKG.VERSION', '1.0.1');
-INSERT INTO "metadata" VALUES('NKG.DATE', '2024-04-02');
+INSERT INTO "metadata" VALUES('NKG.VERSION', '1.0.w');
+INSERT INTO "metadata" VALUES('NKG.DATE', '2025-02-13');
 
 -- extent for NKG2008 transformations
 INSERT INTO "extent" VALUES(
@@ -181,10 +181,10 @@ INSERT INTO "usage" VALUES (
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_NKG_ETRF00', 2, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_NKG_ETRF00', 3, 'NKG', 'NKG_ETRF00_TO_ETRF2000')
+    ('NKG', 'ITRF2000_TO_NKG_ETRF00', 2, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_NKG_ETRF00', 3, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse')
 ;
 
 
@@ -252,10 +252,10 @@ INSERT INTO "usage" VALUES (
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_NKG_ETRF14', 2, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_NKG_ETRF14', 3, 'NKG', 'NKG_ETRF14_TO_ETRF2014')
+    ('NKG', 'ITRF2014_TO_NKG_ETRF14', 2, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_NKG_ETRF14', 3, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse')
 ;
 
 
@@ -844,10 +844,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_DK', 1, 'NKG', 'P1_2008_DK'),
-    ('NKG', 'ETRF00_TO_DK', 2, 'NKG', 'ETRF92_2000_TO_ETRF92_1994')
+    ('NKG', 'ETRF00_TO_DK', 1, 'NKG', 'P1_2008_DK', 'forward'),
+    ('NKG', 'ETRF00_TO_DK', 2, 'NKG', 'ETRF92_2000_TO_ETRF92_1994', 'forward')
 ;
 
 
@@ -878,12 +878,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_DK', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_DK', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_DK', 3, 'NKG', 'P1_2008_DK'),
-    ('NKG', 'ITRF2000_TO_DK', 4, 'NKG', 'ETRF92_2000_TO_ETRF92_1994')
+    ('NKG', 'ITRF2000_TO_DK', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_DK', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_DK', 3, 'NKG', 'P1_2008_DK', 'forward'),
+    ('NKG', 'ITRF2000_TO_DK', 4, 'NKG', 'ETRF92_2000_TO_ETRF92_1994', 'forward')
 ;
 
 
@@ -949,10 +949,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_EE', 1, 'NKG', 'P1_2008_EE'),
-    ('NKG', 'ETRF00_TO_EE', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_56')
+    ('NKG', 'ETRF00_TO_EE', 1, 'NKG', 'P1_2008_EE', 'forward'),
+    ('NKG', 'ETRF00_TO_EE', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_56', 'forward')
 ;
 
 
@@ -983,12 +983,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_EE', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_EE', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_EE', 3, 'NKG', 'P1_2008_EE'),
-    ('NKG', 'ITRF2000_TO_EE', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_56')
+    ('NKG', 'ITRF2000_TO_EE', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_EE', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_EE', 3, 'NKG', 'P1_2008_EE', 'forward'),
+    ('NKG', 'ITRF2000_TO_EE', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_56', 'forward')
 ;
 
 
@@ -1092,12 +1092,12 @@ VALUES
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_FI', 1, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ETRF00_TO_FI', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997'),
-    ('NKG', 'ETRF00_TO_EUREF-FIN', 1, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ETRF00_TO_EUREF-FIN', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN')
+    ('NKG', 'ETRF00_TO_FI', 1, 'NKG', 'P1_2008_FI', 'forward'),
+    ('NKG', 'ETRF00_TO_FI', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997', 'forward'),
+    ('NKG', 'ETRF00_TO_EUREF-FIN', 1, 'NKG', 'P1_2008_FI', 'forward'),
+    ('NKG', 'ETRF00_TO_EUREF-FIN', 2, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN', 'forward')
 ;
 
 
@@ -1147,16 +1147,16 @@ INSERT INTO "concatenated_operation" VALUES
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_FI', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_FI', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_FI', 3, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ITRF2000_TO_FI', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997'),
-    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 3, 'NKG', 'P1_2008_FI'),
-    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN')
+    ('NKG', 'ITRF2000_TO_FI', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_FI', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_FI', 3, 'NKG', 'P1_2008_FI', 'forward'),
+    ('NKG', 'ITRF2000_TO_FI', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997', 'forward'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 3, 'NKG', 'P1_2008_FI', 'forward'),
+    ('NKG', 'ITRF2000_TO_FI_EUREF-FIN', 4, 'NKG', 'ETRF96_2000_TO_ETRF96_1997_EUREF-FIN', 'forward')
 ;
 
 
@@ -1234,10 +1234,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_LV', 1, 'NKG', 'P1_2008_LV'),
-    ('NKG', 'ETRF00_TO_LV', 2, 'NKG', 'ETRF89_2000_TO_ETRF89_1992')
+    ('NKG', 'ETRF00_TO_LV', 1, 'NKG', 'P1_2008_LV', 'forward'),
+    ('NKG', 'ETRF00_TO_LV', 2, 'NKG', 'ETRF89_2000_TO_ETRF89_1992', 'forward')
 ;
 
 
@@ -1268,12 +1268,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_LV', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_LV', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_LV', 3, 'NKG', 'P1_2008_LV'),
-    ('NKG', 'ITRF2000_TO_LV', 4, 'NKG', 'ETRF89_2000_TO_ETRF89_1992')
+    ('NKG', 'ITRF2000_TO_LV', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_LV', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_LV', 3, 'NKG', 'P1_2008_LV', 'forward'),
+    ('NKG', 'ITRF2000_TO_LV', 4, 'NKG', 'ETRF89_2000_TO_ETRF89_1992', 'forward')
 ;
 
 
@@ -1341,10 +1341,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_LT', 1, 'NKG', 'P1_2008_LT'),
-    ('NKG', 'ETRF00_TO_LT', 2, 'NKG', 'ETRF2000_2000_TO_ETRF_2000_2003')
+    ('NKG', 'ETRF00_TO_LT', 1, 'NKG', 'P1_2008_LT', 'forward'),
+    ('NKG', 'ETRF00_TO_LT', 2, 'NKG', 'ETRF2000_2000_TO_ETRF_2000_2003', 'forward')
 ;
 
 
@@ -1375,12 +1375,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_LT', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_LT', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_LT', 3, 'NKG', 'P1_2008_LT'),
-    ('NKG', 'ITRF2000_TO_LT', 4, 'NKG', 'ETRF2000_2000_TO_ETRF_2000_2003')
+    ('NKG', 'ITRF2000_TO_LT', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_LT', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_LT', 3, 'NKG', 'P1_2008_LT', 'forward'),
+    ('NKG', 'ITRF2000_TO_LT', 4, 'NKG', 'ETRF2000_2000_TO_ETRF_2000_2003', 'forward')
 ;
 
 
@@ -1448,10 +1448,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_NO', 1, 'NKG', 'P1_2008_NO'),
-    ('NKG', 'ETRF00_TO_NO', 2, 'NKG', 'ETRF93_2000_TO_ETRF93_1995')
+    ('NKG', 'ETRF00_TO_NO', 1, 'NKG', 'P1_2008_NO', 'forward'),
+    ('NKG', 'ETRF00_TO_NO', 2, 'NKG', 'ETRF93_2000_TO_ETRF93_1995', 'forward')
 ;
 
 
@@ -1482,12 +1482,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_NO', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_NO', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_NO', 3, 'NKG', 'P1_2008_NO'),
-    ('NKG', 'ITRF2000_TO_NO', 4, 'NKG', 'ETRF93_2000_TO_ETRF93_1995')
+    ('NKG', 'ITRF2000_TO_NO', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_NO', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_NO', 3, 'NKG', 'P1_2008_NO', 'forward'),
+    ('NKG', 'ITRF2000_TO_NO', 4, 'NKG', 'ETRF93_2000_TO_ETRF93_1995', 'forward')
 ;
 
 
@@ -1555,10 +1555,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF00_TO_SE', 1, 'NKG', 'P1_2008_SE'),
-    ('NKG', 'ETRF00_TO_SE', 2, 'NKG', 'ETRF97_2000_TO_ETRF97_1999')
+    ('NKG', 'ETRF00_TO_SE', 1, 'NKG', 'P1_2008_SE', 'forward'),
+    ('NKG', 'ETRF00_TO_SE', 2, 'NKG', 'ETRF97_2000_TO_ETRF97_1999', 'forward')
 ;
 
 
@@ -1589,12 +1589,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2000_TO_SE', 1, 'EPSG', '7941'), -- ITRF2000 -> ETRF2000
-    ('NKG', 'ITRF2000_TO_SE', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000'),
-    ('NKG', 'ITRF2000_TO_SE', 3, 'NKG', 'P1_2008_SE'),
-    ('NKG', 'ITRF2000_TO_SE', 4, 'NKG', 'ETRF97_2000_TO_ETRF97_1999')
+    ('NKG', 'ITRF2000_TO_SE', 1, 'EPSG', '7941', 'forward'), -- ITRF2000 -> ETRF2000
+    ('NKG', 'ITRF2000_TO_SE', 2, 'NKG', 'NKG_ETRF00_TO_ETRF2000', 'reverse'),
+    ('NKG', 'ITRF2000_TO_SE', 3, 'NKG', 'P1_2008_SE', 'forward'),
+    ('NKG', 'ITRF2000_TO_SE', 4, 'NKG', 'ETRF97_2000_TO_ETRF97_1999', 'forward')
 ;
 
 
@@ -1660,10 +1660,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_DK', 1, 'NKG', 'PAR_2020_DK'),
-    ('NKG', 'ETRF14_TO_DK', 2, 'NKG', 'DK_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_DK', 1, 'NKG', 'PAR_2020_DK', 'forward'),
+    ('NKG', 'ETRF14_TO_DK', 2, 'NKG', 'DK_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -1694,12 +1694,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_DK', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_DK', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_DK', 3, 'NKG', 'PAR_2020_DK'),
-    ('NKG', 'ITRF2014_TO_DK', 4, 'NKG', 'DK_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_DK', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_DK', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_DK', 3, 'NKG', 'PAR_2020_DK', 'forward'),
+    ('NKG', 'ITRF2014_TO_DK', 4, 'NKG', 'DK_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -1774,10 +1774,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_EE', 1, 'NKG', 'PAR_2020_EE'),
-    ('NKG', 'ETRF14_TO_EE', 2, 'NKG', 'EE_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_EE', 1, 'NKG', 'PAR_2020_EE', 'forward'),
+    ('NKG', 'ETRF14_TO_EE', 2, 'NKG', 'EE_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -1808,12 +1808,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_EE', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_EE', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_EE', 3, 'NKG', 'PAR_2020_EE'),
-    ('NKG', 'ITRF2014_TO_EE', 4, 'NKG', 'EE_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_EE', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_EE', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_EE', 3, 'NKG', 'PAR_2020_EE', 'forward'),
+    ('NKG', 'ITRF2014_TO_EE', 4, 'NKG', 'EE_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -1919,12 +1919,12 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_FI', 1, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ETRF14_TO_FI', 2, 'NKG', 'FI_2020_INTRAPLATE'),
-    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 1, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 2, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN')
+    ('NKG', 'ETRF14_TO_FI', 1, 'NKG', 'PAR_2020_FI', 'forward'),
+    ('NKG', 'ETRF14_TO_FI', 2, 'NKG', 'FI_2020_INTRAPLATE', 'forward'),
+    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 1, 'NKG', 'PAR_2020_FI', 'forward'),
+    ('NKG', 'ETRF14_TO_FI_EUREF-FIN', 2, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN', 'forward')
 ;
 
 
@@ -1973,16 +1973,16 @@ INSERT INTO "concatenated_operation"  VALUES (
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_FI', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_FI', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_FI', 3, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ITRF2014_TO_FI', 4, 'NKG', 'FI_2020_INTRAPLATE'),
-    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 3, 'NKG', 'PAR_2020_FI'),
-    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 4, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN')
+    ('NKG', 'ITRF2014_TO_FI', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_FI', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_FI', 3, 'NKG', 'PAR_2020_FI', 'forward'),
+    ('NKG', 'ITRF2014_TO_FI', 4, 'NKG', 'FI_2020_INTRAPLATE', 'forward'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 3, 'NKG', 'PAR_2020_FI', 'forward'),
+    ('NKG', 'ITRF2014_TO_FI_EUREF-FIN', 4, 'NKG', 'FI_2020_INTRAPLATE_EUREF-FIN', 'forward')
 ;
 
 INSERT INTO "usage" VALUES (
@@ -2072,10 +2072,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_LV', 1, 'NKG', 'PAR_2020_LV'),
-    ('NKG', 'ETRF14_TO_LV', 2, 'NKG', 'LV_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_LV', 1, 'NKG', 'PAR_2020_LV', 'forward'),
+    ('NKG', 'ETRF14_TO_LV', 2, 'NKG', 'LV_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -2106,12 +2106,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_LV', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_LV', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_LV', 3, 'NKG', 'PAR_2020_LV'),
-    ('NKG', 'ITRF2014_TO_LV', 4, 'NKG', 'LV_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_LV', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_LV', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_LV', 3, 'NKG', 'PAR_2020_LV', 'forward'),
+    ('NKG', 'ITRF2014_TO_LV', 4, 'NKG', 'LV_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -2188,10 +2188,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_LT', 1, 'NKG', 'PAR_2020_LT'),
-    ('NKG', 'ETRF14_TO_LT', 2, 'NKG', 'LT_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_LT', 1, 'NKG', 'PAR_2020_LT', 'forward'),
+    ('NKG', 'ETRF14_TO_LT', 2, 'NKG', 'LT_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -2222,12 +2222,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_LT', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_LT', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_LT', 3, 'NKG', 'PAR_2020_LT'),
-    ('NKG', 'ITRF2014_TO_LT', 4, 'NKG', 'LT_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_LT', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_LT', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_LT', 3, 'NKG', 'PAR_2020_LT', 'forward'),
+    ('NKG', 'ITRF2014_TO_LT', 4, 'NKG', 'LT_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -2303,10 +2303,10 @@ INSERT INTO "concatenated_operation" VALUES(
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_NO', 1, 'NKG', 'PAR_2020_NO'),
-    ('NKG', 'ETRF14_TO_NO', 2, 'NKG', 'NO_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_NO', 1, 'NKG', 'PAR_2020_NO', 'forward'),
+    ('NKG', 'ETRF14_TO_NO', 2, 'NKG', 'NO_2020_INTRAPLATE', 'forward')
 ;
 
 INSERT INTO "usage" VALUES (
@@ -2334,12 +2334,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_NO', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_NO', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_NO', 3, 'NKG', 'NKG_ETRF14_ETRF93_2000'),
-    ('NKG', 'ITRF2014_TO_NO', 4, 'NKG', 'NO_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_NO', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_NO', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_NO', 3, 'NKG', 'NKG_ETRF14_ETRF93_2000', 'forward'),
+    ('NKG', 'ITRF2014_TO_NO', 4, 'NKG', 'NO_2020_INTRAPLATE', 'forward')
 ;
 
 INSERT INTO "usage" VALUES (
@@ -2414,10 +2414,10 @@ INSERT INTO "concatenated_operation" VALUES(
 
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ETRF14_TO_SE', 1, 'NKG', 'PAR_2020_SE'),
-    ('NKG', 'ETRF14_TO_SE', 2, 'NKG', 'SE_2020_INTRAPLATE')
+    ('NKG', 'ETRF14_TO_SE', 1, 'NKG', 'PAR_2020_SE', 'forward'),
+    ('NKG', 'ETRF14_TO_SE', 2, 'NKG', 'SE_2020_INTRAPLATE', 'forward')
 ;
 
 
@@ -2448,12 +2448,12 @@ INSERT INTO "concatenated_operation"  VALUES (
 );
 
 INSERT INTO "concatenated_operation_step" (
-    operation_auth_name, operation_code, step_number, step_auth_name, step_code
+    operation_auth_name, operation_code, step_number, step_auth_name, step_code, step_direction
 ) VALUES
-    ('NKG', 'ITRF2014_TO_SE', 1, 'EPSG', '8366'), -- ITRF2014 -> ETRF2014
-    ('NKG', 'ITRF2014_TO_SE', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014'),
-    ('NKG', 'ITRF2014_TO_SE', 3, 'NKG', 'PAR_2020_SE'),
-    ('NKG', 'ITRF2014_TO_SE', 4, 'NKG', 'SE_2020_INTRAPLATE')
+    ('NKG', 'ITRF2014_TO_SE', 1, 'EPSG', '8366', 'forward'), -- ITRF2014 -> ETRF2014
+    ('NKG', 'ITRF2014_TO_SE', 2, 'NKG', 'NKG_ETRF14_TO_ETRF2014', 'reverse'),
+    ('NKG', 'ITRF2014_TO_SE', 3, 'NKG', 'PAR_2020_SE', 'forward'),
+    ('NKG', 'ITRF2014_TO_SE', 4, 'NKG', 'SE_2020_INTRAPLATE', 'forward')
 ;
 
 

--- a/test/gie/nkg.gie
+++ b/test/gie/nkg.gie
@@ -106,6 +106,12 @@ tolerance   1 mm
 accept      3541657.3778 948984.2343 5201383.5231 2020.5
 expect      3541657.9522 948983.7911 5201383.2230 2020.5
 
+operation   urn:ogc:def:coordinateOperation:NKG::ITRF2000_TO_FI_EUREF-FIN
+tolerance   1 mm
+
+accept      3541657.3778 948984.2343 5201383.5231 2020.5
+expect      3541657.9522 948983.7911 5201383.2230 2020.5
+
 
 operation   urn:ogc:def:coordinateOperation:NKG::ETRF00_TO_FI
 tolerance   1 mm
@@ -117,6 +123,13 @@ expect      3541657.3989 948984.2274 5201383.5235 2020.5
 # 2020 Transformations
 
 operation   urn:ogc:def:coordinateOperation:NKG::ITRF2014_TO_FI
+tolerance   0.1 mm
+
+# DEGE
+accept      2994012.0569   1112559.9272   5502272.0863 2015.0
+expect      2994012.5170   1112559.5902   5502271.7683 2015.0
+
+operation   urn:ogc:def:coordinateOperation:NKG::ITRF2014_TO_FI_EUREF-FIN
 tolerance   0.1 mm
 
 # DEGE


### PR DESCRIPTION
Recently the Finish national realization of ETRS89 was added to the EPSG registry as it's own separate entity. This commits adds support for the new EUREF-FIN CRS (EPSG:10689) in the NKG transformations. This is done by duplicating the existing transformation entries for Finland and modifying them to have EUREF-FIN as their end-point. This ensures backwards compatibility for users that implemented the original approach in their workflows.

The gist of it all is that in addition to the existing transformations

    NKG:ITRF2000_TO_FI and NKG:ITRF2014_TO_FI

two new ones have been added:

    NKG:ITRF2000_TO_FI_EUREF-FIN and NKG:ITRF2014_TO_FI_EUREF-FIN

Below a few examples are given, that verify that the old and newly added transformations are equivalent, apart from their final target CRS.

First a demonstration of use of the transformations directly

```sh
export PROJ_DATA=data/
export PROJ_NETWORK=ON

echo 27 62 100 | bin/cct +proj=cart
 2675020.1042   1362990.8210  5608603.5251           inf

echo 2675020.1042 1362990.8210 5608603.5251 2025.0 | bin/cct -d 8 NKG:ITRF2000_TO_FI
2675020.75185987  1362990.35866198  5608603.16545234     2025.0000

echo 2675020.1042 1362990.8210 5608603.5251 2025.0 | bin/cct -d 8 NKG:ITRF2000_TO_FI_EUREF-FIN
2675020.75185987  1362990.35866198  5608603.16545234     2025.0000

echo 2675020.1042 1362990.8210 5608603.5251 2025.0 | bin/cct -d 8 NKG:ITRF2014_TO_FI
2675020.76927503  1362990.36127342  5608603.12613439     2025.0000

echo 2675020.1042 1362990.8210 5608603.5251 2025.0 | bin/cct -d 8 NKG:ITRF2014_TO_FI
2675020.76927503  1362990.36127342  5608603.12613439     2025.0000
```

and then using source and target CRS's. The invovled EPSG-codes are:

```
EPSG:7912:  ITRF2014    geodetic coordinates
EPSG:4937:  ETRS89      geodetic coordinates
EPSG:10689: EUREF-FIN   geodetic coordinates
```

```sh
echo 62 27 100 2025.0 | bin/cs2cs -d 8 EPSG:7912 EPSG:10689
61.99999528     26.99998642 99.82795259 2025

echo 62 27 100 2025.0 | bin/cs2cs -d 8 EPSG:7912 EPSG:10689 --area finland
61.99999528     26.99998642 99.82795259 2025

echo 62 27 100 2025.0 | bin/cs2cs -d 8 EPSG:7912 EPSG:4937
61.99999528     26.99998642 99.82795259 2025

echo 62 27 100 2025.0 | bin/cs2cs -d 8 EPSG:7912 EPSG:4937 --area finland
61.99999528     26.99998642 99.82795259 2025
```

As shown, the results are equivalent, which keeps existing workflows happy.
