### PR TITLE
libproj: Add proper rpath for linux and macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,8 @@ if (USE_ONLY_EMBEDDED_RESOURCE_FILES AND NOT EMBED_RESOURCE_FILES)
   message(WARNING "USE_ONLY_EMBEDDED_RESOURCE_FILES=ON set but EMBED_RESOURCE_FILES=OFF: some drivers will lack required resource files")
 endif()
 
+option(PROJ_SET_INSTALL_RELATIVE_RPATH "Whether to set rpath on installed libraries" OFF)
+
 ################################################################################
 # Build configured components
 ################################################################################

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -433,9 +433,9 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
     Path to an existing directory used to cache :file:`proj.db` to speed-up
     subsequent builds without modifications to source SQL files.
 
-.. option:: PROJ_SET_INSTALL_RELATIVE_RPATH
+.. option:: PROJ_SET_INSTALL_RELATIVE_RPATH=OFF
 
-    Whether to set rpath on installed libraries
+    Whether to set relative rpath on installed libraries.
 
 .. option:: TESTING_USE_NETWORK=ON
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -433,6 +433,10 @@ All cached entries can be viewed using ``cmake -LAH`` from a build directory.
     Path to an existing directory used to cache :file:`proj.db` to speed-up
     subsequent builds without modifications to source SQL files.
 
+.. option:: PROJ_SET_INSTALL_RELATIVE_RPATH
+
+    Whether to set rpath on installed libraries
+
 .. option:: TESTING_USE_NETWORK=ON
 
     .. versionadded:: 9.5

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -388,6 +388,14 @@ add_library(proj
 )
 add_library(PROJ::proj ALIAS proj)
 
+if (PROJ_SET_INSTALL_RELATIVE_RPATH)
+  if(APPLE)
+    set_target_properties(proj PROPERTIES INSTALL_RPATH "@loader_path")
+  elseif(UNIX)
+    set_target_properties(proj PROPERTIES INSTALL_RPATH "$ORIGIN")
+  endif()
+endif()
+
 if(MSVC OR MINGW)
     target_compile_definitions(proj PRIVATE -DNOMINMAX)
 endif()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This add proper rpath in order to be able to use libsqlite not from system.

 - [ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
- [ ] Closes #xxxx
- [ ] Tests added
- [x] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
