### PR TITLE
[9.6 branch] [fix] use std::abs instead of abs for NetBSD

### DIFF
--- a/src/latitudes.cpp
+++ b/src/latitudes.cpp
@@ -58,7 +58,7 @@ double pj_conformal_lat_inverse(double chi, double e, double threshold) {
             2 * atan(taninit *
                      std::pow(((1 + esinphi) / (1 - esinphi)), (e / 2))) -
             0.5 * M_PI;
-        if (abs(new_phi - phi) < threshold) {
+        if (std::abs(new_phi - phi) < threshold) {
             phi = new_phi;
             break;
         }


### PR DESCRIPTION
Discussed at https://lists.osgeo.org/pipermail/proj/2025-May/011851.html

The bug happens only in NetBSD

Does not apply to master because that code was refactored in #4446 
- [x] Added clear title that can be used to generate release notes
