### PR TITLE
Fix Windows build when both EMBED_RESOURCE_FILES and USE_ONLY_EMBEDDED_RESOURCE_FILES are set

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,7 +159,7 @@ jobs:
             mingw-w64-x86_64-python-yaml
             mingw-w64-x86_64-sqlite3
 
-      - name: Build
+      - name: First build with EMBED_RESOURCE_FILES=ON and USE_ONLY_EMBEDDED_RESOURCE_FILES=ON
         run: |
             mkdir -p $HOME/.ccache
             ccache -M 500M
@@ -167,6 +167,27 @@ jobs:
             PROJ_BUILD=${GITHUB_WORKSPACE}/build
             PROJ_DIR=${GITHUB_WORKSPACE}/proj_dir
             mkdir ${PROJ_BUILD}
+            cd ${PROJ_BUILD}
+
+            cmake -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+              -D BUILD_SHARED_LIBS=${{ env.BUILD_SHARED_LIBS }} \
+              -D CMAKE_INSTALL_PREFIX="${PROJ_DIR}" \
+              -D CMAKE_C_FLAGS="-Werror" \
+              -D CMAKE_CXX_FLAGS="-Werror" \
+              -D USE_CCACHE=ON \
+              -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
+              -D CMAKE_UNITY_BUILD=ON \
+              -D Python_ROOT_DIR=/mingw64 \
+              -D CMAKE_CXX_STANDARD=20 \
+              -D EMBED_RESOURCE_FILES=ON \
+              -D USE_ONLY_EMBEDDED_RESOURCE_FILES=ON \
+              ..
+            make -j 2
+
+      - name: Seond build with EMBED_RESOURCE_FILES=OFF and USE_ONLY_EMBEDDED_RESOURCE_FILES=OFF
+        run: |
+            PROJ_BUILD=${GITHUB_WORKSPACE}/build
+            PROJ_DIR=${GITHUB_WORKSPACE}/proj_dir
             cd ${PROJ_BUILD}
             cmake -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
               -D BUILD_SHARED_LIBS=${{ env.BUILD_SHARED_LIBS }} \
@@ -178,6 +199,8 @@ jobs:
               -D CMAKE_UNITY_BUILD=ON \
               -D Python_ROOT_DIR=/mingw64 \
               -D CMAKE_CXX_STANDARD=20 \
+              -D EMBED_RESOURCE_FILES=OFF \
+              -D USE_ONLY_EMBEDDED_RESOURCE_FILES=OFF \
               ..
             make -j 2
             make install

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -144,8 +144,6 @@ std::string File::read_line(size_t maxLen, bool &maxLenReached,
 
 // ---------------------------------------------------------------------------
 
-#if !USE_ONLY_EMBEDDED_RESOURCE_FILES
-
 #ifdef _WIN32
 
 /* The bulk of utf8towc()/utf8fromwc() is derived from the utf.c module from
@@ -590,6 +588,12 @@ static std::string Win32Recode(const char *src, unsigned src_code_page,
     return out;
 }
 
+#endif // _defined(_WIN32)
+
+#if !(EMBED_RESOURCE_FILES && USE_ONLY_EMBEDDED_RESOURCE_FILES)
+
+#ifdef _WIN32
+
 // ---------------------------------------------------------------------------
 
 class FileWin32 : public File {
@@ -729,7 +733,8 @@ std::unique_ptr<File> FileWin32::open(PJ_CONTEXT *ctx, const char *filename,
         return nullptr;
     }
 }
-#else
+
+#else // if !defined(_WIN32)
 
 // ---------------------------------------------------------------------------
 
@@ -799,7 +804,7 @@ unsigned long long FileStdio::tell() {
 
 std::unique_ptr<File> FileStdio::open(PJ_CONTEXT *ctx, const char *filename,
                                       FileAccess access) {
-    auto fp = fopen(filename, access == FileAccess::READ_ONLY     ? "rb"
+    auto fp = fopen(filename, access == FileAccess::READ_ONLY ? "rb"
                               : access == FileAccess::READ_UPDATE ? "r+b"
                                                                   : "w+b");
     return std::unique_ptr<File>(fp ? new FileStdio(filename, ctx, fp)
@@ -808,7 +813,7 @@ std::unique_ptr<File> FileStdio::open(PJ_CONTEXT *ctx, const char *filename,
 
 #endif // _WIN32
 
-#endif // !USE_ONLY_EMBEDDED_RESOURCE_FILES
+#endif // !(EMBED_RESOURCE_FILES && USE_ONLY_EMBEDDED_RESOURCE_FILES)
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #4506
