### PR TITLE
Remove hashbang from bash completion.

### DIFF
--- a/scripts/projinfo-bash-completion.sh
+++ b/scripts/projinfo-bash-completion.sh
@@ -1,3 +1,5 @@
+# Hashbang deliberately missing because this file should be sourced, not executed
+
 function_exists() {
     declare -f -F "$1" > /dev/null
     return $?

--- a/scripts/projinfo-bash-completion.sh
+++ b/scripts/projinfo-bash-completion.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 function_exists() {
     declare -f -F "$1" > /dev/null
     return $?


### PR DESCRIPTION
Completions are meant to be sourced, not executed.

See also: https://lintian.debian.org/tags/bash-completion-with-hashbang.html
