### PR TITLE
proj_download_file(): invalidate in-memory caches related to downloaded file (for the current context)

### DIFF
--- a/include/proj/internal/io_internal.hpp
+++ b/include/proj/internal/io_internal.hpp
@@ -175,7 +175,7 @@ NS_PROJ_END
 // ---------------------------------------------------------------------------
 
 /** Auxiliary structure to PJ_CONTEXT storing C++ context stuff. */
-struct projCppContext {
+struct PROJ_GCC_DLL projCppContext {
   private:
     NS_PROJ::io::DatabaseContextPtr databaseContext_{};
     PJ_CONTEXT *ctx_ = nullptr;
@@ -208,7 +208,7 @@ struct projCppContext {
         return auxDbPaths_;
     }
 
-    NS_PROJ::io::DatabaseContextNNPtr getDatabaseContext();
+    NS_PROJ::io::DatabaseContextNNPtr PROJ_FOR_TEST getDatabaseContext();
 
     void closeDb() { databaseContext_ = nullptr; }
 };

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -926,6 +926,8 @@ class PROJ_GCC_DLL DatabaseContext {
     PROJ_INTERNAL std::string
     getProjGridName(const std::string &oldProjGridName);
 
+    PROJ_INTERNAL void invalidateGridInfo(const std::string &projFilename);
+
     PROJ_INTERNAL std::string getOldProjGridName(const std::string &gridName);
 
     PROJ_INTERNAL std::string

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -824,7 +824,14 @@ pj_approx_3D_trans(PJconsts*, PJ_DIRECTION, PJ_COORD)
 pj_atof(char const*)
 pj_chomp(char*)
 pj_context_get_grid_cache_filename(pj_ctx*)
+pj_ctx::createDefault()
+pj_ctx::get_cpp_context()
+pj_ctx::~pj_ctx()
+pj_ctx::pj_ctx(pj_ctx const&)
+pj_ctx::set_ca_bundle_path(std::string const&)
+pj_ctx::set_search_paths(std::vector<std::string, std::allocator<std::string> > const&)
 pj_ell_set(pj_ctx*, ARG_list*, double*, double*)
+pj_find_file(pj_ctx*, char const*, char*, unsigned long)
 pj_fwd(PJ_LP, PJconsts*)
 pj_get_datums_ref()
 pj_get_default_ctx()
@@ -900,6 +907,10 @@ proj_coordoperation_get_towgs84_values
 proj_coordoperation_has_ballpark_transformation
 proj_coordoperation_is_instantiable
 proj_coordoperation_requires_per_coordinate_input_time
+projCppContext::clone(pj_ctx*) const
+projCppContext::getDatabaseContext()
+projCppContext::projCppContext(pj_ctx*, char const*, std::vector<std::string, std::allocator<std::string> > const&)
+projCppContext::toVector(char const* const*)
 proj_create
 proj_create_argv
 proj_create_cartesian_2D_cs

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -784,7 +784,7 @@ struct projFileApiCallbackAndData {
 };
 
 /* proj thread context */
-struct pj_ctx {
+struct PROJ_GCC_DLL pj_ctx {
     std::string lastFullErrorMessage{}; // used by proj_context_errno_string
     int last_errno = 0;
     int debug_level = PJ_LOG_ERROR;
@@ -841,7 +841,7 @@ struct pj_ctx {
 
     pj_ctx &operator=(const pj_ctx &) = delete;
 
-    projCppContext *get_cpp_context();
+    projCppContext PROJ_FOR_TEST *get_cpp_context();
     void set_search_paths(const std::vector<std::string> &search_paths_in);
     void set_ca_bundle_path(const std::string &ca_bundle_path_in);
 
@@ -1035,8 +1035,10 @@ bool pj_log_active(PJ_CONTEXT *ctx, int level);
 void pj_log(PJ_CONTEXT *ctx, int level, const char *fmt, ...);
 void pj_stderr_logger(void *, int, const char *);
 
-int pj_find_file(PJ_CONTEXT *ctx, const char *short_filename,
-                 char *out_full_filename, size_t out_full_filename_size);
+// PROJ_DLL for tests
+int PROJ_DLL pj_find_file(PJ_CONTEXT *ctx, const char *short_filename,
+                          char *out_full_filename,
+                          size_t out_full_filename_size);
 
 // To remove when PROJ_LIB definitely goes away
 void PROJ_DLL pj_stderr_proj_lib_deprecation_warning();


### PR DESCRIPTION
Fixes #4397
