### PR TITLE
C++ API: CartesianCS::create(): by default check that all axis have the same unit

### DIFF
--- a/include/proj/coordinatesystem.hpp
+++ b/include/proj/coordinatesystem.hpp
@@ -48,6 +48,23 @@ namespace cs {
 
 // ---------------------------------------------------------------------------
 
+/** \brief Exception that can be thrown when an invalid coordinate system is
+ * attempted to be constructed.
+ *
+ * @since 9.9
+ */
+class PROJ_GCC_DLL InvalidCoordinateSystem : public util::Exception {
+  public:
+    //! @cond Doxygen_Suppress
+    PROJ_INTERNAL explicit InvalidCoordinateSystem(const char *message);
+    PROJ_INTERNAL explicit InvalidCoordinateSystem(const std::string &message);
+    PROJ_DLL InvalidCoordinateSystem(const InvalidCoordinateSystem &other);
+    PROJ_DLL ~InvalidCoordinateSystem() override;
+    //! @endcond
+};
+
+// ---------------------------------------------------------------------------
+
 /** \brief The direction of positive increase in the coordinate value for a
  * coordinate system axis.
  *
@@ -549,12 +566,12 @@ class PROJ_GCC_DLL CartesianCS final : public CoordinateSystem {
     PROJ_DLL static CartesianCSNNPtr
     create(const util::PropertyMap &properties,
            const CoordinateSystemAxisNNPtr &axis1,
-           const CoordinateSystemAxisNNPtr &axis2);
+           const CoordinateSystemAxisNNPtr &axis2, bool enforceSameUnit = true);
     PROJ_DLL static CartesianCSNNPtr
     create(const util::PropertyMap &properties,
            const CoordinateSystemAxisNNPtr &axis1,
            const CoordinateSystemAxisNNPtr &axis2,
-           const CoordinateSystemAxisNNPtr &axis3);
+           const CoordinateSystemAxisNNPtr &axis3, bool enforceSameUnit = true);
 
     PROJ_DLL static CartesianCSNNPtr
     createEastingNorthing(const common::UnitOfMeasure &unit);

--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -209,8 +209,8 @@ osgeo::proj::cs::CartesianCS::createEastingNorthing(osgeo::proj::common::UnitOfM
 osgeo::proj::cs::CartesianCS::createGeocentric(osgeo::proj::common::UnitOfMeasure const&)
 osgeo::proj::cs::CartesianCS::createNorthingEasting(osgeo::proj::common::UnitOfMeasure const&)
 osgeo::proj::cs::CartesianCS::createNorthPoleEastingSouthNorthingSouth(osgeo::proj::common::UnitOfMeasure const&)
-osgeo::proj::cs::CartesianCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&)
-osgeo::proj::cs::CartesianCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&)
+osgeo::proj::cs::CartesianCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, bool)
+osgeo::proj::cs::CartesianCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, bool)
 osgeo::proj::cs::CartesianCS::createSouthPoleEastingNorthNorthingNorth(osgeo::proj::common::UnitOfMeasure const&)
 osgeo::proj::cs::CartesianCS::createWestingSouthing(osgeo::proj::common::UnitOfMeasure const&)
 osgeo::proj::cs::CoordinateSystemAxis::abbreviation() const
@@ -234,6 +234,8 @@ osgeo::proj::cs::EllipsoidalCS::createLongitudeLatitude(osgeo::proj::common::Uni
 osgeo::proj::cs::EllipsoidalCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&)
 osgeo::proj::cs::EllipsoidalCS::create(osgeo::proj::util::PropertyMap const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&, dropbox::oxygen::nn<std::shared_ptr<osgeo::proj::cs::CoordinateSystemAxis> > const&)
 osgeo::proj::cs::EllipsoidalCS::~EllipsoidalCS()
+osgeo::proj::cs::InvalidCoordinateSystem::~InvalidCoordinateSystem()
+osgeo::proj::cs::InvalidCoordinateSystem::InvalidCoordinateSystem(osgeo::proj::cs::InvalidCoordinateSystem const&)
 osgeo::proj::cs::Meridian::create(osgeo::proj::common::Angle const&)
 osgeo::proj::cs::Meridian::longitude() const
 osgeo::proj::cs::Meridian::~Meridian()

--- a/src/iso19111/coordinatesystem.cpp
+++ b/src/iso19111/coordinatesystem.cpp
@@ -746,6 +746,27 @@ bool CoordinateSystem::_isEquivalentTo(
 }
 //! @endcond
 
+//! @cond Doxygen_Suppress
+// ---------------------------------------------------------------------------
+
+InvalidCoordinateSystem::InvalidCoordinateSystem(const char *message)
+    : Exception(message) {}
+
+// ---------------------------------------------------------------------------
+
+InvalidCoordinateSystem::InvalidCoordinateSystem(const std::string &message)
+    : Exception(message) {}
+
+// ---------------------------------------------------------------------------
+
+InvalidCoordinateSystem::InvalidCoordinateSystem(
+    const InvalidCoordinateSystem &) = default;
+
+// ---------------------------------------------------------------------------
+
+InvalidCoordinateSystem::~InvalidCoordinateSystem() = default;
+//! @endcond
+
 // ---------------------------------------------------------------------------
 
 //! @cond Doxygen_Suppress
@@ -1101,12 +1122,20 @@ CartesianCS::CartesianCS(const CartesianCS &) = default;
  * @param properties See \ref general_properties.
  * @param axis1 The first axis.
  * @param axis2 The second axis.
+ * @param enforceSameUnit Whether to check that all axis have the same unit.
+ * (since 9.9)
  * @return a new CartesianCS.
+ * @throw InvalidCoordinateSystem in case of error (since 9.9)
  */
 CartesianCSNNPtr CartesianCS::create(const util::PropertyMap &properties,
                                      const CoordinateSystemAxisNNPtr &axis1,
-                                     const CoordinateSystemAxisNNPtr &axis2) {
+                                     const CoordinateSystemAxisNNPtr &axis2,
+                                     bool enforceSameUnit) {
     std::vector<CoordinateSystemAxisNNPtr> axis{axis1, axis2};
+    if (enforceSameUnit && axis1->unit() != axis2->unit()) {
+        throw InvalidCoordinateSystem(
+            "All axis of a CartesianCS must have the same unit");
+    }
     auto cs(CartesianCS::nn_make_shared<CartesianCS>(axis));
     cs->setProperties(properties);
     return cs;
@@ -1120,13 +1149,22 @@ CartesianCSNNPtr CartesianCS::create(const util::PropertyMap &properties,
  * @param axis1 The first axis.
  * @param axis2 The second axis.
  * @param axis3 The third axis.
+ * @param enforceSameUnit Whether to check that all axis have the same unit.
+ * (since 9.9)
  * @return a new CartesianCS.
+ * @throw InvalidCoordinateSystem in case of error (since 9.9)
  */
 CartesianCSNNPtr CartesianCS::create(const util::PropertyMap &properties,
                                      const CoordinateSystemAxisNNPtr &axis1,
                                      const CoordinateSystemAxisNNPtr &axis2,
-                                     const CoordinateSystemAxisNNPtr &axis3) {
+                                     const CoordinateSystemAxisNNPtr &axis3,
+                                     bool enforceSameUnit) {
     std::vector<CoordinateSystemAxisNNPtr> axis{axis1, axis2, axis3};
+    if (enforceSameUnit &&
+        (axis1->unit() != axis2->unit() || axis1->unit() != axis3->unit())) {
+        throw InvalidCoordinateSystem(
+            "All axis of a CartesianCS must have the same unit");
+    }
     auto cs(CartesianCS::nn_make_shared<CartesianCS>(axis));
     cs->setProperties(properties);
     return cs;

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -1298,8 +1298,9 @@ std::string CRS::getOriginatingAuthName() const {
 /** \brief Return a variant of this CRS "promoted" to a 3D one, if not already
  * the case.
  *
- * The new axis will be ellipsoidal height, oriented upwards, and with metre
- * units.
+ * The new axis will be ellipsoidal height, oriented upwards, and with the same
+ * unit as the existing coordinate system for a CartesianCS, or otherwise
+ * with metre units
  *
  * @param newName Name of the new CRS. If empty, nameStr() will be used.
  * @param dbContext Database context to look for potentially already registered
@@ -1310,11 +1311,26 @@ std::string CRS::getOriginatingAuthName() const {
  */
 CRSNNPtr CRS::promoteTo3D(const std::string &newName,
                           const io::DatabaseContextPtr &dbContext) const {
+
+    common::UnitOfMeasure uom = common::UnitOfMeasure::METRE;
+    if (auto projCRS = dynamic_cast<const ProjectedCRS *>(this)) {
+        const auto &axisList = projCRS->coordinateSystem()->axisList();
+        assert(!axisList.empty());
+        uom = axisList[0]->unit();
+    } else if (auto derivedProjCRS =
+                   dynamic_cast<const DerivedProjectedCRS *>(this)) {
+        const auto &cs = derivedProjCRS->coordinateSystem();
+        if (dynamic_cast<const cs::CartesianCS *>(cs.get())) {
+            const auto &axisList = cs->axisList();
+            assert(!axisList.empty());
+            uom = axisList[0]->unit();
+        }
+    }
+
     auto upAxis = cs::CoordinateSystemAxis::create(
         util::PropertyMap().set(IdentifiedObject::NAME_KEY,
                                 cs::AxisName::Ellipsoidal_height),
-        cs::AxisAbbreviation::h, cs::AxisDirection::UP,
-        common::UnitOfMeasure::METRE);
+        cs::AxisAbbreviation::h, cs::AxisDirection::UP, uom);
     return promoteTo3D(newName, dbContext, upAxis);
 }
 
@@ -1375,8 +1391,8 @@ CRSNNPtr CRS::promoteTo3D(const std::string &newName,
                 util::PropertyMap(), axisList[0], axisList[1],
                 verticalAxisIfNotAlreadyPresent);
             auto baseGeog3DCRS = util::nn_dynamic_pointer_cast<GeodeticCRS>(
-                derivedGeogCRS->baseCRS()->promoteTo3D(
-                    std::string(), dbContext, verticalAxisIfNotAlreadyPresent));
+                derivedGeogCRS->baseCRS()->promoteTo3D(std::string(),
+                                                       dbContext));
             return util::nn_static_pointer_cast<CRS>(
                 DerivedGeographicCRS::create(
                     createProperties(),
@@ -1393,8 +1409,8 @@ CRSNNPtr CRS::promoteTo3D(const std::string &newName,
                                               axisList[1],
                                               verticalAxisIfNotAlreadyPresent);
             auto baseProj3DCRS = util::nn_dynamic_pointer_cast<ProjectedCRS>(
-                derivedProjCRS->baseCRS()->promoteTo3D(
-                    std::string(), dbContext, verticalAxisIfNotAlreadyPresent));
+                derivedProjCRS->baseCRS()->promoteTo3D(std::string(),
+                                                       dbContext));
             return util::nn_static_pointer_cast<CRS>(
                 DerivedProjectedCRS::create(
                     createProperties(),

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -3097,10 +3097,21 @@ WKTParser::Private::buildCS(const WKTNodeNNPtr &node, /* maybe null */
         }
     } else if (ci_equal(csType, CartesianCS::WKT2_TYPE)) {
         if (axisCount == 2) {
-            return CartesianCS::create(csMap, axisList[0], axisList[1]);
-        } else if (axisCount == 3) {
+            if (axisList[0]->unit() != axisList[1]->unit()) {
+                emitRecoverableWarning(
+                    "All axis of a CartesianCS must have the same unit");
+            }
             return CartesianCS::create(csMap, axisList[0], axisList[1],
-                                       axisList[2]);
+                                       /* enforceSameUnit = */ false);
+        } else if (axisCount == 3) {
+            if (axisList[0]->unit() != axisList[1]->unit() ||
+                axisList[0]->unit() != axisList[2]->unit()) {
+                emitRecoverableWarning(
+                    "All axis of a CartesianCS must have the same unit");
+            }
+            return CartesianCS::create(csMap, axisList[0], axisList[1],
+                                       axisList[2],
+                                       /* enforceSameUnit = */ false);
         }
     } else if (ci_equal(csType, AffineCS::WKT2_TYPE)) {
         if (axisCount == 2) {
@@ -5943,6 +5954,7 @@ BaseObjectNNPtr WKTParser::Private::build(const WKTNodeNNPtr &node) {
 class JSONParser {
     DatabaseContextPtr dbContext_{};
     std::string deformationModelName_{};
+    PJ_CONTEXT *ctx_ = nullptr;
 
     static std::string getString(const json &j, const char *key);
     static json getObject(const json &j, const char *key);
@@ -6053,11 +6065,26 @@ class JSONParser {
                                  NN_NO_CHECK(csCast));
     }
 
+    void emitRecoverableWarning(const std::string &warningMsg) {
+        if (ctx_) {
+            proj_context_log_debug(ctx_, "PROJJSON parsing: %s",
+                                   warningMsg.c_str());
+        }
+    }
+
+    JSONParser(const JSONParser &) = delete;
+    JSONParser &operator=(const JSONParser &) = delete;
+
   public:
     JSONParser() = default;
 
     JSONParser &attachDatabaseContext(const DatabaseContextPtr &dbContext) {
         dbContext_ = dbContext;
+        return *this;
+    }
+
+    JSONParser &attachContext(PJ_CONTEXT *ctx) {
+        ctx_ = ctx;
         return *this;
     }
 
@@ -7113,11 +7140,22 @@ CoordinateSystemNNPtr JSONParser::buildCS(const json &j) {
     }
     if (subtype == CartesianCS::WKT2_TYPE) {
         if (axisCount == 2) {
-            return CartesianCS::create(csMap, axisList[0], axisList[1]);
+            if (axisList[0]->unit() != axisList[1]->unit()) {
+                emitRecoverableWarning(
+                    "All axis of a CartesianCS must have the same unit");
+            }
+            return CartesianCS::create(csMap, axisList[0], axisList[1],
+                                       /* enforceSameUnit = */ false);
         }
         if (axisCount == 3) {
+            if (axisList[0]->unit() != axisList[1]->unit() ||
+                axisList[0]->unit() != axisList[2]->unit()) {
+                emitRecoverableWarning(
+                    "All axis of a CartesianCS must have the same unit");
+            }
             return CartesianCS::create(csMap, axisList[0], axisList[1],
-                                       axisList[2]);
+                                       axisList[2],
+                                       /* enforceSameUnit = */ false);
         }
         throw ParsingException("Expected 2 or 3 axis");
     }
@@ -7721,7 +7759,10 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
         } catch (const std::exception &e) {
             throw ParsingException(e.what());
         }
-        return JSONParser().attachDatabaseContext(dbContext).create(j);
+        return JSONParser()
+            .attachContext(ctx)
+            .attachDatabaseContext(dbContext)
+            .create(j);
     }
 
     if (!ci_starts_with(text, "step proj=") &&
@@ -12330,9 +12371,11 @@ PROJStringParser::Private::buildProjectedCRS(int iStep,
 
     auto csGeodCRS = geodCRS->coordinateSystem();
     auto cs = csGeodCRS->axisList().size() == 2
-                  ? CartesianCS::create(emptyPropertyMap, axis[0], axis[1])
+                  ? CartesianCS::create(emptyPropertyMap, axis[0], axis[1],
+                                        /* enforceSameUnit = */ false)
                   : CartesianCS::create(emptyPropertyMap, axis[0], axis[1],
-                                        csGeodCRS->axisList()[2]);
+                                        csGeodCRS->axisList()[2],
+                                        /* enforceSameUnit = */ false);
     if (isTopocentricStep(step.name)) {
         cs = CartesianCS::create(
             emptyPropertyMap,

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -71,6 +71,44 @@ static nn<std::shared_ptr<UnrelatedObject>> createUnrelatedObject() {
 
 // ---------------------------------------------------------------------------
 
+TEST(cs, CartesianCS) {
+    auto axis0 = CoordinateSystemAxis::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "Easting"), "X",
+        AxisDirection::EAST, UnitOfMeasure::METRE);
+
+    auto axis1 = CoordinateSystemAxis::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "Northing"), "Y",
+        AxisDirection::NORTH, UnitOfMeasure::METRE);
+
+    auto axis2 = CoordinateSystemAxis::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "Height"), "H",
+        AxisDirection::UP, UnitOfMeasure::METRE);
+
+    EXPECT_NO_THROW(CartesianCS::create(PropertyMap(), axis0, axis1));
+    EXPECT_NO_THROW(CartesianCS::create(PropertyMap(), axis0, axis1, axis2));
+
+    auto axis2_foot = CoordinateSystemAxis::create(
+        PropertyMap().set(IdentifiedObject::NAME_KEY, "Height"), "H",
+        AxisDirection::UP, UnitOfMeasure::FOOT);
+
+    EXPECT_THROW(CartesianCS::create(PropertyMap(), axis0, axis2_foot),
+                 InvalidCoordinateSystem);
+    EXPECT_THROW(CartesianCS::create(PropertyMap(), axis0, axis2_foot, true),
+                 InvalidCoordinateSystem);
+    EXPECT_NO_THROW(
+        CartesianCS::create(PropertyMap(), axis0, axis2_foot, false));
+
+    EXPECT_THROW(CartesianCS::create(PropertyMap(), axis0, axis1, axis2_foot),
+                 InvalidCoordinateSystem);
+    EXPECT_THROW(
+        CartesianCS::create(PropertyMap(), axis0, axis1, axis2_foot, true),
+        InvalidCoordinateSystem);
+    EXPECT_NO_THROW(
+        CartesianCS::create(PropertyMap(), axis0, axis1, axis2_foot, false));
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(crs, EPSG_4326_get_components) {
     auto crs = GeographicCRS::EPSG_4326;
     ASSERT_EQ(crs->identifiers().size(), 1U);


### PR DESCRIPTION
This is a constraint of ISO-19111 we didn't enforce.

For backward compatibility:
- do not enforce it when importing PROJ.4 styles, like "+proj=merc +unit=foot +vunit=m +type=crs"
- when importing WKT, in non-strict mode, just emit a warning in case of violation
- when importing PROJJSON, emit a PROJ debug message in case of violation

It will be enforced when reading objects from the database
