### PR TITLE
Add an option to ship PDB files

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,6 +75,7 @@ jobs:
             if "${{ env.BUILD_TYPE }}"=="Release" (set CMAKE_UNITY_BUILD_OPT="-DCMAKE_UNITY_BUILD=ON")
             cmake -D CMAKE_BUILD_TYPE="${{ env.BUILD_TYPE }}" ^
               -D BUILD_SHARED_LIBS="${{ env.BUILD_SHARED_LIBS }}" ^
+              -D EXPORT_PDB="ON" ^
               -D CMAKE_C_FLAGS="/WX" ^
               -D CMAKE_CXX_FLAGS="/WX" ^
               %CMAKE_CXX_STANDARD% ^

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,29 @@ install(FILES ${docfiles}
         DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 ################################################################################
+# Build debug symbols
+################################################################################
+option(EXPORT_PDB "Export PDB file" OFF)
+
+if (WIN32 AND EXPORT_PDB)
+  target_compile_options(proj PRIVATE /Zi /Zf)
+  target_link_options(proj PRIVATE /DEBUG /OPT:REF /OPT:ICF)
+
+  if(BUILD_SHARED_LIBS)
+    set(pdbFile $<TARGET_PDB_FILE:proj>)
+  else()
+    set(pdbDirFullPath ${CMAKE_BINARY_DIR}/lib)
+    set_target_properties(proj
+        PROPERTIES
+            COMPILE_PDB_OUTPUT_DIRECTORY ${pdbDirFullPath}
+            COMPILE_PDB_NAME proj)
+    set(pdbFile ${pdbDirFullPath}/proj.pdb)
+  endif()
+
+  install(FILES ${pdbFile} DESTINATION lib)
+endif()
+
+################################################################################
 # pkg-config support
 ################################################################################
 configure_proj_pc()


### PR DESCRIPTION
A new CMake option `EXPORT_PDB` is added, when enabled, on Windows, a PDB file will be generated. Default value for `EXPORT_PDB` is `OFF`.