### PR TITLE
Database: reference nl_nsgi_nllat2018.tif and nl_nsgi_bongeo2004.tif grids

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "900c3d63e49523457636e21c6d188bf4")
+set(PROJ_DB_SQL_EXPECTED_MD5 "5f19bf7d48f8e74cea99ef72cc14084f")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -275,6 +275,9 @@ VALUES
 ('NOT-YET-IN-GRID-TRANSFORMATION-rdcorr2018.gsb','nl_nsgi_rdcorr2018.tif','rdcorr2018.gsb','GTiff','hgridshift',0,NULL,'https://cdn.proj.org/nl_nsgi_rdcorr2018.tif',1,1,NULL),
 ('naptrans2008.gtx','','naptrans2008.gtx','GTX','geoid_like',0,NULL,'https://salsa.debian.org/debian-gis-team/proj-rdnap/raw/upstream/2008/naptrans2008.gtx',1,0,NULL),
 ('rdtrans2008.gsb','','rdtrans2008.gsb','NTv2','hgridshift',0,NULL,'https://salsa.debian.org/debian-gis-team/proj-rdnap/raw/upstream/2008/rdtrans2008.gsb',1,0,NULL),
+('nllat2018.gtx','nl_nsgi_nllat2018.tif','nllat2018.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/nl_nsgi_nllat2018.tif',1,1,NULL),
+-- Bonaire
+('bongeo2004.gtx','nl_nsgi_bongeo2004.tif','bongeo2004.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/nl_nsgi_bongeo2004.tif',1,1,NULL),
 
 -- no_kv - Kartverket
 -- Norwegian grids


### PR DESCRIPTION
Those grids were added in PROJ-data 1.22 per https://github.com/OSGeo/PROJ-data/pull/137 but the proj.db changes were missing
