### PR TITLE
[Backport 9.8] proj_cleanup(): make it release (static) memory allocated by proj_info()

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -136,6 +136,19 @@ PJ_INFO proj_info(void) {
 }
 
 /*****************************************************************************/
+void pj_clear_proj_info()
+/*****************************************************************************
+     Release memory associated to "info" singleton
+ *****************************************************************************/
+{
+    pj_acquire_lock();
+    if (info.searchpath != empty)
+        free(const_cast<char *>(info.searchpath));
+    info.searchpath = nullptr;
+    pj_release_lock();
+}
+
+/*****************************************************************************/
 PJ_PROJ_INFO proj_pj_info(PJ *P) {
     /******************************************************************************
         Basic info about a particular instance of a projection object.

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -204,4 +204,5 @@ void proj_cleanup() {
     pj_clear_vgridshift_knowngrids_cache();
     pj_clear_gridshift_knowngrids_cache();
     pj_clear_sqlite_cache();
+    pj_clear_proj_info();
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -1003,6 +1003,8 @@ int pj_get_suggested_operation(PJ_CONTEXT *ctx,
 const PJ_UNITS *pj_list_linear_units();
 const PJ_UNITS *pj_list_angular_units();
 
+void pj_clear_proj_info();
+
 void pj_clear_hgridshift_knowngrids_cache();
 void pj_clear_vgridshift_knowngrids_cache();
 void pj_clear_gridshift_knowngrids_cache();


### PR DESCRIPTION
Backport #4755
 **Authored by:** @rouault