### PR TITLE
Remove old transformation for Faroe FVR09 height in favour of EPSG

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "3def2bc8874c82e7445f4f0c03aabec1")
+set(PROJ_DB_SQL_EXPECTED_MD5 "955183e53b96c40a87212b7466396cb8")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -131,7 +131,7 @@ VALUES
 -- Denmark mainland
 ('dnn.gtx','dk_sdfe_dnn.tif','dnn.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_dnn.tif',1,1,NULL),
 --  Faroe islands height models
-('fvr09.gtx','dk_sdfe_fvr09.tif','fvr09.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_fvr09.tif',1,1,NULL),
+('fo_geoid2012a.gri','dk_sdfe_fvr09.tif','fvr09.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_fvr09.tif',1,1,NULL),
 -- Greenland height models
 ('gr2000g.gri','dk_sdfe_gvr2000.tif','gvr2000.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_gvr2000.tif',1,1,NULL),
 ('ggeoid16.gri','dk_sdfe_gvr2016.tif','gvr2016.gtx','GTiff','geoid_like',0,NULL,'https://cdn.proj.org/dk_sdfe_gvr2016.tif',1,1,NULL),

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -24,30 +24,6 @@ INSERT INTO "usage" VALUES(
     'EPSG','1024'  -- unknown
 );
 
--- Faroe Islands
-
-INSERT INTO "grid_transformation" VALUES(
-    'PROJ','EPSG_4937_TO_EPSG_5317','ETRS89 to FVR09 height',
-    NULL,
-    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
-    'EPSG','4937', -- source CRS (ETRS89)
-    'EPSG','5317', -- target CRS (FVR09 height)
-    NULL,
-    'EPSG','8666','Geoid (height correction) model file','fvr09.gtx',
-    NULL,NULL,NULL,NULL,NULL,NULL,NULL,
-    NULL,NULL,NULL,NULL,NULL,NULL,
-    NULL,NULL,NULL,NULL,NULL,NULL,0);
-
-INSERT INTO "usage" VALUES(
-    'PROJ',
-    'EPSG_4937_TO_EPSG_5317_USAGE',
-    'grid_transformation',
-    'PROJ',
-    'EPSG_4937_TO_EPSG_5317',
-    'EPSG','3248', -- area of use: Faroe Islands - onshore
-    'EPSG','1024'  -- unknown
-);
-
 -- Sweden
 
 INSERT INTO "grid_transformation" VALUES(


### PR DESCRIPTION
Use https://epsg.org/transformation_11122/ETRS89-FRO-2008-to-ETRS89-FRO-2008-FVR09-height-1.html instead of the custom old one.
Don't touch PROJ-data to minimize churn there. `dk_sdfe_fvr09.tif` stays there.
There is no change for the user, as the geoid model data is the same.

 - [ ] ~AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.~
- [x] Closes https://github.com/OSGeo/PROJ-data/issues/152
- [ ] Tests added -> see below
- [x] Added clear title that can be used to generate release notes -> Is it worth it to be mentioned in the release notes?

```
$ PROJ_DATA=../data/ ./projinfo EPSG:4258 EPSG:4258+5317 --3d -o proj
Candidate operations found: 2
-------------------------------------
Operation No. 1:

unknown id, ETRS89-FRO [2008] to FVR09 height (1), 0.02 m, Faroe Islands - onshore., at least one grid missing

PROJ string:
+proj=pipeline
  +step +proj=axisswap +order=2,1
  +step +proj=unitconvert +xy_in=deg +xy_out=rad
  +step +inv +proj=vgridshift +grids=dk_sdfe_fvr09.tif +multiplier=1
  +step +proj=unitconvert +xy_in=rad +xy_out=deg
  +step +proj=axisswap +order=2,1

Grid dk_sdfe_fvr09.tif needed but not found on the system. Can be obtained at https://cdn.proj.org/dk_sdfe_fvr09.tif

-------------------------------------
Operation No. 2:

unknown id, Inverse of Transformation from FVR09 height to ETRS89 (ballpark vertical transformation, without ellipsoid height to vertical height correction), unknown accuracy, World, has ballpark transformation

PROJ string:
+proj=noop
```
```
$ echo 62 -7 0 | PROJ_DATA=../data/ PROJ_DEBUG=2 PROJ_NETWORK=ON ./cs2cs EPSG:4258 EPSG:4258+5317 --3d 
pj_open_lib(proj.ini): call fopen(../data//proj.ini) - succeeded
pj_open_lib(proj.db): call fopen(../data//proj.db) - succeeded
pj_open_lib(dk_sdfe_fvr09.tif): call fopen(../data//dk_sdfe_fvr09.tif) - failed
pj_open_lib(fvr09.gtx): call fopen(../data//fvr09.gtx) - failed
pj_open_lib(dk_sdfe_fvr09.tif): call fopen(../data//dk_sdfe_fvr09.tif) - failed
pj_open_lib(fvr09.gtx): call fopen(../data//fvr09.gtx) - failed
Using coordinate operation ETRS89-FRO [2008] to FVR09 height (1)
pj_open_lib(dk_sdfe_fvr09.tif): call fopen(../data//dk_sdfe_fvr09.tif) - failed
pj_open_lib(fvr09.gtx): call fopen(../data//fvr09.gtx) - failed
Using https://cdn.proj.org/dk_sdfe_fvr09.tif
62.00	-7.00 -56.42
```