### PR TITLE
Retry "SSL connection timeout"

### DIFF
--- a/src/networkfilemanager.cpp
+++ b/src/networkfilemanager.cpp
@@ -1696,7 +1696,8 @@ static double GetNewRetryDelay(int response_code, double dfOldDelay,
         (response_code == 400 && pszErrBuf &&
          strstr(pszErrBuf, "RequestTimeout")) ||
         (pszCurlError && strstr(pszCurlError, "Connection reset by peer")) ||
-        (pszCurlError && strstr(pszCurlError, "Connection timed out"))) {
+        (pszCurlError && strstr(pszCurlError, "Connection timed out")) ||
+        (pszCurlError && strstr(pszCurlError, "SSL connection timeout"))) {
         // Use an exponential backoff factor of 2 plus some random jitter
         // We don't care about cryptographic quality randomness, hence:
         // coverity[dont_call]


### PR DESCRIPTION
Building the GDAL image can fail with:

Downloading https://cdn.proj.org/de_lgvl_saarland_README.txt... (86 / 439)
Downloading https://cdn.proj.org/de_lgvl_saarland_SeTa2016.tif... (87 / 439)
Cannot open https://cdn.proj.org/de_lgvl_saarland_SeTa2016.tif: SSL connection timeout
Cannot download https://cdn.proj.org/de_lgvl_saarland_SeTa2016.tif

so add SSL connection timeout
to the list of things that get
a retry time.

Sibling of commit 72307126.

- [ ] Tests added
- [X] Added clear title that can be used to generate release notes
