### PR TITLE
getGeoidModels: use vertical_crs.datum_code to get vcrss ...

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -6910,58 +6910,21 @@ AuthorityFactory::getGeoidModels(const std::string &code) const {
     ListOfParams params;
     std::string sql;
     sql += "SELECT DISTINCT GM0.name "
-           " FROM geoid_model GM0 "
+           "  FROM geoid_model GM0 "
            "INNER JOIN grid_transformation GT0 "
-           " ON  GT0.code = GM0.operation_code "
-           " AND GT0.auth_name = GM0.operation_auth_name "
-           " AND GT0.target_crs_code = ? ";
+           "  ON  GT0.code = GM0.operation_code "
+           "  AND GT0.auth_name = GM0.operation_auth_name "
+           "  AND GT0.deprecated = 0 "
+           "INNER JOIN vertical_crs VC0 "
+           "  ON VC0.code = GT0.target_crs_code "
+           "  AND VC0.auth_name = GT0.target_crs_auth_name "
+           "INNER JOIN vertical_crs VC1 "
+           "  ON VC1.datum_code = VC0.datum_code "
+           "  AND VC1.datum_auth_name = VC0.datum_auth_name "
+           "  AND VC1.code = ? ";
     params.emplace_back(code);
     if (d->hasAuthorityRestriction()) {
         sql += " AND GT0.target_crs_auth_name = ? ";
-        params.emplace_back(d->authority());
-    }
-
-    /// The second part of the query is for CRSs that use that geoid model via
-    /// Height Depth Reversal (EPSG:1068) or Change of Vertical Unit (EPSG:1069)
-    sql += "UNION "
-           "SELECT DISTINCT GM0.name "
-           " FROM geoid_model GM0 "
-           "INNER JOIN grid_transformation GT1 "
-           " ON  GT1.code = GM0.operation_code "
-           " AND GT1.auth_name = GM0.operation_auth_name "
-           "INNER JOIN other_transformation OT1 "
-           " ON  OT1.source_crs_code = GT1.target_crs_code "
-           " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
-           " AND OT1.method_auth_name = 'EPSG' "
-           " AND OT1.method_code IN (1068, 1069, 1104) "
-           " AND OT1.target_crs_code = ? ";
-    params.emplace_back(code);
-    if (d->hasAuthorityRestriction()) {
-        sql += " AND OT1.target_crs_auth_name = ? ";
-        params.emplace_back(d->authority());
-    }
-
-    /// The third part of the query is for CRSs that use that geoid model via
-    /// other_transformation table twice, like transforming depth and feet
-    sql += "UNION "
-           "SELECT DISTINCT GM0.name "
-           " FROM geoid_model GM0 "
-           "INNER JOIN grid_transformation GT1 "
-           " ON  GT1.code = GM0.operation_code "
-           " AND GT1.auth_name = GM0.operation_auth_name "
-           "INNER JOIN other_transformation OT1 "
-           " ON  OT1.source_crs_code = GT1.target_crs_code "
-           " AND OT1.source_crs_auth_name = GT1.target_crs_auth_name "
-           " AND OT1.method_auth_name = 'EPSG' "
-           " AND OT1.method_code IN (1068, 1069, 1104) "
-           "INNER JOIN other_transformation OT2 "
-           " ON  OT2.source_crs_code = OT1.target_crs_code "
-           " AND OT2.source_crs_auth_name = OT1.target_crs_auth_name "
-           " AND OT2.method_code IN (1068, 1069, 1104) "
-           " AND OT2.target_crs_code = ? ";
-    params.emplace_back(code);
-    if (d->hasAuthorityRestriction()) {
-        sql += " AND OT2.target_crs_auth_name = ? ";
         params.emplace_back(d->authority());
     }
     sql += " ORDER BY 1 ";


### PR DESCRIPTION
that uses different units

Working in https://github.com/jjimenezshaw/NSRS-2022-PROJ I realized that the method getGeoidModels was using a deprecated transformation.
The proper way is to consider vertical CRSs that have the same datum.
The SQL query is changed accordingly.

- [x] Tests added (they where there)
- [x] Added clear title that can be used to generate release notes
