### PR TITLE
ProjectedCRS::identify(): more robust identification of old ESRI names using _IntlFeet

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -9941,12 +9941,12 @@ AuthorityFactory::createProjectedCRSFromExisting(
         }
     }
 
-    std::string sql(
-        "SELECT projected_crs.auth_name, projected_crs.code FROM projected_crs "
-        "JOIN conversion_table conv ON "
-        "projected_crs.conversion_auth_name = conv.auth_name AND "
-        "projected_crs.conversion_code = conv.code WHERE "
-        "projected_crs.deprecated = 0 AND ");
+    std::string sql("SELECT projected_crs.auth_name, projected_crs.code, "
+                    "projected_crs.name FROM projected_crs "
+                    "JOIN conversion_table conv ON "
+                    "projected_crs.conversion_auth_name = conv.auth_name AND "
+                    "projected_crs.conversion_code = conv.code WHERE "
+                    "projected_crs.deprecated = 0 AND ");
     ListOfParams params;
     if (!candidatesGeodCRS.empty()) {
         sql += buildSqlLookForAuthNameCode(candidatesGeodCRS, params,
@@ -10058,6 +10058,20 @@ AuthorityFactory::createProjectedCRSFromExisting(
         sql += "))";
     }
     auto sqlRes = d->run(sql, params);
+
+    for (const auto &row : sqlRes) {
+        const auto &name = row[2];
+        if (metadata::Identifier::isEquivalentName(crs->nameStr().c_str(),
+                                                   name.c_str())) {
+            const auto &auth_name = row[0];
+            const auto &code = row[1];
+            res.emplace_back(
+                d->createFactory(auth_name)->createProjectedCRS(code));
+        }
+    }
+    if (!res.empty()) {
+        return res;
+    }
 
     params.clear();
 

--- a/src/iso19111/metadata.cpp
+++ b/src/iso19111/metadata.cpp
@@ -1352,6 +1352,13 @@ std::string Identifier::canonicalizeName(const std::string &str,
                 continue;
             }
         }
+
+        if (matchesLowerCase(c_str + i, "_IntlFeet") &&
+            c_str[i + strlen("_IntlFeet")] == 0) {
+            res += "feet";
+            break;
+        }
+
         if (!isIgnoredChar(ch)) {
             res.push_back(ch);
         }
@@ -1390,6 +1397,18 @@ bool Identifier::isEquivalentName(const char *a, const char *b,
             j += 3;
             continue;
         }
+
+        if (matchesLowerCase(a + i, "_IntlFeet") &&
+            a[i + strlen("_IntlFeet")] == 0 &&
+            matchesLowerCase(b + j, "_Feet") && b[j + strlen("_Feet")] == 0) {
+            return true;
+        } else if (matchesLowerCase(a + i, "_Feet") &&
+                   a[i + strlen("_Feet")] == 0 &&
+                   matchesLowerCase(b + j, "_IntlFeet") &&
+                   b[j + strlen("_IntlFeet")] == 0) {
+            return true;
+        }
+
         if (isIgnoredChar(aCh)) {
             ++i;
             continue;
@@ -1475,6 +1494,7 @@ bool Identifier::isEquivalentName(const char *a, const char *b,
                 j += strlen(replacement->utf8) - 1;
             }
         }
+
         if (aCh != bCh) {
             return false;
         }

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -3522,6 +3522,30 @@ TEST(crs, projectedCRS_identify_db) {
         EXPECT_EQ(*(res.front().first->identifiers()[0]->codeSpace()), "ESRI");
         EXPECT_EQ(res.front().second, 100);
     }
+    {
+        // Identify a WKT ESRI using deprecated ESRI names
+        // Cf https://github.com/OSGeo/gdal/issues/12511
+        auto obj = WKTParser().attachDatabaseContext(dbContext).createFromWKT(
+            "PROJCS[\"NAD_1983_StatePlane_Arizona_Central_FIPS_0202_IntlFeet\","
+            "GEOGCS[\"GCS_North_American_1983\","
+            "DATUM[\"D_North_American_1983\","
+            "SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],"
+            "PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],"
+            "PROJECTION[\"Transverse_Mercator\"],"
+            "PARAMETER[\"False_Easting\",700000.0],"
+            "PARAMETER[\"False_Northing\",0.0],"
+            "PARAMETER[\"Central_Meridian\",-111.9166666666667],"
+            "PARAMETER[\"Scale_Factor\",0.9999],"
+            "PARAMETER[\"Latitude_Of_Origin\",31.0],UNIT[\"Foot\",0.3048]]");
+        auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        auto allFactory = AuthorityFactory::create(dbContext, std::string());
+        auto res = crs->identify(allFactory);
+        ASSERT_GE(res.size(), 1U);
+        EXPECT_EQ(res.front().first->identifiers()[0]->code(), "2223");
+        EXPECT_EQ(*(res.front().first->identifiers()[0]->codeSpace()), "EPSG");
+        EXPECT_EQ(res.front().second, 70);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_metadata.cpp
+++ b/test/unit/test_metadata.cpp
@@ -514,4 +514,11 @@ TEST(metadata, Identifier_isEquivalentName) {
     EXPECT_TRUE(Identifier::isEquivalentName("foo + ", "foo + "));
     EXPECT_TRUE(Identifier::isEquivalentName("foo + bar", "foo + bar"));
     EXPECT_TRUE(Identifier::isEquivalentName("foo + bar", "foobar"));
+
+    EXPECT_TRUE(Identifier::isEquivalentName("foo_IntlFeet", "foo_Feet"));
+    EXPECT_TRUE(Identifier::isEquivalentName("foo_Feet", "foo_IntlFeet"));
+    EXPECT_FALSE(
+        Identifier::isEquivalentName("foo_IntlFeet_bar", "foo_Feet_bar"));
+    EXPECT_FALSE(
+        Identifier::isEquivalentName("foo_Feet_bar", "foo_IntlFeet_bar"));
 }


### PR DESCRIPTION
Fixe https://github.com/OSGeo/gdal/issues/12511
