### PR TITLE
Geostationary projection: speed up inverse spherical and ellipsoidal computation

### DIFF
--- a/src/projections/geos.cpp
+++ b/src/projections/geos.cpp
@@ -184,8 +184,10 @@ static PJ_LP geos_e_inverse(PJ_XY xy, PJ *P) { /* Ellipsoidal, inverse */
 
     /* Calculation of longitude and latitude.*/
     lp.lam = atan2(Vy, Vx);
-    lp.phi = atan(Vz * cos(lp.lam) / Vx);
-    lp.phi = atan(Q->radius_p_inv2 * tan(lp.phi));
+    // Initial formula:
+    // lp.phi = atan(Q->radius_p_inv2 * Vz * cos(lp.lam) / Vx);
+    // Given that cos(atan2(y,x) = x / hypot(x,y)
+    lp.phi = atan(Q->radius_p_inv2 * Vz / hypot(Vx, Vy));
 
     return lp;
 }

--- a/src/projections/geos.cpp
+++ b/src/projections/geos.cpp
@@ -145,7 +145,10 @@ static PJ_LP geos_s_inverse(PJ_XY xy, PJ *P) { /* Spheroidal, inverse */
 
     /* Calculation of longitude and latitude.*/
     lp.lam = atan2(Vy, Vx);
-    lp.phi = atan(Vz * cos(lp.lam) / Vx);
+    // Initial formula:
+    // lp.phi = atan(Vz * cos(lp.lam) / Vx);
+    // Given that cos(atan2(y,x) = x / hypot(x,y)
+    lp.phi = atan(Vz / hypot(Vx, Vy));
 
     return lp;
 }


### PR DESCRIPTION
Fixes #4522

* Spherical case:
Before:
```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +inv +step +proj=geos +h=35785831.0 +lon_0=0 +ellps=sphere" 137881.85 4490747.09
137881.85 4490747.09 -> 0.034807228056148 0.850471730911161
Duration: 677 ms
Throughput: 7.39 million coordinates/s
```

After:
```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +inv +step +proj=geos +h=35785831.0 +lon_0=0 +ellps=sphere" 137881.85 4490747.09
137881.85 4490747.09 -> 0.034807228056148 0.850471730911161
Duration: 602 ms
Throughput: 8.31 million coordinates/s
```

* Ellipsoidal case:

Before:
```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +inv +step +proj=geos +h=35785831.0 +lon_0=0 +ellps=WGS84" 137881.85 4490747.09
137881.85 4490747.09 -> 0.0349065842446029 0.855211334383648
Duration: 978 ms
Throughput: 5.11 million coordinates/s
```

After:
```
$ bin/bench_proj_trans --pipeline "+proj=pipeline +inv +step +proj=geos +h=35785831.0 +lon_0=0 +ellps=WGS84" 137881.85 4490747.09
137881.85 4490747.09 -> 0.0349065842446029 0.855211334383648
Duration: 668 ms
Throughput: 7.49 million coordinates/s
```
