### PR TITLE
Bug correction in Wagner VI parameters Cx and Cy

### DIFF
--- a/src/projections/eck3.cpp
+++ b/src/projections/eck3.cpp
@@ -87,8 +87,8 @@ PJ *PJ_PROJECTION(wag6) {
         return pj_default_destructor(P, PROJ_ERR_OTHER /*ENOMEM*/);
     P->opaque = Q;
 
-    Q->C_x = 0.94745;
-    Q->C_y = 0.94745;
+    Q->C_x = 1.0;
+    Q->C_y = 1.0;
     Q->A = 0.0;
     Q->B = 0.30396355092701331433;
 


### PR DESCRIPTION
Wagner VI projection parameters Cx and Cy must have both the value 1.0 according to the projection definition. See 
Evenden (2005). libproj4: A Comprehensive Library of Cartographic Projection Functions (Preliminary Draft), p. 55, where the parameters for Wagner VI are in accordance with https://en.wikipedia.org/wiki/Wagner_VI_projection and https://www.boehmwanderkarten.de/kartographie/is_netze_wagner_123456789_inversions.html