### PR TITLE
Use correct path alias syntax on windows

### DIFF
--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -39,7 +39,7 @@ The following paths are checked in order:
 
   The PROJ user writable directory, which is :
 
-    * on Windows, ``${LOCALAPPDATA}/proj``
+    * on Windows, ``%LOCALAPPDATA%/proj``
     * on macOS, ``${HOME}/Library/Application Support/proj``
     * on other platforms (Linux), ``${XDG_DATA_HOME}/proj`` if
       :envvar:`XDG_DATA_HOME` is defined. Else ``${HOME}/.local/share/proj``

--- a/docs/source/resource_files.rst
+++ b/docs/source/resource_files.rst
@@ -39,7 +39,7 @@ The following paths are checked in order:
 
   The PROJ user writable directory, which is :
 
-    * on Windows, ``%LOCALAPPDATA%/proj``
+    * on Windows, ``%LOCALAPPDATA%\proj``
     * on macOS, ``${HOME}/Library/Application Support/proj``
     * on other platforms (Linux), ``${XDG_DATA_HOME}/proj`` if
       :envvar:`XDG_DATA_HOME` is defined. Else ``${HOME}/.local/share/proj``


### PR DESCRIPTION
When reading through the documentation, I saw that you have to adjust the path alias manually before you can use it.