### PR TITLE
Fix tolower()/toupper() implementation to not lead to undefined behavior

### DIFF
--- a/src/dmstor.cpp
+++ b/src/dmstor.cpp
@@ -46,7 +46,9 @@ double dmstor_ctx(PJ_CONTEXT *ctx, const char *is, char **rs) {
      * It is possible that a really odd input (like lots of leading zeros)
      * could be truncated in copying into work.  But ...
      */
-    while ((isgraph(*p) || *p == DEG_SIGN1 || *p == DEG_SIGN2) && --n)
+    while ((isgraph(static_cast<unsigned char>(*p)) || *p == DEG_SIGN1 ||
+            *p == DEG_SIGN2) &&
+           --n)
         *s++ = *p++;
     *s = '\0';
     int sign = *(s = work);

--- a/src/iso19111/internal.cpp
+++ b/src/iso19111/internal.cpp
@@ -129,8 +129,9 @@ std::string tolower(const std::string &str)
 
 {
     std::string ret(str);
-    for (size_t i = 0; i < ret.size(); i++)
-        ret[i] = static_cast<char>(::tolower(ret[i]));
+    for (char &ch : ret)
+        ch =
+            (ch >= 'A' && ch <= 'Z') ? static_cast<char>(ch + ('a' - 'A')) : ch;
     return ret;
 }
 
@@ -144,8 +145,9 @@ std::string toupper(const std::string &str)
 
 {
     std::string ret(str);
-    for (size_t i = 0; i < ret.size(); i++)
-        ret[i] = static_cast<char>(::toupper(ret[i]));
+    for (char &ch : ret)
+        ch =
+            (ch >= 'a' && ch <= 'z') ? static_cast<char>(ch - ('a' - 'A')) : ch;
     return ret;
 }
 


### PR DESCRIPTION
Fixes #4537
