### PR TITLE
On SQLite query error, show first the error msg than the sql query

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -494,12 +494,13 @@ SQLResultSet SQLiteHandle::run(sqlite3_stmt *stmt, const std::string &sql,
         } else if (ret == SQLITE_DONE) {
             break;
         } else {
-            throw FactoryException(std::string("SQLite error on ")
-                                       .append(sql)
-                                       .append(": code = ")
+            throw FactoryException(std::string("SQLite error [ ")
+                                       .append("code = ")
                                        .append(internal::toString(ret))
                                        .append(", msg = ")
-                                       .append(sqlite3_errmsg(sqlite_handle_)));
+                                       .append(sqlite3_errmsg(sqlite_handle_))
+                                       .append(" ] on ")
+                                       .append(sql));
         }
     }
     return result;
@@ -515,8 +516,10 @@ SQLResultSet SQLiteHandle::run(const std::string &sql,
         if (sqlite3_prepare_v2(sqlite_handle_, sql.c_str(),
                                static_cast<int>(sql.size()), &stmt,
                                nullptr) != SQLITE_OK) {
-            throw FactoryException("SQLite error on " + sql + ": " +
-                                   sqlite3_errmsg(sqlite_handle_));
+            throw FactoryException(std::string("SQLite error [ ")
+                                       .append(sqlite3_errmsg(sqlite_handle_))
+                                       .append(" ] on ")
+                                       .append(sql));
         }
         auto ret = run(stmt, sql, parameters, useMaxFloatPrecision);
         sqlite3_finalize(stmt);
@@ -1443,8 +1446,11 @@ SQLResultSet DatabaseContext::Private::run(const std::string &sql,
         if (sqlite3_prepare_v2(l_handle->handle(), sql.c_str(),
                                static_cast<int>(sql.size()), &stmt,
                                nullptr) != SQLITE_OK) {
-            throw FactoryException("SQLite error on " + sql + ": " +
-                                   sqlite3_errmsg(l_handle->handle()));
+            throw FactoryException(
+                std::string("SQLite error [ ")
+                    .append(sqlite3_errmsg(l_handle->handle()))
+                    .append(" ] on ")
+                    .append(sql));
         }
         mapSqlToStatement_.insert(
             std::pair<std::string, sqlite3_stmt *>(sql, stmt));


### PR DESCRIPTION
The query could be huge, and the text not registered completely.

For example, this is what I see in the reporting application

Fatal Exception: osgeo::proj::io::FactoryException
SQLite error on SELECT * FROM (SELECT c.auth_name, c.code, c.name, c.type, c.deprecated, a.west_lon, a.south_lat, a.east_lon, a.north_lat, a.description, NULL, cb.name FROM geodetic_crs c LEFT JOIN usage u ON u.object_table_name = 'geodetic_crs' AND u.object_auth_name = c.auth_name AND u.object_code = c.code LEFT JOIN extent a ON a.auth_name = u.extent_auth_name AND a.code = u.extent_code LEFT JOIN geodetic_datum gd ON gd.auth_name = c.datum_auth_name AND gd.code = c.datum_code LEFT JOIN ellipsoid e ON e.auth_name = gd.ellipsoid_auth_name AND e.code = gd.ellipsoid_code LEFT JOIN celestial_body cb ON cb.auth_name = e.celestial_body_auth_name AND cb.code = e.celestial_body_code WHERE c.auth_name = ? UNION ALL SELECT c.auth_name, c.code, c.name, 'projected', c.deprecated, a.west_lon, a.south_lat, a.east_lon, a.north_lat, a.description, cm.name, cb.name AS conversion_method_name FROM projected_crs c LEFT JOIN conversion_table conv ON c.conversion_auth_name = conv.auth_name AND c.conversion_code = conv.code LEFT JOIN conversion_method cm ON conv.method_auth_name = cm.auth_name AND conv.method_code = cm.code LEFT JOIN geodetic_crs gcrs ON gcrs.auth_name = c.geodetic_crs_auth_name AND gcrs.code = c.geodetic_crs_code LEFT JOIN usage u ON u.object_table_name = 'projected_crs' AND u.object_auth_name = c.auth_name AND u.object_code = c.code LEFT JOIN extent a ON a.auth_name = u.extent_auth_name AND a.code = u.extent_code LEFT JOIN geodetic_datum gd ON gd.auth_name = gcrs.datum_auth_name AND gd.code = gcrs.datum_code LEFT JOIN ellipsoid e ON e.auth_name = gd.ellipsoid_auth_name AND e.code = gd.ellipsoid_code LEFT JOIN celestial_body cb ON cb.auth_name = e.celestial_body_auth_name AND cb.code = e.celestial_body_code WHERE c.auth_name = ? UNION ALL SELECT c.auth_name, c.code, c.name, 'vertical', c.deprecated, a.west_lon, a.south_lat, a.east_lon, a.north_lat, a.description, NULL, 'Earth' FROM vertical_crs c LEFT JOIN usage u ON u.object_table_name = 'vertical_crs' AND u.object_auth_name = c.auth_name AND u.object_code = c.code

As you can see, the SQL query is not complete because the message length is limited in the tracking system. That avoids us to see the actual message.

This PR is just reordering the exception message, showing first the sql_message and later the sql query.