### PR TITLE
Add missing include for uint32_t on Windows with gcc 15.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -176,6 +176,7 @@ jobs:
               -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
               -D CMAKE_UNITY_BUILD=ON \
               -D Python_ROOT_DIR=/mingw64 \
+              -D CMAKE_CXX_STANDARD=20 \
               ..
             make -j 2
             make install

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -41,6 +41,7 @@
 #include <stdlib.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <string>
 

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -7459,8 +7459,8 @@ AuthorityFactory::createFromCRSCodesWithIntermediates(
         return listTmp;
     }
 
-    const auto CheckIfHasOperations = [=](const std::string &auth_name,
-                                          const std::string &code) {
+    const auto CheckIfHasOperations = [this](const std::string &auth_name,
+                                             const std::string &code) {
         return !(d->run("SELECT 1 FROM coordinate_operation_view WHERE "
                         "(source_crs_auth_name = ? AND source_crs_code = ?) OR "
                         "(target_crs_auth_name = ? AND target_crs_code = ?) "


### PR DESCRIPTION
Fixes https://github.com/OSGeo/PROJ/actions/runs/14691467666/job/41227338487
